### PR TITLE
[Core-108] Removed support for Windows 32-bit

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,7 @@ natives
 │  │  └─ x64
 │  │     └─ libglfw3.dylib
 │  └─ windows
-│     ├─ x64
-│     │  └─ glfw3.dll
-│     └─ x86
+│     └─ x64
 │        └─ glfw3.dll
 └─ stb https://github.com/Over-Run/stb-ci
    ├─ linux
@@ -121,8 +119,6 @@ natives
    └─ windows
       ├─ arm64
       │  └─ stb.dll
-      ├─ x64
-      │  └─ stb.dll
-      └─ x86
+      └─ x64
          └─ stb.dll
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,6 @@ for (Artifact module : Artifact.VALUES) {
 project(":samples").ext.subName = "samples"
 
 enum NativePlatform {
-    WIN_32("windows", "x86", "windows-x86", "", ".dll", "Win32"),
     WIN_64("windows", "x64", "windows", "", ".dll", "Win64"),
     WIN_ARM64("windows", "arm64", "windows-arm64", "", ".dll", "WinArm64"),
     LINUX_64("linux", "x64", "linux", "lib", ".so", "Linux64"),
@@ -68,7 +67,7 @@ enum NativePlatform {
 
 enum NativeBinding {
     GLFW("glfw", "glfw3",
-        NativePlatform.WIN_32, NativePlatform.WIN_64,
+        NativePlatform.WIN_64,
         NativePlatform.LINUX_64, NativePlatform.LINUX_ARM64,
         NativePlatform.MACOS, NativePlatform.MACOS_ARM64),
     STB("stb", "stb", NativePlatform.ALL),

--- a/modules/overrungl/core/src/main/java/org/overrun/glib/os/OperatingSystems.java
+++ b/modules/overrungl/core/src/main/java/org/overrun/glib/os/OperatingSystems.java
@@ -50,8 +50,8 @@ public final class OperatingSystems {
             return arch.startsWith("aarch64") ? "arm64" : "x64";
         }
         if (os == WINDOWS) {
-            return arch.contains("64") ? (arch.startsWith("aarch64") ? "arm64" : "x64") : "x86";
+            if (arch.contains("64")) return arch.startsWith("aarch64") ? "arm64" : "x64";
         }
-        throw new IllegalStateException(STR."Doesn't support to os \{os}; only support to Linux, macOS and Windows");
+        throw new IllegalStateException(STR."Doesn't support to os \{os} or arch \{arch}; only support to Linux, macOS and Windows");
     }
 }


### PR DESCRIPTION
[JDK 21](https://openjdk.org/jeps/449) is deprecating the Windows 32-bit x86 port for removal. We removed the support for Windows 32-bit. We will soon later remove it from CI.