### PR TITLE
Replace SegmentAllocator to MemoryStack for certain methods

### DIFF
--- a/modules/overrungl/core/src/main/java/overrungl/RuntimeHelper.java
+++ b/modules/overrungl/core/src/main/java/overrungl/RuntimeHelper.java
@@ -268,17 +268,9 @@ public final class RuntimeHelper {
      *
      * @param segment the segment.
      */
+    @Deprecated
     public static boolean isNullptr(@Nullable MemorySegment segment) {
         return segment == null || segment.equals(MemorySegment.NULL);
-    }
-
-    /**
-     * {@return {@code true} if <i>{@code address}</i> is {@value NULL}}
-     *
-     * @param address the address.
-     */
-    public static boolean isNullptr(long address) {
-        return address == NULL;
     }
 
     /**

--- a/modules/overrungl/core/src/main/java/overrungl/util/DebugAllocator.java
+++ b/modules/overrungl/core/src/main/java/overrungl/util/DebugAllocator.java
@@ -75,7 +75,7 @@ final class DebugAllocator {
     }
 
     static long track(long address, long size) {
-        if (RuntimeHelper.isNullptr(address)) {
+        if (MemoryUtil.isNullptr(address)) {
             Thread t = Thread.currentThread();
             THREADS.putIfAbsent(t.threadId(), t.getName());
 
@@ -131,7 +131,7 @@ final class DebugAllocator {
     }
 
     static long untrack(long address) {
-        if (RuntimeHelper.isNullptr(address)) {
+        if (MemoryUtil.isNullptr(address)) {
             return 0L;
         }
 

--- a/modules/overrungl/glfw/src/main/java/overrungl/glfw/GLFW.java
+++ b/modules/overrungl/glfw/src/main/java/overrungl/glfw/GLFW.java
@@ -1802,8 +1802,12 @@ public final class GLFW {
     public static GLFWVidMode.Value getVideoMode(MemorySegment monitor) {
         var pMode = ngetVideoMode(monitor);
         if (RuntimeHelper.isNullptr(pMode)) return null;
-        try (MemoryStack stack = MemoryStack.stackPush()) {
-            return new GLFWVidMode(pMode, stack).constCast();
+        final MemoryStack stack = MemoryStack.stackGet();
+        final long stackPointer = stack.getPointer();
+        try {
+            return new GLFWVidMode(pMode, stack).value();
+        } finally {
+            stack.setPointer(stackPointer);
         }
     }
 
@@ -2034,13 +2038,18 @@ public final class GLFW {
     /**
      * Sets the specified window hint to the desired value.
      *
-     * @param allocator The value allocator.
-     * @param hint      The <a href="https://www.glfw.org/docs/latest/window_guide.html#window_hints">window hint</a> to set.
-     * @param value     The new value of the window hint.
+     * @param hint  The <a href="https://www.glfw.org/docs/latest/window_guide.html#window_hints">window hint</a> to set.
+     * @param value The new value of the window hint.
      * @see #nwindowHintString(int, MemorySegment) nwindowHintString
      */
-    public static void windowHintString(SegmentAllocator allocator, int hint, String value) {
-        nwindowHintString(hint, allocator.allocateUtf8String(value));
+    public static void windowHintString(int hint, String value) {
+        final MemoryStack stack = MemoryStack.stackGet();
+        final long stackPointer = stack.getPointer();
+        try {
+            nwindowHintString(hint, stack.allocateUtf8String(value));
+        } finally {
+            stack.setPointer(stackPointer);
+        }
     }
 
     /**
@@ -2205,22 +2214,27 @@ public final class GLFW {
     /**
      * Creates a window and its associated context.
      *
-     * @param allocator The title allocator.
-     * @param width     The desired width, in screen coordinates, of the window.
-     *                  This must be greater than zero.
-     * @param height    The desired height, in screen coordinates, of the window.
-     *                  This must be greater than zero.
-     * @param title     The initial, UTF-8 encoded window title.
-     * @param monitor   The monitor to use for full screen mode, or {@link MemorySegment#NULL NULL} for
-     *                  windowed mode.
-     * @param share     The window whose context to share resources with, or {@link MemorySegment#NULL NULL}
-     *                  to not share resources.
+     * @param width   The desired width, in screen coordinates, of the window.
+     *                This must be greater than zero.
+     * @param height  The desired height, in screen coordinates, of the window.
+     *                This must be greater than zero.
+     * @param title   The initial, UTF-8 encoded window title.
+     * @param monitor The monitor to use for full screen mode, or {@link MemorySegment#NULL NULL} for
+     *                windowed mode.
+     * @param share   The window whose context to share resources with, or {@link MemorySegment#NULL NULL}
+     *                to not share resources.
      * @return The handle of the created window, or {@link MemorySegment#NULL NULL} if an
      * <a href="https://www.glfw.org/docs/latest/intro_guide.html#error_handling">error</a> occurred.
      * @see #ncreateWindow(int, int, MemorySegment, MemorySegment, MemorySegment) ncreateWindow
      */
-    public static MemorySegment createWindow(SegmentAllocator allocator, int width, int height, String title, MemorySegment monitor, MemorySegment share) {
-        return ncreateWindow(width, height, allocator.allocateUtf8String(title), monitor, share);
+    public static MemorySegment createWindow(int width, int height, String title, MemorySegment monitor, MemorySegment share) {
+        final MemoryStack stack = MemoryStack.stackGet();
+        final long stackPointer = stack.getPointer();
+        try {
+            return ncreateWindow(width, height, stack.allocateUtf8String(title), monitor, share);
+        } finally {
+            stack.setPointer(stackPointer);
+        }
     }
 
     /**
@@ -2314,13 +2328,18 @@ public final class GLFW {
     /**
      * Sets the title of the specified window.
      *
-     * @param allocator The title allocator.
-     * @param window    The window whose title to change.
-     * @param title     The UTF-8 encoded window title.
+     * @param window The window whose title to change.
+     * @param title  The UTF-8 encoded window title.
      * @see #nsetWindowTitle(MemorySegment, MemorySegment) nsetWindowTitle
      */
-    public static void setWindowTitle(SegmentAllocator allocator, MemorySegment window, String title) {
-        nsetWindowTitle(window, allocator.allocateUtf8String(title));
+    public static void setWindowTitle(MemorySegment window, String title) {
+        final MemoryStack stack = MemoryStack.stackGet();
+        final long stackPointer = stack.getPointer();
+        try {
+            nsetWindowTitle(window, stack.allocateUtf8String(title));
+        } finally {
+            stack.setPointer(stackPointer);
+        }
     }
 
     /**
@@ -5256,14 +5275,19 @@ public final class GLFW {
     /**
      * Adds the specified SDL_GameControllerDB gamepad mappings.
      *
-     * @param allocator The string allocator.
-     * @param string    The string containing the gamepad mappings.
+     * @param string The string containing the gamepad mappings.
      * @return {@code true} if successful, or {@code false} if an
      * <a href="https://www.glfw.org/docs/latest/intro_guide.html#error_handling">error</a> occurred.
      * @see #nupdateGamepadMappings(MemorySegment) nupdateGamepadMappings
      */
-    public static boolean updateGamepadMappings(SegmentAllocator allocator, String string) {
-        return nupdateGamepadMappings(allocator.allocateUtf8String(string));
+    public static boolean updateGamepadMappings(String string) {
+        final MemoryStack stack = MemoryStack.stackGet();
+        final long stackPointer = stack.getPointer();
+        try {
+            return nupdateGamepadMappings(stack.allocateUtf8String(string));
+        } finally {
+            stack.setPointer(stackPointer);
+        }
     }
 
     /**
@@ -5368,18 +5392,17 @@ public final class GLFW {
      * This function sets the system clipboard to the specified, UTF-8 encoded
      * string.
      *
-     * @param window Deprecated.  Any valid window or {@link MemorySegment#NULL NULL}.
      * @param string A UTF-8 encoded string.
      * @glfw.errors Possible errors include {@link #NOT_INITIALIZED} and
      * {@link #PLATFORM_ERROR}.
      * @glfw.pointer_lifetime The specified string is copied before this function
      * returns.
      * @glfw.thread_safety This function must only be called from the main thread.
-     * @see #ngetClipboardString(MemorySegment) getClipboardString
+     * @see #ngetClipboardString() getClipboardString
      */
-    public static void nsetClipboardString(@Deprecated MemorySegment window, MemorySegment string) {
+    public static void nsetClipboardString(MemorySegment string) {
         try {
-            glfwSetClipboardString.invokeExact(window, string);
+            glfwSetClipboardString.invokeExact(MemorySegment.NULL, string);
         } catch (Throwable e) {
             throw new AssertionError("should not reach here", e);
         }
@@ -5388,13 +5411,17 @@ public final class GLFW {
     /**
      * Sets the clipboard to the specified string.
      *
-     * @param allocator The string allocator.
-     * @param window    Deprecated.  Any valid window or {@link MemorySegment#NULL NULL}.
-     * @param string    A UTF-8 encoded string.
-     * @see #nsetClipboardString(MemorySegment, MemorySegment) nsetClipboardString
+     * @param string A UTF-8 encoded string.
+     * @see #nsetClipboardString(MemorySegment) nsetClipboardString
      */
-    public static void setClipboardString(SegmentAllocator allocator, @Deprecated MemorySegment window, String string) {
-        nsetClipboardString(window, allocator.allocateUtf8String(string));
+    public static void setClipboardString(String string) {
+        final MemoryStack stack = MemoryStack.stackGet();
+        final long stackPointer = stack.getPointer();
+        try {
+            nsetClipboardString(stack.allocateUtf8String(string));
+        } finally {
+            stack.setPointer(stackPointer);
+        }
     }
 
     /**
@@ -5405,22 +5432,21 @@ public final class GLFW {
      * if its contents cannot be converted, {@link MemorySegment#NULL NULL} is returned and a
      * {@link #FORMAT_UNAVAILABLE} error is generated.
      *
-     * @param window Deprecated.  Any valid window or {@link MemorySegment#NULL NULL}.
      * @return The contents of the clipboard as a UTF-8 encoded string, or {@link MemorySegment#NULL NULL}
      * if an <a href="https://www.glfw.org/docs/latest/intro_guide.html#error_handling">error</a> occurred.
      * @glfw.errors Possible errors include {@link #NOT_INITIALIZED},
      * {@link #FORMAT_UNAVAILABLE} and {@link #PLATFORM_ERROR}.
      * @glfw.pointer_lifetime The returned string is allocated and freed by GLFW.  You
      * should not free it yourself.  It is valid until the next call to
-     * {@link #ngetClipboardString(MemorySegment) getClipboardString} or
-     * {@link #nsetClipboardString(MemorySegment, MemorySegment) setClipboardString},
+     * {@code getClipboardString} or
+     * {@link #nsetClipboardString(MemorySegment) setClipboardString},
      * or until the library is terminated.
      * @glfw.thread_safety This function must only be called from the main thread.
-     * @see #nsetClipboardString(MemorySegment, MemorySegment) setClipboardString
+     * @see #nsetClipboardString(MemorySegment) setClipboardString
      */
-    public static MemorySegment ngetClipboardString(@Deprecated MemorySegment window) {
+    public static MemorySegment ngetClipboardString() {
         try {
-            return (MemorySegment) glfwGetClipboardString.invokeExact(window);
+            return (MemorySegment) glfwGetClipboardString.invokeExact(MemorySegment.NULL);
         } catch (Throwable e) {
             throw new AssertionError("should not reach here", e);
         }
@@ -5429,13 +5455,13 @@ public final class GLFW {
     /**
      * Returns the contents of the clipboard as a string.
      *
-     * @param window Deprecated.  Any valid window or {@link MemorySegment#NULL NULL}.
      * @return The contents of the clipboard as a UTF-8 encoded string, or {@code null}
      * if an <a href="https://www.glfw.org/docs/latest/intro_guide.html#error_handling">error</a> occurred.
+     * @see #ngetClipboardString() ngetClipboardString
      */
     @Nullable
     public static String getClipboardString(@Deprecated MemorySegment window) {
-        var pString = ngetClipboardString(window);
+        var pString = ngetClipboardString();
         return RuntimeHelper.isNullptr(pString) ? null : pString.getUtf8String(0);
     }
 
@@ -5706,14 +5732,19 @@ public final class GLFW {
     /**
      * Returns whether the specified extension is available.
      *
-     * @param allocator The extension string allocator.
      * @param extension The ASCII encoded name of the extension.
      * @return {@code true} if the extension is available, or {@code false}
      * otherwise.
      * @see #nextensionSupported(MemorySegment) nextensionSupported
      */
-    public static boolean extensionSupported(SegmentAllocator allocator, String extension) {
-        return nextensionSupported(allocator.allocateUtf8String(extension));
+    public static boolean extensionSupported(String extension) {
+        final MemoryStack stack = MemoryStack.stackGet();
+        final long stackPointer = stack.getPointer();
+        try {
+            return nextensionSupported(stack.allocateUtf8String(extension));
+        } finally {
+            stack.setPointer(stackPointer);
+        }
     }
 
     /**
@@ -5759,14 +5790,19 @@ public final class GLFW {
      * Returns the address of the specified function for the current
      * context.
      *
-     * @param allocator The segment allocator to allocate the string.
-     * @param procName  The ASCII encoded name of the function.
+     * @param procName The ASCII encoded name of the function.
      * @return The address of the function, or {@link MemorySegment#NULL NULL} if an
      * <a href="https://www.glfw.org/docs/latest/intro_guide.html#error_handling">error</a> occurred.
      * @see #ngetProcAddress(MemorySegment) ngetProcAddress
      */
-    public static MemorySegment getProcAddress(SegmentAllocator allocator, String procName) {
-        return ngetProcAddress(allocator.allocateUtf8String(procName));
+    public static MemorySegment getProcAddress(String procName) {
+        final MemoryStack stack = MemoryStack.stackGet();
+        final long stackPointer = stack.getPointer();
+        try {
+            return ngetProcAddress(stack.allocateUtf8String(procName));
+        } finally {
+            stack.setPointer(stackPointer);
+        }
     }
 
     /**

--- a/modules/overrungl/glfw/src/main/java/overrungl/glfw/GLFWNative.java
+++ b/modules/overrungl/glfw/src/main/java/overrungl/glfw/GLFWNative.java
@@ -20,7 +20,6 @@ import org.jetbrains.annotations.Nullable;
 import overrungl.util.MemoryStack;
 
 import java.lang.foreign.MemorySegment;
-import java.lang.foreign.SegmentAllocator;
 import java.lang.foreign.ValueLayout;
 
 import static overrungl.glfw.Handles.*;
@@ -288,7 +287,7 @@ public final class GLFWNative {
      * returns.
      * @glfw.thread_safety This function must only be called from the main thread.
      * @see #ngetX11SelectionString() getX11SelectionString
-     * @see GLFW#nsetClipboardString(MemorySegment, MemorySegment) setClipboardString
+     * @see GLFW#nsetClipboardString(MemorySegment) setClipboardString
      */
     public static void nsetX11SelectionString(MemorySegment string) {
         try {
@@ -301,12 +300,17 @@ public final class GLFWNative {
     /**
      * Sets the current primary selection to the specified string.
      *
-     * @param allocator the allocator of <i>{@code string}</i>.
      * @param string A UTF-8 encoded string.
      * @see #nsetX11SelectionString(MemorySegment) nsetX11SelectionString
      */
-    public static void setX11SelectionString(SegmentAllocator allocator, String string) {
-        nsetX11SelectionString(allocator.allocateUtf8String(string));
+    public static void setX11SelectionString(String string) {
+        final MemoryStack stack = MemoryStack.stackGet();
+        final long stackPointer = stack.getPointer();
+        try {
+            nsetX11SelectionString(stack.allocateUtf8String(string));
+        } finally {
+            stack.setPointer(stackPointer);
+        }
     }
 
     /**
@@ -324,7 +328,7 @@ public final class GLFWNative {
      * library is terminated.
      * @glfw.thread_safety This function must only be called from the main thread.
      * @see #nsetX11SelectionString(MemorySegment) setX11SelectionString
-     * @see GLFW#ngetClipboardString(MemorySegment) getClipboardString
+     * @see GLFW#ngetClipboardString() getClipboardString
      */
     public static MemorySegment ngetX11SelectionString() {
         try {

--- a/modules/overrungl/glfw/src/main/java/overrungl/glfw/GLFWVidMode.java
+++ b/modules/overrungl/glfw/src/main/java/overrungl/glfw/GLFWVidMode.java
@@ -105,12 +105,10 @@ public class GLFWVidMode extends Struct {
     }
 
     /**
-     * {@code const_cast<GLFWVidMode>(this)}
-     *
-     * @return the immutable state
+     * {@return an immutable state of this struct}
      */
-    public Value constCast() {
-        return new Value(address(), allocator(), this);
+    public Value value() {
+        return new Value(width(), height(), redBits(), greenBits(), blueBits(), refreshRate());
     }
 
     /**
@@ -158,64 +156,23 @@ public class GLFWVidMode extends Struct {
     /**
      * The immutable state of {@link GLFWVidMode}.
      *
+     * @param width       the width, in screen coordinates, of the video mode
+     * @param height      the height, in screen coordinates, of the video mode
+     * @param redBits     the bit depth of the red channel, of the video mode
+     * @param greenBits   the bit depth of the green channel, of the video mode
+     * @param blueBits    the bit depth of the blue channel, of the video mode
+     * @param refreshRate the refresh rate, in Hz, of the video mode
      * @author squid233
      * @since 0.1.0
      */
-    public static final /* value */ class Value extends GLFWVidMode {
-        private final int width;
-        private final int height;
-        private final int redBits;
-        private final int greenBits;
-        private final int blueBits;
-        private final int refreshRate;
-
-        private Value(MemorySegment address, SegmentAllocator allocator, GLFWVidMode mode) {
-            super(address, allocator);
-            this.width = mode.width();
-            this.height = mode.height();
-            this.redBits = mode.redBits();
-            this.greenBits = mode.greenBits();
-            this.blueBits = mode.blueBits();
-            this.refreshRate = mode.refreshRate();
-        }
-
-        /**
-         * {@return this}
-         */
-        @Override
-        public Value constCast() {
-            return this;
-        }
-
-        @Override
-        public int width() {
-            return width;
-        }
-
-        @Override
-        public int height() {
-            return height;
-        }
-
-        @Override
-        public int redBits() {
-            return redBits;
-        }
-
-        @Override
-        public int greenBits() {
-            return greenBits;
-        }
-
-        @Override
-        public int blueBits() {
-            return blueBits;
-        }
-
-        @Override
-        public int refreshRate() {
-            return refreshRate;
-        }
+    public /* value */ record Value(
+        int width,
+        int height,
+        int redBits,
+        int greenBits,
+        int blueBits,
+        int refreshRate
+    ) {
     }
 
     /**
@@ -268,7 +225,7 @@ public class GLFWVidMode extends Struct {
          * Gets the red bits at the given index.
          *
          * @param index the index
-         * @return The bit depth of the red channel of the video mode.
+         * @return The bit depth of the red channel, of the video mode.
          */
         public int redBitsAt(long index) {
             return (int) pRedBits.get(segment(), index);
@@ -278,7 +235,7 @@ public class GLFWVidMode extends Struct {
          * Gets the green bits at the given index.
          *
          * @param index the index
-         * @return The bit depth of the green channel of the video mode.
+         * @return The bit depth of the green channel, of the video mode.
          */
         public int greenBitsAt(long index) {
             return (int) pGreenBits.get(segment(), index);
@@ -288,7 +245,7 @@ public class GLFWVidMode extends Struct {
          * Gets the blue bits at the given index.
          *
          * @param index the index
-         * @return The bit depth of the blue channel of the video mode.
+         * @return The bit depth of the blue channel, of the video mode.
          */
         public int blueBitsAt(long index) {
             return (int) pBlueBits.get(segment(), index);

--- a/modules/overrungl/glfw/src/main/java/overrungl/glfw/GLFWVulkan.java
+++ b/modules/overrungl/glfw/src/main/java/overrungl/glfw/GLFWVulkan.java
@@ -19,7 +19,6 @@ package overrungl.glfw;
 import overrungl.util.MemoryStack;
 
 import java.lang.foreign.MemorySegment;
-import java.lang.foreign.SegmentAllocator;
 import java.lang.foreign.ValueLayout;
 
 import static overrungl.glfw.Handles.*;
@@ -86,16 +85,21 @@ public final class GLFWVulkan {
     /**
      * Returns the address of the specified Vulkan instance function.
      *
-     * @param allocator The segment allocator to allocate function name string.
-     * @param instance  The Vulkan instance to query, or {@link MemorySegment#NULL NULL} to retrieve
-     *                  functions related to instance creation.
-     * @param procName  The ASCII encoded name of the function.
+     * @param instance The Vulkan instance to query, or {@link MemorySegment#NULL NULL} to retrieve
+     *                 functions related to instance creation.
+     * @param procName The ASCII encoded name of the function.
      * @return The address of the function, or {@link MemorySegment#NULL NULL} if an
      * <a href="https://www.glfw.org/docs/latest/intro_guide.html#error_handling">error</a> occurred.
      * @see #nglfwGetInstanceProcAddress(MemorySegment, MemorySegment) nglfwGetInstanceProcAddress
      */
-    public static MemorySegment glfwGetInstanceProcAddress(SegmentAllocator allocator, MemorySegment instance, String procName) {
-        return nglfwGetInstanceProcAddress(instance, allocator.allocateUtf8String(procName));
+    public static MemorySegment glfwGetInstanceProcAddress(MemorySegment instance, String procName) {
+        final MemoryStack stack = MemoryStack.stackGet();
+        final long stackPointer = stack.getPointer();
+        try {
+            return nglfwGetInstanceProcAddress(instance, stack.allocateUtf8String(procName));
+        } finally {
+            stack.setPointer(stackPointer);
+        }
     }
 
     /**

--- a/modules/overrungl/nfd/src/main/java/overrungl/nfd/NFD.java
+++ b/modules/overrungl/nfd/src/main/java/overrungl/nfd/NFD.java
@@ -61,7 +61,7 @@ import static overrungl.FunctionDescriptors.*;
  *         var filterItem = NFDNFilterItem.create(stack,
  *             new Pair<>("Source code", "java"),
  *             new Pair<>("Image file", "png,jpg"));
- *         var result = NFD.openDialogN(stack, outPath, filterItem, null);
+ *         var result = NFD.openDialogN(outPath, filterItem, null);
  *         switch (result) {
  *             case ERROR -> System.err.println("Error: " + NFD.getError());
  *             case OKAY -> System.out.println("Success! " + outPath[0]);
@@ -183,9 +183,15 @@ public final class NFD {
         return RuntimeHelper.downcallSafe(LOOKUP.find(name).orElse(MemorySegment.NULL), function);
     }
 
-    static MemorySegment allocateString(SegmentAllocator allocator, String str) {
-        if (isOsWin) return RuntimeHelper.allocateUtf16LEString(allocator, str);
-        return allocator.allocateUtf8String(str);
+    static MemorySegment allocateString(String str) {
+        final MemoryStack stack = MemoryStack.stackGet();
+        final long stackPointer = stack.getPointer();
+        try {
+            if (isOsWin) return RuntimeHelper.allocateUtf16LEString(stack, str);
+            return stack.allocateUtf8String(str);
+        } finally {
+            stack.setPointer(stackPointer);
+        }
     }
 
     static String getString(MemorySegment segment, long offset) {
@@ -254,14 +260,13 @@ public final class NFD {
     /**
      * single file open dialog
      *
-     * @param allocator   the allocator of <i>{@code defaultPath}</i>
      * @param outPath     the out path
      * @param filterList  the filter list
      * @param defaultPath If defaultPath is NULL, the operating system will decide
      * @return the result
      * @see #nopenDialogN(MemorySegment, MemorySegment, int, MemorySegment) nopenDialogN
      */
-    public static NFDResult openDialogN(SegmentAllocator allocator, String[] outPath, NFDNFilterItem.Buffer filterList, String defaultPath) {
+    public static NFDResult openDialogN(String[] outPath, NFDNFilterItem.Buffer filterList, String defaultPath) {
         final MemoryStack stack = MemoryStack.stackGet();
         final long stackPointer = stack.getPointer();
         try {
@@ -269,7 +274,7 @@ public final class NFD {
             final NFDResult result = nopenDialogN(seg,
                 filterList != null ? filterList.address() : MemorySegment.NULL,
                 filterList != null ? Math.toIntExact(filterList.elementCount()) : 0,
-                defaultPath != null ? allocateString(allocator, defaultPath) : MemorySegment.NULL);
+                defaultPath != null ? allocateString(defaultPath) : MemorySegment.NULL);
             if (result == NFDResult.OKAY) {
                 final MemorySegment path = seg.get(RuntimeHelper.ADDRESS_UNBOUNDED, 0);
                 outPath[0] = getString(path, 0);
@@ -302,7 +307,6 @@ public final class NFD {
     /**
      * multiple file open dialog
      *
-     * @param allocator   the allocator of <i>{@code defaultPath}</i>
      * @param outPaths    It is the caller's responsibility to free <i>{@code *outPaths}</i>
      *                    via {@link #pathSetFree} if this function returns {@link NFDResult#OKAY}
      * @param filterList  the filter list
@@ -310,11 +314,11 @@ public final class NFD {
      * @return the result
      * @see #nopenDialogMultipleN(MemorySegment, MemorySegment, int, MemorySegment) nopenDialogMultipleN
      */
-    public static NFDResult openDialogMultipleN(SegmentAllocator allocator, @NativeType("const nfdpathset_t**") MemorySegment outPaths, NFDNFilterItem.Buffer filterList, String defaultPath) {
+    public static NFDResult openDialogMultipleN(@NativeType("const nfdpathset_t**") MemorySegment outPaths, NFDNFilterItem.Buffer filterList, String defaultPath) {
         return nopenDialogMultipleN(outPaths,
             filterList != null ? filterList.address() : MemorySegment.NULL,
             filterList != null ? Math.toIntExact(filterList.elementCount()) : 0,
-            defaultPath != null ? allocateString(allocator, defaultPath) : MemorySegment.NULL);
+            defaultPath != null ? allocateString(defaultPath) : MemorySegment.NULL);
     }
 
     /**
@@ -339,7 +343,6 @@ public final class NFD {
     /**
      * save dialog
      *
-     * @param allocator   the allocator of <i>{@code defaultPath}</i>
      * @param outPath     the out path
      * @param filterList  the filter list
      * @param defaultPath If defaultPath is NULL, the operating system will decide
@@ -347,7 +350,7 @@ public final class NFD {
      * @return the result
      * @see #nopenDialogMultipleN(MemorySegment, MemorySegment, int, MemorySegment) nopenDialogMultipleN
      */
-    public static NFDResult saveDialogN(SegmentAllocator allocator, String[] outPath, NFDNFilterItem.Buffer filterList, String defaultPath, String defaultName) {
+    public static NFDResult saveDialogN(String[] outPath, NFDNFilterItem.Buffer filterList, String defaultPath, String defaultName) {
         final MemoryStack stack = MemoryStack.stackGet();
         final long stackPointer = stack.getPointer();
         try {
@@ -355,8 +358,8 @@ public final class NFD {
             final NFDResult result = nsaveDialogN(seg,
                 filterList != null ? filterList.address() : MemorySegment.NULL,
                 filterList != null ? Math.toIntExact(filterList.elementCount()) : 0,
-                defaultPath != null ? allocateString(allocator, defaultPath) : MemorySegment.NULL,
-                defaultName != null ? allocateString(allocator, defaultName) : MemorySegment.NULL);
+                defaultPath != null ? allocateString(defaultPath) : MemorySegment.NULL,
+                defaultName != null ? allocateString(defaultName) : MemorySegment.NULL);
             if (result == NFDResult.OKAY) {
                 final MemorySegment path = seg.get(RuntimeHelper.ADDRESS_UNBOUNDED, 0);
                 outPath[0] = getString(path, 0);
@@ -387,18 +390,17 @@ public final class NFD {
     /**
      * select folder dialog
      *
-     * @param allocator   the allocator of <i>{@code outPath}</i>
      * @param outPath     the out path
      * @param defaultPath If defaultPath is NULL, the operating system will decide
      * @return the result
      * @see #npickFolderN(MemorySegment, MemorySegment) npickFolderN
      */
-    public static NFDResult pickFolderN(SegmentAllocator allocator, String[] outPath, String defaultPath) {
+    public static NFDResult pickFolderN(String[] outPath, String defaultPath) {
         final MemoryStack stack = MemoryStack.stackGet();
         final long stackPointer = stack.getPointer();
         try {
             final MemorySegment seg = stack.calloc(ADDRESS);
-            final NFDResult result = npickFolderN(seg, defaultPath != null ? allocateString(allocator, defaultPath) : MemorySegment.NULL);
+            final NFDResult result = npickFolderN(seg, defaultPath != null ? allocateString(defaultPath) : MemorySegment.NULL);
             if (result == NFDResult.OKAY) {
                 final MemorySegment path = seg.get(RuntimeHelper.ADDRESS_UNBOUNDED, 0);
                 outPath[0] = getString(path, 0);
@@ -705,14 +707,13 @@ public final class NFD {
     /**
      * single file open dialog
      *
-     * @param allocator   the allocator of <i>{@code defaultPath}</i>
      * @param outPath     the out path
      * @param filterList  the filter list
      * @param defaultPath If defaultPath is NULL, the operating system will decide
      * @return the result
      * @see #nopenDialogU8(MemorySegment, MemorySegment, int, MemorySegment) nopenDialogU8
      */
-    public static NFDResult openDialogU8(SegmentAllocator allocator, String[] outPath, NFDU8FilterItem.Buffer filterList, String defaultPath) {
+    public static NFDResult openDialogU8(String[] outPath, NFDU8FilterItem.Buffer filterList, String defaultPath) {
         final MemoryStack stack = MemoryStack.stackGet();
         final long stackPointer = stack.getPointer();
         try {
@@ -720,7 +721,7 @@ public final class NFD {
             final NFDResult result = nopenDialogU8(seg,
                 filterList != null ? filterList.address() : MemorySegment.NULL,
                 filterList != null ? Math.toIntExact(filterList.elementCount()) : 0,
-                defaultPath != null ? allocator.allocateUtf8String(defaultPath) : MemorySegment.NULL);
+                defaultPath != null ? stack.allocateUtf8String(defaultPath) : MemorySegment.NULL);
             if (result == NFDResult.OKAY) {
                 final MemorySegment path = seg.get(RuntimeHelper.ADDRESS_UNBOUNDED, 0);
                 outPath[0] = path.getUtf8String(0);
@@ -755,7 +756,6 @@ public final class NFD {
     /**
      * multiple file open dialog
      *
-     * @param allocator   the allocator of <i>{@code defaultPath}</i>
      * @param outPaths    It is the caller's responsibility to free <i>{@code *outPaths}</i>
      *                    via {@link #pathSetFree} if this function returns {@link NFDResult#OKAY}
      * @param filterList  the filter list
@@ -763,11 +763,17 @@ public final class NFD {
      * @return the result
      * @see #nopenDialogMultipleU8(MemorySegment, MemorySegment, int, MemorySegment) nopenDialogMultipleU8
      */
-    public static NFDResult openDialogMultipleU8(SegmentAllocator allocator, @NativeType("const nfdpathset_t**") MemorySegment outPaths, NFDU8FilterItem.Buffer filterList, String defaultPath) {
-        return nopenDialogMultipleU8(outPaths,
-            filterList != null ? filterList.address() : MemorySegment.NULL,
-            filterList != null ? Math.toIntExact(filterList.elementCount()) : 0,
-            defaultPath != null ? allocator.allocateUtf8String(defaultPath) : MemorySegment.NULL);
+    public static NFDResult openDialogMultipleU8(@NativeType("const nfdpathset_t**") MemorySegment outPaths, NFDU8FilterItem.Buffer filterList, String defaultPath) {
+        final MemoryStack stack = MemoryStack.stackGet();
+        final long stackPointer = stack.getPointer();
+        try {
+            return nopenDialogMultipleU8(outPaths,
+                filterList != null ? filterList.address() : MemorySegment.NULL,
+                filterList != null ? Math.toIntExact(filterList.elementCount()) : 0,
+                defaultPath != null ? stack.allocateUtf8String(defaultPath) : MemorySegment.NULL);
+        } finally {
+            stack.setPointer(stackPointer);
+        }
     }
 
     /**
@@ -794,7 +800,6 @@ public final class NFD {
     /**
      * save dialog
      *
-     * @param allocator   the allocator of <i>{@code defaultPath}</i>
      * @param outPath     the out path
      * @param filterList  the filter list
      * @param defaultPath If defaultPath is NULL, the operating system will decide
@@ -802,7 +807,7 @@ public final class NFD {
      * @return the result
      * @see #nopenDialogMultipleU8(MemorySegment, MemorySegment, int, MemorySegment) nopenDialogMultipleU8
      */
-    public static NFDResult saveDialogU8(SegmentAllocator allocator, String[] outPath, NFDU8FilterItem.Buffer filterList, String defaultPath, String defaultName) {
+    public static NFDResult saveDialogU8(String[] outPath, NFDU8FilterItem.Buffer filterList, String defaultPath, String defaultName) {
         final MemoryStack stack = MemoryStack.stackGet();
         final long stackPointer = stack.getPointer();
         try {
@@ -810,8 +815,8 @@ public final class NFD {
             final NFDResult result = nsaveDialogU8(seg,
                 filterList != null ? filterList.address() : MemorySegment.NULL,
                 filterList != null ? Math.toIntExact(filterList.elementCount()) : 0,
-                defaultPath != null ? allocator.allocateUtf8String(defaultPath) : MemorySegment.NULL,
-                defaultName != null ? allocator.allocateUtf8String(defaultName) : MemorySegment.NULL);
+                defaultPath != null ? stack.allocateUtf8String(defaultPath) : MemorySegment.NULL,
+                defaultName != null ? stack.allocateUtf8String(defaultName) : MemorySegment.NULL);
             if (result == NFDResult.OKAY) {
                 final MemorySegment path = seg.get(RuntimeHelper.ADDRESS_UNBOUNDED, 0);
                 outPath[0] = path.getUtf8String(0);
@@ -844,18 +849,17 @@ public final class NFD {
     /**
      * select folder dialog
      *
-     * @param allocator   the allocator of <i>{@code outPath}</i>
      * @param outPath     the out path
      * @param defaultPath If defaultPath is NULL, the operating system will decide
      * @return the result
      * @see #npickFolderU8(MemorySegment, MemorySegment) npickFolderU8
      */
-    public static NFDResult pickFolderU8(SegmentAllocator allocator, String[] outPath, String defaultPath) {
+    public static NFDResult pickFolderU8(String[] outPath, String defaultPath) {
         final MemoryStack stack = MemoryStack.stackGet();
         final long stackPointer = stack.getPointer();
         try {
             final MemorySegment seg = stack.calloc(ADDRESS);
-            final NFDResult result = npickFolderU8(seg, defaultPath != null ? allocator.allocateUtf8String(defaultPath) : MemorySegment.NULL);
+            final NFDResult result = npickFolderU8(seg, defaultPath != null ? stack.allocateUtf8String(defaultPath) : MemorySegment.NULL);
             if (result == NFDResult.OKAY) {
                 final MemorySegment path = seg.get(RuntimeHelper.ADDRESS_UNBOUNDED, 0);
                 outPath[0] = path.getUtf8String(0);

--- a/modules/overrungl/nfd/src/main/java/overrungl/nfd/NFD.java
+++ b/modules/overrungl/nfd/src/main/java/overrungl/nfd/NFD.java
@@ -117,7 +117,7 @@ import static overrungl.FunctionDescriptors.*;
  * @since 0.1.0
  */
 public final class NFD {
-    private static final SymbolLookup LOOKUP = RuntimeHelper.load("nfd", "nfd", "0.1.0");
+    private static final SymbolLookup LOOKUP = RuntimeHelper.load("nfd", "nfd", RuntimeHelper.VERSION);
     private static final OperatingSystem os = OperatingSystem.current();
     private static final boolean isOsWin = os.isWindows();
     private static final boolean isOsWinOrApple = os.isWindows() || os.isMacOsX();

--- a/modules/overrungl/nfd/src/main/java/overrungl/nfd/NFDNFilterItem.java
+++ b/modules/overrungl/nfd/src/main/java/overrungl/nfd/NFDNFilterItem.java
@@ -78,8 +78,8 @@ public class NFDNFilterItem extends Struct {
      */
     public static NFDNFilterItem create(SegmentAllocator allocator, String name, String spec) {
         final NFDNFilterItem item = new NFDNFilterItem(allocator.allocate(LAYOUT), allocator);
-        pName.set(item.segment(), NFD.allocateString(allocator, name));
-        pSpec.set(item.segment(), NFD.allocateString(allocator, spec));
+        pName.set(item.segment(), NFD.allocateString(name));
+        pSpec.set(item.segment(), NFD.allocateString(spec));
         return item;
     }
 
@@ -95,8 +95,8 @@ public class NFDNFilterItem extends Struct {
         final Buffer buffer = new Buffer(allocator.allocateArray(LAYOUT, items.length), allocator, items.length);
         for (int i = 0, len = items.length; i < len; i++) {
             Pair<String> item = items[i];
-            buffer.pName.set(buffer.segment(), (long) i, NFD.allocateString(allocator, item.key()));
-            buffer.pSpec.set(buffer.segment(), (long) i, NFD.allocateString(allocator, item.value()));
+            buffer.pName.set(buffer.segment(), (long) i, NFD.allocateString(item.key()));
+            buffer.pSpec.set(buffer.segment(), (long) i, NFD.allocateString(item.value()));
         }
         return buffer;
     }

--- a/modules/overrungl/opengl/src/main/java/overrungl/opengl/GL10.java
+++ b/modules/overrungl/opengl/src/main/java/overrungl/opengl/GL10.java
@@ -30,6 +30,7 @@ import static overrungl.opengl.GLLoader.getCapabilities;
 /**
  * The OpenGL 1.0 functions.
  *
+ * @sealedGraph
  * @author squid233
  * @since 0.1.0
  */

--- a/modules/overrungl/opengl/src/main/java/overrungl/opengl/GL10C.java
+++ b/modules/overrungl/opengl/src/main/java/overrungl/opengl/GL10C.java
@@ -30,6 +30,7 @@ import static overrungl.opengl.GLLoader.*;
 /**
  * The OpenGL 1.0 forward compatible functions.
  *
+ * @sealedGraph
  * @author squid233
  * @since 0.1.0
  */

--- a/modules/overrungl/opengl/src/main/java/overrungl/opengl/GL11.java
+++ b/modules/overrungl/opengl/src/main/java/overrungl/opengl/GL11.java
@@ -27,6 +27,7 @@ import static overrungl.opengl.GLLoader.getCapabilities;
 /**
  * The OpenGL 1.1 functions.
  *
+ * @sealedGraph
  * @author squid233
  * @since 0.1.0
  */

--- a/modules/overrungl/opengl/src/main/java/overrungl/opengl/GL11C.java
+++ b/modules/overrungl/opengl/src/main/java/overrungl/opengl/GL11C.java
@@ -29,6 +29,7 @@ import static overrungl.opengl.GLLoader.*;
 /**
  * The OpenGL 1.1 forward compatible functions.
  *
+ * @sealedGraph
  * @author squid233
  * @since 0.1.0
  */

--- a/modules/overrungl/opengl/src/main/java/overrungl/opengl/GL12.java
+++ b/modules/overrungl/opengl/src/main/java/overrungl/opengl/GL12.java
@@ -19,6 +19,7 @@ package overrungl.opengl;
 /**
  * The OpenGL 1.2 constants.
  *
+ * @sealedGraph
  * @author squid233
  * @since 0.1.0
  */

--- a/modules/overrungl/opengl/src/main/java/overrungl/opengl/GL12C.java
+++ b/modules/overrungl/opengl/src/main/java/overrungl/opengl/GL12C.java
@@ -25,6 +25,7 @@ import static overrungl.FunctionDescriptors.*;
 /**
  * The OpenGL 1.2 forward compatible functions.
  *
+ * @sealedGraph
  * @author squid233
  * @since 0.1.0
  */

--- a/modules/overrungl/opengl/src/main/java/overrungl/opengl/GL13.java
+++ b/modules/overrungl/opengl/src/main/java/overrungl/opengl/GL13.java
@@ -34,6 +34,7 @@ import static overrungl.opengl.GLLoader.getCapabilities;
  *     <li>{@linkplain GLARBTransposeMatrix GL_ARB_transpose_matrix}</li>
  * </ul>
  *
+ * @sealedGraph
  * @author squid233
  * @since 0.1.0
  */

--- a/modules/overrungl/opengl/src/main/java/overrungl/opengl/GL13C.java
+++ b/modules/overrungl/opengl/src/main/java/overrungl/opengl/GL13C.java
@@ -35,6 +35,7 @@ import static overrungl.opengl.GLLoader.*;
  *     <li>{@linkplain GLARBTextureCubeMap GL_ARB_texture_cube_map}</li>
  * </ul>
  *
+ * @sealedGraph
  * @author squid233
  * @since 0.1.0
  */

--- a/modules/overrungl/opengl/src/main/java/overrungl/opengl/GL14.java
+++ b/modules/overrungl/opengl/src/main/java/overrungl/opengl/GL14.java
@@ -25,6 +25,7 @@ import static overrungl.FunctionDescriptors.*;
 /**
  * The OpenGL 1.4 functions.
  *
+ * @sealedGraph
  * @author squid233
  * @since 0.1.0
  */

--- a/modules/overrungl/opengl/src/main/java/overrungl/opengl/GL14C.java
+++ b/modules/overrungl/opengl/src/main/java/overrungl/opengl/GL14C.java
@@ -38,6 +38,7 @@ import static overrungl.opengl.GLLoader.*;
  *     <li>{@linkplain GLARBTextureMirroredRepeat GL_ARB_texture_mirrored_repeat}</li>
  * </ul>
  *
+ * @sealedGraph
  * @author squid233
  * @since 0.1.0
  */

--- a/modules/overrungl/opengl/src/main/java/overrungl/opengl/GL15C.java
+++ b/modules/overrungl/opengl/src/main/java/overrungl/opengl/GL15C.java
@@ -34,6 +34,7 @@ import static overrungl.FunctionDescriptors.*;
  *     <li>{@linkplain GLARBOcclusionQuery GL_ARB_occlusion_query}</li>
  * </ul>
  *
+ * @sealedGraph
  * @author squid233
  * @since 0.1.0
  */

--- a/modules/overrungl/opengl/src/main/java/overrungl/opengl/GL20C.java
+++ b/modules/overrungl/opengl/src/main/java/overrungl/opengl/GL20C.java
@@ -40,6 +40,7 @@ import static overrungl.opengl.GLLoader.*;
  *     <li>{@linkplain GLARBShaderObjects GL_ARB_shader_objects}</li>
  * </ul>
  *
+ * @sealedGraph
  * @author squid233
  * @since 0.1.0
  */
@@ -258,8 +259,14 @@ public sealed class GL20C extends GL15C permits GL21C {
         }
     }
 
-    public static void bindAttribLocation(SegmentAllocator allocator, int program, int index, String name) {
-        bindAttribLocation(program, index, allocator.allocateUtf8String(name));
+    public static void bindAttribLocation(int program, int index, String name) {
+        final MemoryStack stack = MemoryStack.stackGet();
+        final long stackPointer = stack.getPointer();
+        try {
+            bindAttribLocation(program, index, stack.allocateUtf8String(name));
+        } finally {
+            stack.setPointer(stackPointer);
+        }
     }
 
     public static void blendEquationSeparate(int modeRGB, int modeAlpha) {
@@ -430,8 +437,14 @@ public sealed class GL20C extends GL15C permits GL21C {
         }
     }
 
-    public static int getAttribLocation(SegmentAllocator allocator, int program, String name) {
-        return getAttribLocation(program, allocator.allocateUtf8String(name));
+    public static int getAttribLocation(int program, String name) {
+        final MemoryStack stack = MemoryStack.stackGet();
+        final long stackPointer = stack.getPointer();
+        try {
+            return getAttribLocation(program, stack.allocateUtf8String(name));
+        } finally {
+            stack.setPointer(stackPointer);
+        }
     }
 
     public static void getProgramInfoLog(int program, int bufSize, MemorySegment length, MemorySegment infoLog) {
@@ -566,8 +579,14 @@ public sealed class GL20C extends GL15C permits GL21C {
         }
     }
 
-    public static int getUniformLocation(SegmentAllocator allocator, int program, String name) {
-        return getUniformLocation(program, allocator.allocateUtf8String(name));
+    public static int getUniformLocation(int program, String name) {
+        final MemoryStack stack = MemoryStack.stackGet();
+        final long stackPointer = stack.getPointer();
+        try {
+            return getUniformLocation(program, stack.allocateUtf8String(name));
+        } finally {
+            stack.setPointer(stackPointer);
+        }
     }
 
     public static void getUniformfv(int program, int location, MemorySegment params) {
@@ -790,8 +809,14 @@ public sealed class GL20C extends GL15C permits GL21C {
         shaderSource(shader, string.length, pStr, pLen);
     }
 
-    public static void shaderSource(SegmentAllocator allocator, int shader, String string) {
-        shaderSource(shader, 1, allocator.allocate(ADDRESS, allocator.allocateUtf8String(string)), allocator.allocate(JAVA_INT, string.length()));
+    public static void shaderSource(int shader, String string) {
+        final MemoryStack stack = MemoryStack.stackGet();
+        final long stackPointer = stack.getPointer();
+        try {
+            shaderSource(shader, 1, stack.allocate(ADDRESS, stack.allocateUtf8String(string)), stack.allocate(JAVA_INT, string.length()));
+        } finally {
+            stack.setPointer(stackPointer);
+        }
     }
 
     public static void stencilFuncSeparate(int face, int func, int ref, int mask) {

--- a/modules/overrungl/opengl/src/main/java/overrungl/opengl/GL21C.java
+++ b/modules/overrungl/opengl/src/main/java/overrungl/opengl/GL21C.java
@@ -33,6 +33,7 @@ import static overrungl.opengl.GLLoader.*;
  *     <li>{@linkplain GLARBPixelBufferObject GL_ARB_pixel_buffer_object}</li>
  * </ul>
  *
+ * @sealedGraph
  * @author squid233
  * @since 0.1.0
  */

--- a/modules/overrungl/opengl/src/main/java/overrungl/opengl/GL30C.java
+++ b/modules/overrungl/opengl/src/main/java/overrungl/opengl/GL30C.java
@@ -41,6 +41,7 @@ import static overrungl.opengl.GLLoader.*;
  *     <li>GL_ARB_vertex_array_object</li>
  * </ul>
  *
+ * @sealedGraph
  * @author squid233
  * @since 0.1.0
  */
@@ -426,8 +427,14 @@ public sealed class GL30C extends GL21C permits GL31C {
         }
     }
 
-    public static void bindFragDataLocation(SegmentAllocator allocator, int program, int color, String name) {
-        bindFragDataLocation(program, color, allocator.allocateUtf8String(name));
+    public static void bindFragDataLocation(int program, int color, String name) {
+        final MemoryStack stack = MemoryStack.stackGet();
+        final long stackPointer = stack.getPointer();
+        try {
+            bindFragDataLocation(program, color, stack.allocateUtf8String(name));
+        } finally {
+            stack.setPointer(stackPointer);
+        }
     }
 
     public static void bindFramebuffer(int target, int framebuffer) {
@@ -826,8 +833,14 @@ public sealed class GL30C extends GL21C permits GL31C {
         }
     }
 
-    public static int getFragDataLocation(SegmentAllocator allocator, int program, String name) {
-        return getFragDataLocation(program, allocator.allocateUtf8String(name));
+    public static int getFragDataLocation(int program, String name) {
+        final MemoryStack stack = MemoryStack.stackGet();
+        final long stackPointer = stack.getPointer();
+        try {
+            return getFragDataLocation(program, stack.allocateUtf8String(name));
+        } finally {
+            stack.setPointer(stackPointer);
+        }
     }
 
     public static void getFramebufferAttachmentParameteriv(int target, int attachment, int pname, MemorySegment params) {

--- a/modules/overrungl/opengl/src/main/java/overrungl/opengl/GL31C.java
+++ b/modules/overrungl/opengl/src/main/java/overrungl/opengl/GL31C.java
@@ -37,6 +37,7 @@ import static overrungl.FunctionDescriptors.*;
  *     <li>GL_ARB_uniform_buffer_object</li>
  * </ul>
  *
+ * @sealedGraph
  * @author squid233
  * @since 0.1.0
  */
@@ -268,8 +269,14 @@ public sealed class GL31C extends GL30C permits GL32C {
         }
     }
 
-    public static int getUniformBlockIndex(SegmentAllocator allocator, int program, String uniformBlockName) {
-        return getUniformBlockIndex(program, allocator.allocateUtf8String(uniformBlockName));
+    public static int getUniformBlockIndex(int program, String uniformBlockName) {
+        final MemoryStack stack = MemoryStack.stackGet();
+        final long stackPointer = stack.getPointer();
+        try {
+            return getUniformBlockIndex(program, stack.allocateUtf8String(uniformBlockName));
+        } finally {
+            stack.setPointer(stackPointer);
+        }
     }
 
     public static void getUniformIndices(int program, int uniformCount, MemorySegment uniformNames, MemorySegment uniformIndices) {
@@ -292,10 +299,16 @@ public sealed class GL31C extends GL30C permits GL32C {
         RuntimeHelper.toArray(pIndices, uniformIndices);
     }
 
-    public static int getUniformIndex(SegmentAllocator allocator, int program, String uniformName) {
-        var seg = allocator.allocate(JAVA_INT);
-        getUniformIndices(program, 1, allocator.allocateUtf8String(uniformName), seg);
-        return seg.get(JAVA_INT, 0);
+    public static int getUniformIndex(int program, String uniformName) {
+        final MemoryStack stack = MemoryStack.stackGet();
+        final long stackPointer = stack.getPointer();
+        try {
+            var seg = stack.allocate(JAVA_INT);
+            getUniformIndices(program, 1, stack.allocateUtf8String(uniformName), seg);
+            return seg.get(JAVA_INT, 0);
+        } finally {
+            stack.setPointer(stackPointer);
+        }
     }
 
     public static void primitiveRestartIndex(int index) {

--- a/modules/overrungl/opengl/src/main/java/overrungl/opengl/GL32C.java
+++ b/modules/overrungl/opengl/src/main/java/overrungl/opengl/GL32C.java
@@ -37,6 +37,7 @@ import static overrungl.FunctionDescriptors.*;
  *     <li>GL_ARB_texture_multisample</li>
  * </ul>
  *
+ * @sealedGraph
  * @author squid233
  * @since 0.1.0
  */

--- a/modules/overrungl/opengl/src/main/java/overrungl/opengl/GL33C.java
+++ b/modules/overrungl/opengl/src/main/java/overrungl/opengl/GL33C.java
@@ -39,6 +39,7 @@ import static overrungl.opengl.GLLoader.*;
  *     <li>GL_ARB_vertex_type_2_10_10_10_rev</li>
  * </ul>
  *
+ * @sealedGraph
  * @author squid233
  * @since 0.1.0
  */
@@ -108,8 +109,14 @@ public sealed class GL33C extends GL32C permits GL40C {
         }
     }
 
-    public static void bindFragDataLocationIndexed(SegmentAllocator allocator, int program, int colorNumber, int index, String name) {
-        bindFragDataLocationIndexed(program, colorNumber, index, allocator.allocateUtf8String(name));
+    public static void bindFragDataLocationIndexed(int program, int colorNumber, int index, String name) {
+        final MemoryStack stack = MemoryStack.stackGet();
+        final long stackPointer = stack.getPointer();
+        try {
+            bindFragDataLocationIndexed(program, colorNumber, index, stack.allocateUtf8String(name));
+        } finally {
+            stack.setPointer(stackPointer);
+        }
     }
 
     public static void bindSampler(int unit, int sampler) {
@@ -180,8 +187,14 @@ public sealed class GL33C extends GL32C permits GL40C {
         }
     }
 
-    public static int getFragDataIndex(SegmentAllocator allocator, int program, String name) {
-        return getFragDataIndex(program, allocator.allocateUtf8String(name));
+    public static int getFragDataIndex(int program, String name) {
+        final MemoryStack stack = MemoryStack.stackGet();
+        final long stackPointer = stack.getPointer();
+        try {
+            return getFragDataIndex(program, stack.allocateUtf8String(name));
+        } finally {
+            stack.setPointer(stackPointer);
+        }
     }
 
     public static void getQueryObjecti64v(int id, int pname, MemorySegment params) {

--- a/modules/overrungl/opengl/src/main/java/overrungl/opengl/GL40C.java
+++ b/modules/overrungl/opengl/src/main/java/overrungl/opengl/GL40C.java
@@ -47,6 +47,7 @@ import static overrungl.opengl.GLLoader.*;
  *     <li>{@linkplain GLARBTextureGather GL_ARB_texture_gather}</li>
  * </ul>
  *
+ * @sealedGraph
  * @author squid233
  * @since 0.1.0
  */
@@ -462,8 +463,14 @@ public sealed class GL40C extends GL33C permits GL41C {
         }
     }
 
-    public static int getSubroutineIndex(SegmentAllocator allocator, int program, int shaderType, String name) {
-        return getSubroutineIndex(program, shaderType, allocator.allocateUtf8String(name));
+    public static int getSubroutineIndex(int program, int shaderType, String name) {
+        final MemoryStack stack = MemoryStack.stackGet();
+        final long stackPointer = stack.getPointer();
+        try {
+            return getSubroutineIndex(program, shaderType, stack.allocateUtf8String(name));
+        } finally {
+            stack.setPointer(stackPointer);
+        }
     }
 
     public static int getSubroutineUniformLocation(int program, int shaderType, MemorySegment name) {
@@ -475,8 +482,14 @@ public sealed class GL40C extends GL33C permits GL41C {
         }
     }
 
-    public static int getSubroutineUniformLocation(SegmentAllocator allocator, int program, int shaderType, String name) {
-        return getSubroutineUniformLocation(program, shaderType, allocator.allocateUtf8String(name));
+    public static int getSubroutineUniformLocation(int program, int shaderType, String name) {
+        final MemoryStack stack = MemoryStack.stackGet();
+        final long stackPointer = stack.getPointer();
+        try {
+            return getSubroutineUniformLocation(program, shaderType, stack.allocateUtf8String(name));
+        } finally {
+            stack.setPointer(stackPointer);
+        }
     }
 
     public static void getUniformSubroutineuiv(int shaderType, int location, MemorySegment params) {

--- a/modules/overrungl/opengl/src/main/java/overrungl/opengl/GL41C.java
+++ b/modules/overrungl/opengl/src/main/java/overrungl/opengl/GL41C.java
@@ -39,6 +39,7 @@ import static overrungl.opengl.GLLoader.*;
  *     <li>GL_ARB_viewport_array</li>
  * </ul>
  *
+ * @sealedGraph
  * @author squid233
  * @since 0.1.0
  */
@@ -232,8 +233,14 @@ public sealed class GL41C extends GL40C permits GL42C {
         return createShaderProgramv(type, strings.length, seg);
     }
 
-    public static int createShaderProgram(SegmentAllocator allocator, int type, String string) {
-        return createShaderProgramv(type, 1, allocator.allocate(ADDRESS, allocator.allocateUtf8String(string)));
+    public static int createShaderProgram(int type, String string) {
+        final MemoryStack stack = MemoryStack.stackGet();
+        final long stackPointer = stack.getPointer();
+        try {
+            return createShaderProgramv(type, 1, stack.allocate(ADDRESS, stack.allocateUtf8String(string)));
+        } finally {
+            stack.setPointer(stackPointer);
+        }
     }
 
     public static void deleteProgramPipelines(int n, MemorySegment pipelines) {

--- a/modules/overrungl/opengl/src/main/java/overrungl/opengl/GL42C.java
+++ b/modules/overrungl/opengl/src/main/java/overrungl/opengl/GL42C.java
@@ -41,6 +41,7 @@ import static overrungl.opengl.GLLoader.*;
  *     <li>{@linkplain GLARBTextureCompressionBptc GL_ARB_texture_compression_bptc}</li>
  * </ul>
  *
+ * @sealedGraph
  * @author squid233
  * @since 0.1.0
  */

--- a/modules/overrungl/opengl/src/main/java/overrungl/opengl/GL43C.java
+++ b/modules/overrungl/opengl/src/main/java/overrungl/opengl/GL43C.java
@@ -52,6 +52,7 @@ import static overrungl.opengl.GLLoader.*;
  *     <li>GL_KHR_debug</li>
  * </ul>
  *
+ * @sealedGraph
  * @author squid233
  * @since 0.1.0
  */
@@ -444,8 +445,14 @@ public sealed class GL43C extends GL42C permits GL44C {
         }
     }
 
-    public static void debugMessageInsert(SegmentAllocator allocator, int source, int type, int id, int severity, String buf) {
-        debugMessageInsert(source, type, id, severity, -1, allocator.allocateUtf8String(buf));
+    public static void debugMessageInsert(int source, int type, int id, int severity, String buf) {
+        final MemoryStack stack = MemoryStack.stackGet();
+        final long stackPointer = stack.getPointer();
+        try {
+            debugMessageInsert(source, type, id, severity, buf.length(), stack.allocateUtf8String(buf));
+        } finally {
+            stack.setPointer(stackPointer);
+        }
     }
 
     public static void dispatchCompute(int numGroupsX, int numGroupsY, int numGroupsZ) {
@@ -637,8 +644,14 @@ public sealed class GL43C extends GL42C permits GL44C {
         }
     }
 
-    public static int getProgramResourceIndex(SegmentAllocator allocator, int program, int programInterface, String name) {
-        return getProgramResourceIndex(program, programInterface, allocator.allocateUtf8String(name));
+    public static int getProgramResourceIndex(int program, int programInterface, String name) {
+        final MemoryStack stack = MemoryStack.stackGet();
+        final long stackPointer = stack.getPointer();
+        try {
+            return getProgramResourceIndex(program, programInterface, stack.allocateUtf8String(name));
+        } finally {
+            stack.setPointer(stackPointer);
+        }
     }
 
     public static int getProgramResourceLocation(int program, int programInterface, MemorySegment name) {
@@ -650,8 +663,14 @@ public sealed class GL43C extends GL42C permits GL44C {
         }
     }
 
-    public static int getProgramResourceLocation(SegmentAllocator allocator, int program, int programInterface, String name) {
-        return getProgramResourceLocation(program, programInterface, allocator.allocateUtf8String(name));
+    public static int getProgramResourceLocation(int program, int programInterface, String name) {
+        final MemoryStack stack = MemoryStack.stackGet();
+        final long stackPointer = stack.getPointer();
+        try {
+            return getProgramResourceLocation(program, programInterface, stack.allocateUtf8String(name));
+        } finally {
+            stack.setPointer(stackPointer);
+        }
     }
 
     public static int getProgramResourceLocationIndex(int program, int programInterface, MemorySegment name) {
@@ -663,8 +682,14 @@ public sealed class GL43C extends GL42C permits GL44C {
         }
     }
 
-    public static int getProgramResourceLocationIndex(SegmentAllocator allocator, int program, int programInterface, String name) {
-        return getProgramResourceLocationIndex(program, programInterface, allocator.allocateUtf8String(name));
+    public static int getProgramResourceLocationIndex(int program, int programInterface, String name) {
+        final MemoryStack stack = MemoryStack.stackGet();
+        final long stackPointer = stack.getPointer();
+        try {
+            return getProgramResourceLocationIndex(program, programInterface, stack.allocateUtf8String(name));
+        } finally {
+            stack.setPointer(stackPointer);
+        }
     }
 
     public static void getProgramResourceName(int program, int programInterface, int index, int bufSize, MemorySegment length, MemorySegment name) {
@@ -840,8 +865,14 @@ public sealed class GL43C extends GL42C permits GL44C {
         }
     }
 
-    public static void objectLabel(SegmentAllocator allocator, int identifier, int name, String label) {
-        objectLabel(identifier, name, -1, allocator.allocateUtf8String(label));
+    public static void objectLabel(int identifier, int name, String label) {
+        final MemoryStack stack = MemoryStack.stackGet();
+        final long stackPointer = stack.getPointer();
+        try {
+            objectLabel(identifier, name, label.length(), stack.allocateUtf8String(label));
+        } finally {
+            stack.setPointer(stackPointer);
+        }
     }
 
     public static void objectPtrLabel(MemorySegment ptr, int length, MemorySegment label) {
@@ -853,8 +884,14 @@ public sealed class GL43C extends GL42C permits GL44C {
         }
     }
 
-    public static void objectPtrLabel(SegmentAllocator allocator, MemorySegment ptr, String label) {
-        objectPtrLabel(ptr, -1, allocator.allocateUtf8String(label));
+    public static void objectPtrLabel(MemorySegment ptr, String label) {
+        final MemoryStack stack = MemoryStack.stackGet();
+        final long stackPointer = stack.getPointer();
+        try {
+            objectPtrLabel(ptr, label.length(), stack.allocateUtf8String(label));
+        } finally {
+            stack.setPointer(stackPointer);
+        }
     }
 
     public static void popDebugGroup() {
@@ -875,8 +912,14 @@ public sealed class GL43C extends GL42C permits GL44C {
         }
     }
 
-    public static void pushDebugGroup(SegmentAllocator allocator, int source, int id, String message) {
-        pushDebugGroup(source, id, -1, allocator.allocateUtf8String(message));
+    public static void pushDebugGroup(int source, int id, String message) {
+        final MemoryStack stack = MemoryStack.stackGet();
+        final long stackPointer = stack.getPointer();
+        try {
+            pushDebugGroup(source, id, message.length(), stack.allocateUtf8String(message));
+        } finally {
+            stack.setPointer(stackPointer);
+        }
     }
 
     public static void shaderStorageBlockBinding(int program, int storageBlockIndex, int storageBlockBinding) {

--- a/modules/overrungl/opengl/src/main/java/overrungl/opengl/GL44C.java
+++ b/modules/overrungl/opengl/src/main/java/overrungl/opengl/GL44C.java
@@ -33,6 +33,7 @@ import static overrungl.opengl.GLLoader.*;
  *     <li>GL_ARB_multi_bind</li>
  * </ul>
  *
+ * @sealedGraph
  * @author squid233
  * @since 0.1.0
  */

--- a/modules/overrungl/opengl/src/main/java/overrungl/opengl/GL45C.java
+++ b/modules/overrungl/opengl/src/main/java/overrungl/opengl/GL45C.java
@@ -40,6 +40,7 @@ import static overrungl.FunctionDescriptors.*;
  *     <li>GL_KHR_robustness</li>
  * </ul>
  *
+ * @sealedGraph
  * @author squid233
  * @since 0.1.0
  */

--- a/modules/overrungl/opengl/src/main/java/overrungl/opengl/GL46C.java
+++ b/modules/overrungl/opengl/src/main/java/overrungl/opengl/GL46C.java
@@ -21,6 +21,7 @@ import overrungl.opengl.ext.arb.GLARBGLSpirv;
 import overrungl.opengl.ext.arb.GLARBIndirectParameters;
 import overrungl.opengl.ext.arb.GLARBPipelineStatisticsQuery;
 import overrungl.opengl.ext.arb.GLARBTransformFeedbackOverflowQuery;
+import overrungl.util.MemoryStack;
 
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.SegmentAllocator;
@@ -41,6 +42,7 @@ import static overrungl.opengl.GLLoader.*;
  *     <li>{@linkplain GLARBTransformFeedbackOverflowQuery GL_ARB_transform_feedback_overflow_query}</li>
  * </ul>
  *
+ * @sealedGraph
  * @author squid233
  * @since 0.1.0
  */
@@ -123,11 +125,17 @@ public sealed class GL46C extends GL45C permits GL {
             pConstantValue != null ? allocator.allocateArray(ValueLayout.JAVA_INT, pConstantValue) : MemorySegment.NULL);
     }
 
-    public static void specializeShader(SegmentAllocator allocator, int shader, @Nullable String pEntryPoint) {
-        specializeShader(shader,
-            pEntryPoint != null ? allocator.allocateUtf8String(pEntryPoint) : MemorySegment.NULL,
-            0,
-            MemorySegment.NULL,
-            MemorySegment.NULL);
+    public static void specializeShader(int shader, @Nullable String pEntryPoint) {
+        final MemoryStack stack = MemoryStack.stackGet();
+        final long stackPointer = stack.getPointer();
+        try {
+            specializeShader(shader,
+                pEntryPoint != null ? stack.allocateUtf8String(pEntryPoint) : MemorySegment.NULL,
+                0,
+                MemorySegment.NULL,
+                MemorySegment.NULL);
+        } finally {
+            stack.setPointer(stackPointer);
+        }
     }
 }

--- a/modules/overrungl/opengl/src/main/java/overrungl/opengl/GLCapabilities.java
+++ b/modules/overrungl/opengl/src/main/java/overrungl/opengl/GLCapabilities.java
@@ -280,18 +280,9 @@ public class GLCapabilities {
         Ver20, Ver21,
         Ver30, Ver31, Ver32, Ver33,
         Ver40, Ver41, Ver42, Ver43, Ver44, Ver45, Ver46;
-    /**
-     * The raw OpenGL version value.
-     */
-    public int rawGLVersion;
-    /**
-     * Forward compatible flag. {@code false} for deprecated and removed function.
-     */
-    public boolean forwardCompatible;
-    /**
-     * The OpenGL extension capabilities.
-     */
-    public GLExtCaps ext;
+    private int rawGLVersion;
+    private final boolean forwardCompatible;
+    private GLExtCaps ext;
 
     /**
      * Constructs <i>incomplete</i> OpenGL capabilities.
@@ -307,7 +298,6 @@ public class GLCapabilities {
      *
      * @param load the load function.
      * @return the OpenGL version returned from the graphics driver, or {@code 0} if no OpenGL context found.
-     * no guaranteed to actually supported version, please use {@code Ver##}
      */
     public int load(GLLoadFunc load) {
         glGetString = load.invoke("glGetString", FunctionDescriptors.Ip);
@@ -428,5 +418,28 @@ public class GLCapabilities {
         Ver45 = (major == 4 && minor >= 5) || major > 4;
         Ver46 = (major == 4 && minor >= 6) || major > 4;
         return GLLoader.makeVersion(major, minor);
+    }
+
+    /**
+     * {@return the raw OpenGL version value}
+     */
+    public int rawGLVersion() {
+        return rawGLVersion;
+    }
+
+    /**
+     * Forward compatible flag.
+     *
+     * @return {@code false} for deprecated and removed function.
+     */
+    public boolean forwardCompatible() {
+        return forwardCompatible;
+    }
+
+    /**
+     * {@return the OpenGL extension capabilities}
+     */
+    public GLExtCaps ext() {
+        return ext;
     }
 }

--- a/modules/overrungl/opengl/src/main/java/overrungl/opengl/GLLoadFunc.java
+++ b/modules/overrungl/opengl/src/main/java/overrungl/opengl/GLLoadFunc.java
@@ -22,41 +22,30 @@ import overrungl.RuntimeHelper;
 
 import java.lang.foreign.Linker;
 import java.lang.foreign.MemorySegment;
-import java.lang.foreign.SegmentAllocator;
 import java.lang.invoke.MethodHandle;
 
 /**
  * The OpenGL loading function.
  *
  * <h2>Example</h2>
- * <pre>{@code
+ * {@snippet lang = java:
  * // loads OpenGL compatibility profile
- * if (GLLoader.loadConfined(true, GLFW::ngetProcAddress) == 0)
+ * if (GLLoader.load(GLFW::getProcAddress, true) == null)
  *     throw new IllegalStateException("Failed to load OpenGL");
  * }</pre>
  *
  * @author squid233
  * @since 0.1.0
  */
+@FunctionalInterface
 public interface GLLoadFunc {
-    /**
-     * Creates a load function with given segment allocator.
-     *
-     * @param allocator the segment allocator.
-     * @param function  the function pointer getter
-     * @return the load function
-     */
-    static GLLoadFunc of(SegmentAllocator allocator, Getter function) {
-        return new GLLoadFunc.Delegate(allocator, function);
-    }
-
     /**
      * Gets the function pointer of the given GL function.
      *
-     * @param string the address of the string.
+     * @param string the name of the function.
      * @return the function pointer.
      */
-    MemorySegment invoke(MemorySegment string);
+    MemorySegment invoke(String string);
 
     /**
      * Load a function by the given name and creates a downcall handle or {@code null}.
@@ -67,7 +56,9 @@ public interface GLLoadFunc {
      * @return a downcall method handle,  or {@code null} if the symbol is {@link MemorySegment#NULL}
      */
     @Nullable
-    MethodHandle invoke(String procName, FunctionDescriptors function, Linker.Option... options);
+    default MethodHandle invoke(String procName, FunctionDescriptors function, Linker.Option... options) {
+        return RuntimeHelper.downcallSafe(invoke(procName), function, options);
+    }
 
     /**
      * Load a trivial function by the given name and creates a downcall handle or {@code null}.
@@ -78,42 +69,5 @@ public interface GLLoadFunc {
      */
     default MethodHandle trivialHandle(String procName, FunctionDescriptors function) {
         return invoke(procName, function, Linker.Option.isTrivial());
-    }
-
-    /**
-     * The GL function pointer getter.
-     *
-     * @author squid233
-     * @since 0.1.0
-     */
-    @FunctionalInterface
-    interface Getter {
-        /**
-         * Gets the function pointer of the given GL function.
-         *
-         * @param string the address of the string.
-         * @return the function pointer.
-         */
-        MemorySegment get(MemorySegment string);
-    }
-
-    /**
-     * The delegate contained a segment allocator and the callback.
-     *
-     * @param allocator the segment allocator
-     * @param func      the loading function
-     * @author squid233
-     * @since 0.1.0
-     */
-    record Delegate(SegmentAllocator allocator, Getter func) implements GLLoadFunc {
-        @Override
-        public MemorySegment invoke(MemorySegment string) {
-            return func.get(string);
-        }
-
-        @Override
-        public @Nullable MethodHandle invoke(String procName, FunctionDescriptors function, Linker.Option... options) {
-            return RuntimeHelper.downcallSafe(invoke(allocator.allocateUtf8String(procName)), function, options);
-        }
     }
 }

--- a/modules/overrungl/opengl/src/main/java/overrungl/opengl/GLLoader.java
+++ b/modules/overrungl/opengl/src/main/java/overrungl/opengl/GLLoader.java
@@ -22,8 +22,6 @@ import org.jetbrains.annotations.Nullable;
 import overrungl.Configurations;
 import overrungl.RuntimeHelper;
 
-import java.lang.foreign.Arena;
-import java.lang.foreign.SegmentAllocator;
 import java.lang.invoke.MethodHandle;
 
 /**
@@ -36,7 +34,7 @@ import java.lang.invoke.MethodHandle;
  * </ul>
  *
  * <h2>GLCapabilities creation</h2>
- * <p>Instances of {@code GLCapabilities} can be created with the {@link #load(boolean, GLLoadFunc) load} method. An OpenGL context must be current in the current thread
+ * <p>Instances of {@code GLCapabilities} can be created with the {@link #load(GLLoadFunc, boolean) load} method. An OpenGL context must be current in the current thread
  * before it is called. Calling this method is expensive, so the {@code GLCapabilities} instance should be associated with the OpenGL context and reused as
  * necessary.</p>
  *
@@ -45,7 +43,7 @@ import java.lang.invoke.MethodHandle;
  * {@link #setCapabilities} method. The user is also responsible for clearing the current {@code GLCapabilities} instance when the context is destroyed or made
  * current in another thread.</p>
  *
- * <p>Note that the {@link #load(boolean, GLLoadFunc) load} method implicitly calls {@link #setCapabilities} with the newly created instance.</p>
+ * <p>Note that the {@link #load(GLLoadFunc, boolean) load} method implicitly calls {@link #setCapabilities} with the newly created instance.</p>
  *
  * @author squid233
  * @see GLLoadFunc
@@ -80,13 +78,13 @@ public final class GLLoader {
      * <p>
      * This is equivalent to the following code:
      * <pre><code>
-     * {@link #getCapabilities()}.{@link GLCapabilities#ext ext}
+     * {@link #getCapabilities()}.{@link GLCapabilities#ext() ext()}
      * </code></pre>
      *
      * @throws IllegalStateException if {@link #setCapabilities} has never been called in the current thread or was last called with a {@code null} value
      */
     public static GLExtCaps getExtCapabilities() {
-        return getCapabilities().ext;
+        return getCapabilities().ext();
     }
 
     private static GLCapabilities checkCapabilities(@Nullable GLCapabilities caps) {
@@ -98,75 +96,25 @@ public final class GLLoader {
     }
 
     /**
-     * Load OpenGL compatibility profile by the given load function with confined arena.
-     *
-     * @param getter the function pointer getter
-     * @return the OpenGL capabilities, or {@code null} if no OpenGL context found.
-     */
-    @Nullable
-    public static GLCapabilities loadConfined(GLLoadFunc.Getter getter) {
-        return loadConfined(DEFAULT_COMPATIBLE, getter);
-    }
-
-    /**
-     * Load OpenGL by the given load function with confined arena.
-     *
-     * @param forwardCompatible If {@code true}, only loads core profile functions.
-     * @param getter            the function pointer getter
-     * @return the OpenGL capabilities, or {@code null} if no OpenGL context found.
-     */
-    @Nullable
-    public static GLCapabilities loadConfined(boolean forwardCompatible, GLLoadFunc.Getter getter) {
-        try (Arena arena = Arena.ofConfined()) {
-            return load(forwardCompatible, arena, getter);
-        }
-    }
-
-    /**
-     * Load OpenGL compatibility profile by the given load function with the given segment allocator.
-     *
-     * @param allocator the segment allocator.
-     * @param getter    the function pointer getter
-     * @return the OpenGL capabilities, or {@code null} if no OpenGL context found.
-     */
-    @Nullable
-    public static GLCapabilities load(SegmentAllocator allocator, GLLoadFunc.Getter getter) {
-        return load(DEFAULT_COMPATIBLE, allocator, getter);
-    }
-
-    /**
-     * Load OpenGL by the given load function with the given segment allocator.
-     *
-     * @param forwardCompatible If {@code true}, only loads core profile functions.
-     * @param allocator         the segment allocator.
-     * @param getter            the function pointer getter
-     * @return the OpenGL capabilities, or {@code null} if no OpenGL context found.
-     */
-    @Nullable
-    public static GLCapabilities load(boolean forwardCompatible, SegmentAllocator allocator, GLLoadFunc.Getter getter) {
-        return load(forwardCompatible, GLLoadFunc.of(allocator, getter));
-    }
-
-    /**
-     * Load OpenGL compatibility profile by the given load function.
+     * Loads OpenGL compatibility profile with the given load function.
      *
      * @param load the load function
      * @return the OpenGL capabilities, or {@code null} if no OpenGL context found.
      */
     @Nullable
     public static GLCapabilities load(GLLoadFunc load) {
-        return load(DEFAULT_COMPATIBLE, load);
+        return load(load, DEFAULT_COMPATIBLE);
     }
 
     /**
-     * Load OpenGL by the given load function.
+     * Loads OpenGL with the given load function.
      *
-     * @param forwardCompatible If {@code true}, only loads core profile functions.
      * @param load              the load function
+     * @param forwardCompatible If {@code true}, only loads core profile functions.
      * @return the OpenGL capabilities, or {@code null} if no OpenGL context found.
      */
     @Nullable
-    public static GLCapabilities load(boolean forwardCompatible, GLLoadFunc load) {
+    public static GLCapabilities load(GLLoadFunc load, boolean forwardCompatible) {
         var caps = new GLCapabilities(forwardCompatible);
         // set the global capabilities first
         setCapabilities(caps);

--- a/modules/overrungl/opengl/src/main/java/overrungl/opengl/GLUtil.java
+++ b/modules/overrungl/opengl/src/main/java/overrungl/opengl/GLUtil.java
@@ -67,7 +67,7 @@ public final class GLUtil {
     public static Arena setupDebugMessageCallback(Consumer<String> logger) {
         var caps = GLLoader.getCapabilities();
 
-        if (caps.Ver43 || caps.ext.GL_KHR_debug) {
+        if (caps.Ver43 || caps.ext().GL_KHR_debug) {
             if (caps.Ver43) {
                 apiLog("[GL] Using OpenGL 4.3 for error logging.");
             } else {
@@ -99,7 +99,7 @@ public final class GLUtil {
             return arena;
         }
 
-        if (caps.ext.GL_ARB_debug_output) {
+        if (caps.ext().GL_ARB_debug_output) {
             apiLog("[GL] Using ARB_debug_output for error logging.");
             var arena = Arena.ofConfined();
             glDebugMessageCallbackARB(arena, (source, type, id, severity, message, userParam) -> {
@@ -121,7 +121,7 @@ public final class GLUtil {
             return arena;
         }
 
-        if (caps.ext.GL_AMD_debug_output) {
+        if (caps.ext().GL_AMD_debug_output) {
             apiLog("[GL] Using AMD_debug_output for error logging.");
             var arena = Arena.ofConfined();
             glDebugMessageCallbackAMD(arena, (id, category, severity, message, userParam) -> {

--- a/modules/overrungl/stb/src/main/java/overrungl/stb/STBEasyFont.java
+++ b/modules/overrungl/stb/src/main/java/overrungl/stb/STBEasyFont.java
@@ -16,6 +16,8 @@
 
 package overrungl.stb;
 
+import overrungl.util.MemoryStack;
+
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.SegmentAllocator;
 import java.lang.foreign.ValueLayout;
@@ -125,8 +127,14 @@ public final class STBEasyFont {
         }
     }
 
-    public static int width(SegmentAllocator allocator, String text) {
-        return nwidth(allocator.allocateUtf8String(text));
+    public static int width(String text) {
+        final MemoryStack stack = MemoryStack.stackGet();
+        final long stackPointer = stack.getPointer();
+        try {
+            return nwidth(stack.allocateUtf8String(text));
+        } finally {
+            stack.setPointer(stackPointer);
+        }
     }
 
     public static int nheight(MemorySegment text) {
@@ -137,7 +145,13 @@ public final class STBEasyFont {
         }
     }
 
-    public static int height(SegmentAllocator allocator, String text) {
-        return nheight(allocator.allocateUtf8String(text));
+    public static int height(String text) {
+        final MemoryStack stack = MemoryStack.stackGet();
+        final long stackPointer = stack.getPointer();
+        try {
+            return nheight(stack.allocateUtf8String(text));
+        } finally {
+            stack.setPointer(stackPointer);
+        }
     }
 }

--- a/modules/overrungl/stb/src/main/java/overrungl/stb/STBImage.java
+++ b/modules/overrungl/stb/src/main/java/overrungl/stb/STBImage.java
@@ -176,15 +176,21 @@ public final class STBImage {
         }
     }
 
-    public static boolean info(SegmentAllocator allocator, String filename, int[] x, int[] y, int[] comp) {
-        var px = allocator.allocate(JAVA_INT);
-        var py = allocator.allocate(JAVA_INT);
-        var pc = allocator.allocate(JAVA_INT);
-        boolean b = ninfo(allocator.allocateUtf8String(filename), px, py, pc);
-        x[0] = px.get(JAVA_INT, 0);
-        y[0] = py.get(JAVA_INT, 0);
-        comp[0] = pc.get(JAVA_INT, 0);
-        return b;
+    public static boolean info(String filename, int[] x, int[] y, int[] comp) {
+        final MemoryStack stack = MemoryStack.stackGet();
+        final long stackPointer = stack.getPointer();
+        try {
+            var px = stack.allocate(JAVA_INT);
+            var py = stack.allocate(JAVA_INT);
+            var pc = stack.allocate(JAVA_INT);
+            boolean b = ninfo(stack.allocateUtf8String(filename), px, py, pc);
+            x[0] = px.get(JAVA_INT, 0);
+            y[0] = py.get(JAVA_INT, 0);
+            comp[0] = pc.get(JAVA_INT, 0);
+            return b;
+        } finally {
+            stack.setPointer(stackPointer);
+        }
     }
 
     public static boolean ninfoFromCallbacks(MemorySegment clbk, MemorySegment user, MemorySegment x, MemorySegment y, MemorySegment comp) {
@@ -268,8 +274,14 @@ public final class STBImage {
         }
     }
 
-    public static boolean is16Bit(SegmentAllocator allocator, String filename) {
-        return nis16Bit(allocator.allocateUtf8String(filename));
+    public static boolean is16Bit(String filename) {
+        final MemoryStack stack = MemoryStack.stackGet();
+        final long stackPointer = stack.getPointer();
+        try {
+            return nis16Bit(stack.allocateUtf8String(filename));
+        } finally {
+            stack.setPointer(stackPointer);
+        }
     }
 
     public static boolean nis16BitFromCallbacks(MemorySegment clbk, MemorySegment user) {
@@ -316,8 +328,14 @@ public final class STBImage {
         }
     }
 
-    public static boolean isHdr(SegmentAllocator allocator, String filename) {
-        return nisHdr(allocator.allocateUtf8String(filename));
+    public static boolean isHdr(String filename) {
+        final MemoryStack stack = MemoryStack.stackGet();
+        final long stackPointer = stack.getPointer();
+        try {
+            return nisHdr(stack.allocateUtf8String(filename));
+        } finally {
+            stack.setPointer(stackPointer);
+        }
     }
 
     public static boolean nisHdrFromCallbacks(MemorySegment clbk, MemorySegment user) {
@@ -380,15 +398,21 @@ public final class STBImage {
         }
     }
 
-    public static MemorySegment load(SegmentAllocator allocator, String filename, int[] x, int[] y, int[] channelsInFile, int desiredChannels) {
-        var px = allocator.allocate(JAVA_INT);
-        var py = allocator.allocate(JAVA_INT);
-        var pc = allocator.allocate(JAVA_INT);
-        var addr = nload(allocator.allocateUtf8String(filename), px, py, pc, desiredChannels);
-        x[0] = px.get(JAVA_INT, 0);
-        y[0] = py.get(JAVA_INT, 0);
-        channelsInFile[0] = pc.get(JAVA_INT, 0);
-        return addr;
+    public static MemorySegment load(String filename, int[] x, int[] y, int[] channelsInFile, int desiredChannels) {
+        final MemoryStack stack = MemoryStack.stackGet();
+        final long stackPointer = stack.getPointer();
+        try {
+            var px = stack.allocate(JAVA_INT);
+            var py = stack.allocate(JAVA_INT);
+            var pc = stack.allocate(JAVA_INT);
+            var addr = nload(stack.allocateUtf8String(filename), px, py, pc, desiredChannels);
+            x[0] = px.get(JAVA_INT, 0);
+            y[0] = py.get(JAVA_INT, 0);
+            channelsInFile[0] = pc.get(JAVA_INT, 0);
+            return addr;
+        } finally {
+            stack.setPointer(stackPointer);
+        }
     }
 
     public static MemorySegment nload16(MemorySegment filename, MemorySegment x, MemorySegment y, MemorySegment channelsInFile, int desiredChannels) {
@@ -399,15 +423,21 @@ public final class STBImage {
         }
     }
 
-    public static MemorySegment load16(SegmentAllocator allocator, String filename, int[] x, int[] y, int[] channelsInFile, int desiredChannels) {
-        var px = allocator.allocate(JAVA_INT);
-        var py = allocator.allocate(JAVA_INT);
-        var pc = allocator.allocate(JAVA_INT);
-        var addr = nload16(allocator.allocateUtf8String(filename), px, py, pc, desiredChannels);
-        x[0] = px.get(JAVA_INT, 0);
-        y[0] = py.get(JAVA_INT, 0);
-        channelsInFile[0] = pc.get(JAVA_INT, 0);
-        return addr;
+    public static MemorySegment load16(String filename, int[] x, int[] y, int[] channelsInFile, int desiredChannels) {
+        final MemoryStack stack = MemoryStack.stackGet();
+        final long stackPointer = stack.getPointer();
+        try {
+            var px = stack.allocate(JAVA_INT);
+            var py = stack.allocate(JAVA_INT);
+            var pc = stack.allocate(JAVA_INT);
+            var addr = nload16(stack.allocateUtf8String(filename), px, py, pc, desiredChannels);
+            x[0] = px.get(JAVA_INT, 0);
+            y[0] = py.get(JAVA_INT, 0);
+            channelsInFile[0] = pc.get(JAVA_INT, 0);
+            return addr;
+        } finally {
+            stack.setPointer(stackPointer);
+        }
     }
 
     public static MemorySegment nload16FromCallbacks(MemorySegment clbk, MemorySegment user, MemorySegment x, MemorySegment y, MemorySegment channelsInFile, int desiredChannels) {
@@ -592,15 +622,21 @@ public final class STBImage {
         }
     }
 
-    public static MemorySegment loadf(SegmentAllocator allocator, String filename, int[] x, int[] y, int[] channelsInFile, int desiredChannels) {
-        var px = allocator.allocate(JAVA_INT);
-        var py = allocator.allocate(JAVA_INT);
-        var pc = allocator.allocate(JAVA_INT);
-        var addr = nloadf(allocator.allocateUtf8String(filename), px, py, pc, desiredChannels);
-        x[0] = px.get(JAVA_INT, 0);
-        y[0] = py.get(JAVA_INT, 0);
-        channelsInFile[0] = pc.get(JAVA_INT, 0);
-        return addr;
+    public static MemorySegment loadf(String filename, int[] x, int[] y, int[] channelsInFile, int desiredChannels) {
+        final MemoryStack stack = MemoryStack.stackGet();
+        final long stackPointer = stack.getPointer();
+        try {
+            var px = stack.allocate(JAVA_INT);
+            var py = stack.allocate(JAVA_INT);
+            var pc = stack.allocate(JAVA_INT);
+            var addr = nloadf(stack.allocateUtf8String(filename), px, py, pc, desiredChannels);
+            x[0] = px.get(JAVA_INT, 0);
+            y[0] = py.get(JAVA_INT, 0);
+            channelsInFile[0] = pc.get(JAVA_INT, 0);
+            return addr;
+        } finally {
+            stack.setPointer(stackPointer);
+        }
     }
 
     public static MemorySegment nloadfFromCallbacks(MemorySegment clbk, MemorySegment user, MemorySegment x, MemorySegment y, MemorySegment channelsInFile, int desiredChannels) {

--- a/modules/overrungl/stb/src/main/java/overrungl/stb/STBImageWrite.java
+++ b/modules/overrungl/stb/src/main/java/overrungl/stb/STBImageWrite.java
@@ -17,6 +17,7 @@
 package overrungl.stb;
 
 import overrungl.RuntimeHelper;
+import overrungl.util.MemoryStack;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
@@ -160,24 +161,48 @@ public final class STBImageWrite {
         }
     }
 
-    public static boolean png(SegmentAllocator allocator, String filename, int w, int h, int comp, MemorySegment data, int strideInBytes) {
-        return npng(allocator.allocateUtf8String(filename), w, h, comp, data, strideInBytes);
+    public static boolean png(String filename, int w, int h, int comp, MemorySegment data, int strideInBytes) {
+        final MemoryStack stack = MemoryStack.stackGet();
+        final long stackPointer = stack.getPointer();
+        try {
+            return npng(stack.allocateUtf8String(filename), w, h, comp, data, strideInBytes);
+        } finally {
+            stack.setPointer(stackPointer);
+        }
     }
 
-    public static boolean bmp(SegmentAllocator allocator, String filename, int w, int h, int comp, MemorySegment data) {
-        return nbmp(allocator.allocateUtf8String(filename), w, h, comp, data);
+    public static boolean bmp(String filename, int w, int h, int comp, MemorySegment data) {
+        final MemoryStack stack = MemoryStack.stackGet();
+        final long stackPointer = stack.getPointer();
+        try {
+            return nbmp(stack.allocateUtf8String(filename), w, h, comp, data);
+        } finally {
+            stack.setPointer(stackPointer);
+        }
     }
 
-    public static boolean tga(SegmentAllocator allocator, String filename, int w, int h, int comp, MemorySegment data) {
-        return ntga(allocator.allocateUtf8String(filename), w, h, comp, data);
+    public static boolean tga(String filename, int w, int h, int comp, MemorySegment data) {
+        final MemoryStack stack = MemoryStack.stackGet();
+        final long stackPointer = stack.getPointer();
+        try {
+            return ntga(stack.allocateUtf8String(filename), w, h, comp, data);
+        } finally {
+            stack.setPointer(stackPointer);
+        }
     }
 
     public static boolean hdr(SegmentAllocator allocator, String filename, int w, int h, int comp, float[] data) {
         return nhdr(allocator.allocateUtf8String(filename), w, h, comp, allocator.allocateArray(JAVA_FLOAT, data));
     }
 
-    public static boolean jpg(SegmentAllocator allocator, String filename, int x, int y, int comp, MemorySegment data, int quality) {
-        return njpg(allocator.allocateUtf8String(filename), x, y, comp, data, quality);
+    public static boolean jpg(String filename, int x, int y, int comp, MemorySegment data, int quality) {
+        final MemoryStack stack = MemoryStack.stackGet();
+        final long stackPointer = stack.getPointer();
+        try {
+            return njpg(stack.allocateUtf8String(filename), x, y, comp, data, quality);
+        } finally {
+            stack.setPointer(stackPointer);
+        }
     }
 
     public static boolean npngToFunc(MemorySegment func, MemorySegment context, int w, int h, int comp, MemorySegment data, int strideInBytes) {

--- a/modules/samples/src/test/java/overrungl/demo/glfw/GLFWJoystickTest.java
+++ b/modules/samples/src/test/java/overrungl/demo/glfw/GLFWJoystickTest.java
@@ -52,9 +52,7 @@ public final class GLFWJoystickTest {
         GLFW.windowHint(GLFW.VISIBLE, false);
         GLFW.windowHint(GLFW.RESIZABLE, true);
         GLFW.windowHint(GLFW.CLIENT_API, GLFW.NO_API);
-        try (var arena = Arena.ofConfined()) {
-            window = GLFW.createWindow(arena, 200, 100, "Holder", MemorySegment.NULL, MemorySegment.NULL);
-        }
+        window = GLFW.createWindow(200, 100, "Holder", MemorySegment.NULL, MemorySegment.NULL);
         RuntimeHelper.check(!RuntimeHelper.isNullptr(window), "Failed to create the GLFW window");
         GLFW.setKeyCallback(window, (handle, key, scancode, action, mods) -> {
             if (key == GLFW.KEY_ESCAPE && action == GLFW.RELEASE) {

--- a/modules/samples/src/test/java/overrungl/demo/glfw/GLFWTest.java
+++ b/modules/samples/src/test/java/overrungl/demo/glfw/GLFWTest.java
@@ -24,7 +24,6 @@ import overrungl.glfw.Callbacks;
 import overrungl.glfw.GLFW;
 import overrungl.glfw.GLFWErrorCallback;
 
-import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 
 /**
@@ -37,10 +36,8 @@ public final class GLFWTest {
     private MemorySegment window;
 
     public void run() {
-        try (var arena = Arena.ofShared()) {
-            init(arena);
-            load();
-        }
+        init();
+        load();
         loop();
 
         Callbacks.free(window);
@@ -50,13 +47,13 @@ public final class GLFWTest {
         GLFW.setErrorCallback(null);
     }
 
-    private void init(Arena arena) {
+    private void init() {
         GLFWErrorCallback.createPrint().set();
         RuntimeHelper.check(GLFW.init(), "Unable to initialize GLFW");
         GLFW.defaultWindowHints();
         GLFW.windowHint(GLFW.VISIBLE, false);
         GLFW.windowHint(GLFW.RESIZABLE, true);
-        window = GLFW.createWindow(arena, 300, 300, "Hello World!", MemorySegment.NULL, MemorySegment.NULL);
+        window = GLFW.createWindow(300, 300, "Hello World!", MemorySegment.NULL, MemorySegment.NULL);
         RuntimeHelper.check(!RuntimeHelper.isNullptr(window), "Failed to create the GLFW window");
         GLFW.setKeyCallback(window, (handle, key, scancode, action, mods) -> {
             if (key == GLFW.KEY_ESCAPE && action == GLFW.RELEASE) {

--- a/modules/samples/src/test/java/overrungl/demo/glfw/GLFWTest.java
+++ b/modules/samples/src/test/java/overrungl/demo/glfw/GLFWTest.java
@@ -79,7 +79,7 @@ public final class GLFWTest {
     }
 
     private void load() {
-        RuntimeHelper.check(GLLoader.loadConfined(GLFW::ngetProcAddress) != null,
+        RuntimeHelper.check(GLLoader.load(GLFW::getProcAddress) != null,
             "Failed to load OpenGL");
 
         GL.clearColor(0.4f, 0.6f, 0.9f, 1.0f);

--- a/modules/samples/src/test/java/overrungl/demo/glfw/GLFWWindowIconTest.java
+++ b/modules/samples/src/test/java/overrungl/demo/glfw/GLFWWindowIconTest.java
@@ -61,7 +61,7 @@ public final class GLFWWindowIconTest {
         GLFW.defaultWindowHints();
         GLFW.windowHint(GLFW.VISIBLE, false);
         GLFW.windowHint(GLFW.RESIZABLE, true);
-        window = GLFW.createWindow(arena, 300, 300, "Hello World!", MemorySegment.NULL, MemorySegment.NULL);
+        window = GLFW.createWindow(300, 300, "Hello World!", MemorySegment.NULL, MemorySegment.NULL);
         RuntimeHelper.check(!RuntimeHelper.isNullptr(window), "Failed to create the GLFW window");
 
         try {

--- a/modules/samples/src/test/java/overrungl/demo/glfw/GLFWWindowIconTest.java
+++ b/modules/samples/src/test/java/overrungl/demo/glfw/GLFWWindowIconTest.java
@@ -105,7 +105,7 @@ public final class GLFWWindowIconTest {
     }
 
     private void load() {
-        RuntimeHelper.check(GLLoader.loadConfined(true, GLFW::ngetProcAddress) != null,
+        RuntimeHelper.check(GLLoader.load(GLFW::getProcAddress, true) != null,
             "Failed to load OpenGL");
 
         GL.clearColor(0.4f, 0.6f, 0.9f, 1.0f);

--- a/modules/samples/src/test/java/overrungl/demo/nfd/NFDTest.java
+++ b/modules/samples/src/test/java/overrungl/demo/nfd/NFDTest.java
@@ -47,7 +47,7 @@ public final class NFDTest {
                 new Pair<>("Image file", "png,jpg"));
 
             // show the dialog
-            final NFDResult result = NFD.openDialogN(stack, outPath, filterItem, null);
+            final NFDResult result = NFD.openDialogN(outPath, filterItem, null);
 
             switch (result) {
                 case ERROR -> System.err.println("Error: " + NFD.getError());
@@ -77,7 +77,7 @@ public final class NFDTest {
                 new Pair<>("Image file", "png,jpg"));
 
             // show the dialog
-            final NFDResult result = NFD.openDialogMultipleN(stack, pOutPaths, filterItem, null);
+            final NFDResult result = NFD.openDialogMultipleN(pOutPaths, filterItem, null);
             MemorySegment outPaths = pOutPaths.get(ValueLayout.ADDRESS, 0);
 
             switch (result) {
@@ -117,7 +117,7 @@ public final class NFDTest {
                 new Pair<>("Image file", "png,jpg"));
 
             // show the dialog
-            final NFDResult result = NFD.openDialogMultipleN(stack, pOutPaths, filterItem, null);
+            final NFDResult result = NFD.openDialogMultipleN(pOutPaths, filterItem, null);
             MemorySegment outPaths = pOutPaths.get(ValueLayout.ADDRESS, 0);
 
             switch (result) {
@@ -155,7 +155,7 @@ public final class NFDTest {
             String[] outPath = new String[1];
 
             // show the dialog
-            final NFDResult result = NFD.pickFolderN(stack, outPath, null);
+            final NFDResult result = NFD.pickFolderN(outPath, null);
             switch (result) {
                 case ERROR -> System.err.println("Error: " + NFD.getError());
                 case OKAY -> System.out.println("Success! " + outPath[0]);
@@ -183,7 +183,7 @@ public final class NFDTest {
                 new Pair<>("Image file", "png,jpg"));
 
             // show the dialog
-            final NFDResult result = NFD.saveDialogN(stack, savePath, filterItem, null, "Untitled.java");
+            final NFDResult result = NFD.saveDialogN(savePath, filterItem, null, "Untitled.java");
             switch (result) {
                 case ERROR -> System.err.println("Error: " + NFD.getError());
                 case OKAY -> System.out.println("Success! " + savePath[0]);

--- a/modules/samples/src/test/java/overrungl/demo/opengl/GL15Test.java
+++ b/modules/samples/src/test/java/overrungl/demo/opengl/GL15Test.java
@@ -91,7 +91,7 @@ public final class GL15Test {
     }
 
     private void load(Arena arena) {
-        RuntimeHelper.check(GLLoader.loadConfined(GLFW::ngetProcAddress) != null,
+        RuntimeHelper.check(GLLoader.load(GLFW::getProcAddress) != null,
             "Failed to load OpenGL");
 
         GL.clearColor(0.4f, 0.6f, 0.9f, 1.0f);

--- a/modules/samples/src/test/java/overrungl/demo/opengl/GL15Test.java
+++ b/modules/samples/src/test/java/overrungl/demo/opengl/GL15Test.java
@@ -44,7 +44,7 @@ public final class GL15Test {
 
     public void run() {
         try (var arena = Arena.ofShared()) {
-            init(arena);
+            init();
             load(arena);
         }
         loop();
@@ -59,13 +59,13 @@ public final class GL15Test {
         GLFW.setErrorCallback(null);
     }
 
-    private void init(Arena arena) {
+    private void init() {
         GLFWErrorCallback.createPrint().set();
         RuntimeHelper.check(GLFW.init(), "Unable to initialize GLFW");
         GLFW.defaultWindowHints();
         GLFW.windowHint(GLFW.VISIBLE, false);
         GLFW.windowHint(GLFW.RESIZABLE, true);
-        window = GLFW.createWindow(arena, 640, 480, "OpenGL 1.5", MemorySegment.NULL, MemorySegment.NULL);
+        window = GLFW.createWindow(640, 480, "OpenGL 1.5", MemorySegment.NULL, MemorySegment.NULL);
         RuntimeHelper.check(!RuntimeHelper.isNullptr(window), "Failed to create the GLFW window");
         GLFW.setKeyCallback(window, (handle, key, scancode, action, mods) -> {
             if (key == GLFW.KEY_ESCAPE && action == GLFW.RELEASE) {

--- a/modules/samples/src/test/java/overrungl/demo/opengl/GL30Test.java
+++ b/modules/samples/src/test/java/overrungl/demo/opengl/GL30Test.java
@@ -47,7 +47,7 @@ public final class GL30Test {
 
     public void run() {
         try (var arena = Arena.ofShared()) {
-            init(arena);
+            init();
             load(arena);
         }
         loop();
@@ -65,13 +65,13 @@ public final class GL30Test {
         GLFW.setErrorCallback(null);
     }
 
-    private void init(Arena arena) {
+    private void init() {
         GLFWErrorCallback.createPrint().set();
         RuntimeHelper.check(GLFW.init(), "Unable to initialize GLFW");
         GLFW.defaultWindowHints();
         GLFW.windowHint(GLFW.VISIBLE, false);
         GLFW.windowHint(GLFW.RESIZABLE, true);
-        window = GLFW.createWindow(arena, 640, 480, "OpenGL 3.0", MemorySegment.NULL, MemorySegment.NULL);
+        window = GLFW.createWindow(640, 480, "OpenGL 3.0", MemorySegment.NULL, MemorySegment.NULL);
         RuntimeHelper.check(!RuntimeHelper.isNullptr(window), "Failed to create the GLFW window");
         GLFW.setKeyCallback(window, (handle, key, scancode, action, mods) -> {
             if (key == GLFW.KEY_ESCAPE && action == GLFW.RELEASE) {
@@ -131,7 +131,7 @@ public final class GL30Test {
         program = GL.createProgram();
         int vsh = GL.createShader(GL.VERTEX_SHADER);
         int fsh = GL.createShader(GL.FRAGMENT_SHADER);
-        GL.shaderSource(arena, vsh, """
+        GL.shaderSource(vsh, """
             #version 130
 
             in vec3 position;
@@ -144,7 +144,7 @@ public final class GL30Test {
                 texCoord = uv;
             }
             """);
-        GL.shaderSource(arena, fsh, """
+        GL.shaderSource(fsh, """
             #version 130
 
             in vec2 texCoord;
@@ -162,15 +162,15 @@ public final class GL30Test {
         GL.compileShader(fsh);
         GL.attachShader(program, vsh);
         GL.attachShader(program, fsh);
-        GL.bindAttribLocation(arena, program, 0, "position");
-        GL.bindAttribLocation(arena, program, 1, "uv");
+        GL.bindAttribLocation(program, 0, "position");
+        GL.bindAttribLocation(program, 1, "uv");
         GL.linkProgram(program);
         GL.detachShader(program, vsh);
         GL.detachShader(program, fsh);
         GL.deleteShader(vsh);
         GL.deleteShader(fsh);
         GL.useProgram(program);
-        GL.uniform1i(GL.getUniformLocation(arena, program, "sampler"), 0);
+        GL.uniform1i(GL.getUniformLocation(program, "sampler"), 0);
         GL.useProgram(0);
 
         vao = GL.genVertexArray();
@@ -196,7 +196,7 @@ public final class GL30Test {
         GL.bindBuffer(GL.ARRAY_BUFFER, 0);
         GL.bindVertexArray(0);
 
-        colorFactor = GL.getUniformLocation(arena, program, "colorFactor");
+        colorFactor = GL.getUniformLocation(program, "colorFactor");
     }
 
     private void loop() {

--- a/modules/samples/src/test/java/overrungl/demo/opengl/GL30Test.java
+++ b/modules/samples/src/test/java/overrungl/demo/opengl/GL30Test.java
@@ -97,7 +97,7 @@ public final class GL30Test {
     }
 
     private void load(Arena arena) {
-        RuntimeHelper.check(GLLoader.loadConfined(true, GLFW::ngetProcAddress) != null,
+        RuntimeHelper.check(GLLoader.load(GLFW::getProcAddress, true) != null,
             "Failed to load OpenGL");
 
         GL.clearColor(0.4f, 0.6f, 0.9f, 1.0f);

--- a/modules/samples/src/test/java/overrungl/demo/opengl/GL33Test.java
+++ b/modules/samples/src/test/java/overrungl/demo/opengl/GL33Test.java
@@ -107,7 +107,7 @@ public class GL33Test {
     }
 
     private void load(Arena arena) {
-        RuntimeHelper.check(GLLoader.loadConfined(true, GLFW::ngetProcAddress) != null,
+        RuntimeHelper.check(GLLoader.load(GLFW::getProcAddress, true) != null,
             "Failed to load OpenGL");
 
         debugProc = GLUtil.setupDebugMessageCallback();

--- a/modules/samples/src/test/java/overrungl/demo/opengl/GL33Test.java
+++ b/modules/samples/src/test/java/overrungl/demo/opengl/GL33Test.java
@@ -52,7 +52,7 @@ public class GL33Test {
 
     public void run() {
         try (var arena = Arena.ofShared()) {
-            init(arena);
+            init();
             load(arena);
         }
         loop();
@@ -72,7 +72,7 @@ public class GL33Test {
         GLFW.setErrorCallback(null);
     }
 
-    private void init(Arena arena) {
+    private void init() {
         GLFWErrorCallback.createPrint().set();
         RuntimeHelper.check(GLFW.init(), "Unable to initialize GLFW");
         GLFW.defaultWindowHints();
@@ -81,7 +81,7 @@ public class GL33Test {
         GLFW.windowHint(GLFW.CONTEXT_VERSION_MAJOR, 3);
         GLFW.windowHint(GLFW.CONTEXT_VERSION_MINOR, 3);
         GLFW.windowHint(GLFW.OPENGL_PROFILE, GLFW.OPENGL_CORE_PROFILE);
-        window = GLFW.createWindow(arena, 640, 480, WND_TITLE, MemorySegment.NULL, MemorySegment.NULL);
+        window = GLFW.createWindow(640, 480, WND_TITLE, MemorySegment.NULL, MemorySegment.NULL);
         RuntimeHelper.check(!RuntimeHelper.isNullptr(window), "Failed to create the GLFW window");
         GLFW.setKeyCallback(window, (handle, key, scancode, action, mods) -> {
             if (key == GLFW.KEY_ESCAPE && action == GLFW.RELEASE) {
@@ -115,7 +115,7 @@ public class GL33Test {
         program = GL.createProgram();
         int vsh = GL.createShader(GL.VERTEX_SHADER);
         int fsh = GL.createShader(GL.FRAGMENT_SHADER);
-        GL.shaderSource(arena, vsh, """
+        GL.shaderSource(vsh, """
             #version 330
 
             layout (location = 0) in vec3 position;
@@ -131,7 +131,7 @@ public class GL33Test {
                 vertexColor = color;
             }
             """);
-        GL.shaderSource(arena, fsh, """
+        GL.shaderSource(fsh, """
             #version 330
 
             in vec3 vertexColor;
@@ -151,7 +151,7 @@ public class GL33Test {
         GL.detachShader(program, fsh);
         GL.deleteShader(vsh);
         GL.deleteShader(fsh);
-        rotationMat = GL.getUniformLocation(arena, program, "rotationMat");
+        rotationMat = GL.getUniformLocation(program, "rotationMat");
 
         vao = GL.genVertexArray();
         GL.bindVertexArray(vao);
@@ -247,9 +247,7 @@ public class GL33Test {
 
             // using lambda gets higher FPS ??
             timer.calcFPS(fps -> {
-                try (MemoryStack stack = MemoryStack.stackPush()) {
-                    GLFW.setWindowTitle(stack, window, STR."\{WND_TITLE} FPS: \{fps}");
-                }
+                GLFW.setWindowTitle(window, STR."\{WND_TITLE} FPS: \{fps}");
             });
         }
     }

--- a/modules/samples/src/test/java/overrungl/demo/stb/STBPerlinTest.java
+++ b/modules/samples/src/test/java/overrungl/demo/stb/STBPerlinTest.java
@@ -44,7 +44,7 @@ public final class STBPerlinTest {
             }
         }
         try (MemoryStack stack = MemoryStack.stackPush()) {
-            STBImageWrite.png(stack, fileName, WIDTH, HEIGHT, STBImage.GREY, buf, WIDTH);
+            STBImageWrite.png(fileName, WIDTH, HEIGHT, STBImage.GREY, buf, WIDTH);
         }
     }
 


### PR DESCRIPTION
This change is to provide more convenient ways to call certain methods. For example:  
Before:
```java
try (var stack = stackPush()) {
    window = GLFW.createWindow(stack, 800, 600, "Hello world", NULL, NULL);
}
```  
After:
```java
window = GLFW.createWindow(800, 600, "Hello world", NULL, NULL);
```