### PR TITLE
Remove allocator from Pointer

### DIFF
--- a/modules/overrungl.core/src/main/java/overrungl/Pointer.java
+++ b/modules/overrungl.core/src/main/java/overrungl/Pointer.java
@@ -18,7 +18,6 @@ package overrungl;
 
 import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
-import java.lang.foreign.SegmentAllocator;
 
 /**
  * A {@link MemorySegment} wrapper with a segment allocator.
@@ -32,10 +31,6 @@ public class Pointer implements Addressable {
      */
     protected final MemorySegment address;
     /**
-     * The allocator of this pointer.
-     */
-    protected final SegmentAllocator allocator;
-    /**
      * The managed native segment that is not zero-length.
      * <p>
      * This field is not modified with {@code final} since the layout might be null in construction.
@@ -45,24 +40,15 @@ public class Pointer implements Addressable {
     /**
      * Create the pointer instance.
      *
-     * @param address   the address.
-     * @param allocator the allocator of this address.
+     * @param address the address.
      */
-    public Pointer(MemorySegment address, SegmentAllocator allocator) {
+    public Pointer(MemorySegment address) {
         this.address = address;
-        this.allocator = allocator;
     }
 
     @Override
     public MemorySegment address() {
         return address;
-    }
-
-    /**
-     * {@return the allocator of this pointer}
-     */
-    public SegmentAllocator allocator() {
-        return allocator;
     }
 
     /**

--- a/modules/overrungl.core/src/main/java/overrungl/Struct.java
+++ b/modules/overrungl.core/src/main/java/overrungl/Struct.java
@@ -18,7 +18,6 @@ package overrungl;
 
 import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
-import java.lang.foreign.SegmentAllocator;
 
 /**
  * The C struct wrapper.
@@ -37,12 +36,11 @@ public class Struct extends Pointer {
     /**
      * Creates a struct instance with the given memory layout.
      *
-     * @param address   the address.
-     * @param allocator the allocator of this address.
-     * @param layout    the memory layout of this struct.
+     * @param address the address.
+     * @param layout  the memory layout of this struct.
      */
-    public Struct(MemorySegment address, SegmentAllocator allocator, MemoryLayout layout) {
-        super(address, allocator);
+    public Struct(MemorySegment address, MemoryLayout layout) {
+        super(address);
         this.layout = layout;
         segment(layout);
     }
@@ -50,11 +48,10 @@ public class Struct extends Pointer {
     /**
      * Creates a struct instance.
      *
-     * @param address   the address.
-     * @param allocator the allocator of this address.
+     * @param address the address.
      */
-    public Struct(MemorySegment address, SegmentAllocator allocator) {
-        super(address, allocator);
+    public Struct(MemorySegment address) {
+        super(address);
     }
 
     /**

--- a/modules/overrungl.core/src/main/java/overrungl/util/MemoryStack.java
+++ b/modules/overrungl.core/src/main/java/overrungl/util/MemoryStack.java
@@ -71,10 +71,9 @@ public sealed class MemoryStack extends Pointer implements SegmentAllocator, Aut
      * @param container the backing memory buffer, may be null
      * @param address   the backing memory address
      * @param size      the backing memory size
-     * @param arena     the backing arena
      */
-    protected MemoryStack(@Nullable MemorySegment container, MemorySegment address, long size, Arena arena) {
-        super(address, arena);
+    protected MemoryStack(@Nullable MemorySegment container, MemorySegment address, long size) {
+        super(address);
         this.container = container;
 
         this.size = size;
@@ -100,8 +99,19 @@ public sealed class MemoryStack extends Pointer implements SegmentAllocator, Aut
      * @param capacity the maximum number of bytes that may be allocated on the stack
      */
     public static MemoryStack create(long capacity) {
-        final Arena arena = Arena.ofAuto();
-        return create(arena.allocate(capacity), capacity, arena);
+        return create(capacity, Arena.ofAuto());
+    }
+
+    /**
+     * Creates a new {@code MemoryStack} with the specified size and arena.
+     *
+     * <p>In the initial state, there is no active stack frame. The {@link #push} method must be used before any allocations.</p>
+     *
+     * @param capacity the maximum number of bytes that may be allocated on the stack
+     * @param arena    the arena for allocating buffer
+     */
+    public static MemoryStack create(long capacity, Arena arena) {
+        return create(arena.allocate(capacity), capacity);
     }
 
     /**
@@ -111,12 +121,11 @@ public sealed class MemoryStack extends Pointer implements SegmentAllocator, Aut
      *
      * @param buffer the backing memory buffer
      * @param size   the memory buffer size
-     * @param arena  the backing arena
      */
-    public static MemoryStack create(MemorySegment buffer, long size, Arena arena) {
+    public static MemoryStack create(MemorySegment buffer, long size) {
         return DEBUG_STACK
-            ? new DebugMemoryStack(buffer, buffer, size, arena)
-            : new MemoryStack(buffer, buffer, size, arena);
+            ? new DebugMemoryStack(buffer, buffer, size)
+            : new MemoryStack(buffer, buffer, size);
     }
 
     /**
@@ -126,12 +135,11 @@ public sealed class MemoryStack extends Pointer implements SegmentAllocator, Aut
      *
      * @param address the backing memory address
      * @param size    the backing memory size
-     * @param arena   the backing arena
      */
-    public static MemoryStack ncreate(MemorySegment address, long size, Arena arena) {
+    public static MemoryStack ncreate(MemorySegment address, long size) {
         return DEBUG_STACK
-            ? new DebugMemoryStack(null, address, size, arena)
-            : new MemoryStack(null, address, size, arena);
+            ? new DebugMemoryStack(null, address, size)
+            : new MemoryStack(null, address, size);
     }
 
     /**
@@ -194,8 +202,8 @@ public sealed class MemoryStack extends Pointer implements SegmentAllocator, Aut
     private static final class DebugMemoryStack extends MemoryStack {
         private Object[] debugFrames;
 
-        DebugMemoryStack(@Nullable MemorySegment buffer, MemorySegment address, long size, Arena arena) {
-            super(buffer, address, size, arena);
+        DebugMemoryStack(@Nullable MemorySegment buffer, MemorySegment address, long size) {
+            super(buffer, address, size);
             debugFrames = new Object[DEFAULT_STACK_FRAMES];
         }
 

--- a/modules/overrungl.glfw/src/main/java/overrungl/glfw/GLFW.java
+++ b/modules/overrungl.glfw/src/main/java/overrungl/glfw/GLFW.java
@@ -26,7 +26,6 @@ import overrungl.util.value.Tuple2;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
-import java.lang.foreign.SegmentAllocator;
 
 import static java.lang.foreign.ValueLayout.*;
 import static overrungl.glfw.Handles.*;
@@ -1744,13 +1743,12 @@ public final class GLFW {
     /**
      * Returns the available video modes for the specified monitor.
      *
-     * @param allocator The allocator that allocates the result.
      * @param monitor   The monitor to query.
      * @return An array of video modes, or {@code null} if an
      * <a href="https://www.glfw.org/docs/latest/intro_guide.html#error_handling">error</a> occurred.
      * @see #ngetVideoModes(MemorySegment, MemorySegment) ngetVideoModes
      */
-    public static @Nullable GLFWVidMode.Buffer getVideoModes(SegmentAllocator allocator, MemorySegment monitor) {
+    public static @Nullable GLFWVidMode.Buffer getVideoModes(MemorySegment monitor) {
         var stack = MemoryStack.stackGet();
         long stackPointer = stack.getPointer();
         try {
@@ -1758,7 +1756,7 @@ public final class GLFW {
             var pModes = ngetVideoModes(monitor, pCount);
             return RuntimeHelper.isNullptr(pModes) ?
                 null :
-                new GLFWVidMode.Buffer(pModes, allocator, pCount.get(JAVA_INT, 0));
+                new GLFWVidMode.Buffer(pModes, pCount.get(JAVA_INT, 0));
         } finally {
             stack.setPointer(stackPointer);
         }
@@ -1802,13 +1800,7 @@ public final class GLFW {
     public static GLFWVidMode.Value getVideoMode(MemorySegment monitor) {
         var pMode = ngetVideoMode(monitor);
         if (RuntimeHelper.isNullptr(pMode)) return null;
-        final MemoryStack stack = MemoryStack.stackGet();
-        final long stackPointer = stack.getPointer();
-        try {
-            return new GLFWVidMode(pMode, stack).value();
-        } finally {
-            stack.setPointer(stackPointer);
-        }
+        return new GLFWVidMode(pMode).value();
     }
 
     /**
@@ -1881,9 +1873,7 @@ public final class GLFW {
     public static GLFWGammaRamp getGammaRamp(MemorySegment monitor) {
         var pRamp = ngetGammaRamp(monitor);
         if (RuntimeHelper.isNullptr(pRamp)) return null;
-        try (MemoryStack stack = MemoryStack.stackPush()) {
-            return new GLFWGammaRamp(pRamp, stack);
-        }
+        return new GLFWGammaRamp(pRamp);
     }
 
     /**

--- a/modules/overrungl.glfw/src/main/java/overrungl/glfw/GLFWGamepadState.java
+++ b/modules/overrungl.glfw/src/main/java/overrungl/glfw/GLFWGamepadState.java
@@ -57,11 +57,10 @@ public class GLFWGamepadState extends Struct {
     /**
      * Create a {@code GLFWgamepadstate} instance.
      *
-     * @param address   the address.
-     * @param allocator the allocator of this address.
+     * @param address the address.
      */
-    public GLFWGamepadState(MemorySegment address, SegmentAllocator allocator) {
-        super(address, allocator, LAYOUT);
+    public GLFWGamepadState(MemorySegment address) {
+        super(address, LAYOUT);
     }
 
     /**
@@ -71,7 +70,7 @@ public class GLFWGamepadState extends Struct {
      * @return the instance
      */
     public static GLFWGamepadState create(SegmentAllocator allocator) {
-        return new GLFWGamepadState(allocator.allocate(LAYOUT), allocator);
+        return new GLFWGamepadState(allocator.allocate(LAYOUT));
     }
 
     /**

--- a/modules/overrungl.glfw/src/main/java/overrungl/glfw/GLFWGammaRamp.java
+++ b/modules/overrungl.glfw/src/main/java/overrungl/glfw/GLFWGammaRamp.java
@@ -42,13 +42,14 @@ import static java.lang.foreign.ValueLayout.*;
  * @since 0.1.0
  */
 public class GLFWGammaRamp extends Struct {
+    private static final AddressLayout SHORT_ARRAY = ADDRESS.withTargetLayout(MemoryLayout.sequenceLayout(JAVA_SHORT));
     /**
      * The struct layout.
      */
     public static final StructLayout LAYOUT = MemoryLayout.structLayout(
-        ADDRESS.withTargetLayout(MemoryLayout.sequenceLayout(JAVA_SHORT)).withName("red"),
-        ADDRESS.withTargetLayout(MemoryLayout.sequenceLayout(JAVA_SHORT)).withName("green"),
-        ADDRESS.withTargetLayout(MemoryLayout.sequenceLayout(JAVA_SHORT)).withName("blue"),
+        SHORT_ARRAY.withName("red"),
+        SHORT_ARRAY.withName("green"),
+        SHORT_ARRAY.withName("blue"),
         JAVA_INT.withName("size")
     );
     private static final VarHandle
@@ -63,11 +64,10 @@ public class GLFWGammaRamp extends Struct {
     /**
      * Create a {@code GLFWgammaramp const} instance.
      *
-     * @param address   the address.
-     * @param allocator the allocator of this address.
+     * @param address the address.
      */
-    public GLFWGammaRamp(MemorySegment address, SegmentAllocator allocator) {
-        super(address, allocator, LAYOUT);
+    public GLFWGammaRamp(MemorySegment address) {
+        super(address, LAYOUT);
     }
 
     /**
@@ -77,44 +77,47 @@ public class GLFWGammaRamp extends Struct {
      * @return the instance
      */
     public static GLFWGammaRamp create(SegmentAllocator allocator) {
-        return new GLFWGammaRamp(allocator.allocate(LAYOUT), allocator);
+        return new GLFWGammaRamp(allocator.allocate(LAYOUT));
     }
 
     /**
      * Sets the red value array.
      *
-     * @param reds the array
+     * @param allocator the allocator of the array.
+     * @param reds      the array
      * @return this
      */
-    public GLFWGammaRamp red(short[] reds) {
-        ppRed.set(segment(), allocator().allocateArray(JAVA_SHORT, reds));
+    public GLFWGammaRamp red(SegmentAllocator allocator, short[] reds) {
+        ppRed.set(segment(), allocator.allocateArray(JAVA_SHORT, reds));
         return this;
     }
 
     /**
      * Sets the green value array.
      *
-     * @param greens the array
+     * @param allocator the allocator of the array.
+     * @param greens    the array
      * @return this
      */
-    public GLFWGammaRamp green(short[] greens) {
-        ppGreen.set(segment(), allocator().allocateArray(JAVA_SHORT, greens));
+    public GLFWGammaRamp green(SegmentAllocator allocator, short[] greens) {
+        ppGreen.set(segment(), allocator.allocateArray(JAVA_SHORT, greens));
         return this;
     }
 
     /**
      * Sets the blue value array.
      *
-     * @param blues the array
+     * @param allocator the allocator of the array.
+     * @param blues     the array
      * @return this
      */
-    public GLFWGammaRamp blue(short[] blues) {
-        ppBlue.set(segment(), allocator().allocateArray(JAVA_SHORT, blues));
+    public GLFWGammaRamp blue(SegmentAllocator allocator, short[] blues) {
+        ppBlue.set(segment(), allocator.allocateArray(JAVA_SHORT, blues));
         return this;
     }
 
     /**
-     * Sets the arrays size.
+     * Sets the size of arrays.
      *
      * @param size The number of elements in each array.
      * @return this

--- a/modules/overrungl.glfw/src/main/java/overrungl/glfw/GLFWImage.java
+++ b/modules/overrungl.glfw/src/main/java/overrungl/glfw/GLFWImage.java
@@ -57,22 +57,20 @@ public class GLFWImage extends Struct {
     /**
      * Create a {@code GLFWimage} instance.
      *
-     * @param address   the address.
-     * @param allocator the allocator of this address.
+     * @param address the address.
      */
-    public GLFWImage(MemorySegment address, SegmentAllocator allocator) {
-        super(address, allocator, LAYOUT);
+    public GLFWImage(MemorySegment address) {
+        super(address, LAYOUT);
     }
 
     /**
      * Creates a struct instance with the given memory layout.
      *
-     * @param address   the address.
-     * @param allocator the allocator of this address.
-     * @param layout    the memory layout of this struct.
+     * @param address the address.
+     * @param layout  the memory layout of this struct.
      */
-    protected GLFWImage(MemorySegment address, SegmentAllocator allocator, MemoryLayout layout) {
-        super(address, allocator, layout);
+    protected GLFWImage(MemorySegment address, MemoryLayout layout) {
+        super(address, layout);
     }
 
     /**
@@ -82,7 +80,7 @@ public class GLFWImage extends Struct {
      * @return the instance
      */
     public static GLFWImage create(SegmentAllocator allocator) {
-        return new GLFWImage(allocator.allocate(LAYOUT), allocator);
+        return new GLFWImage(allocator.allocate(LAYOUT));
     }
 
     /**
@@ -93,7 +91,7 @@ public class GLFWImage extends Struct {
      * @return the instance
      */
     public static Buffer create(SegmentAllocator allocator, long count) {
-        return new Buffer(allocator.allocateArray(LAYOUT, count), allocator, count);
+        return new Buffer(allocator.allocateArray(LAYOUT, count), count);
     }
 
     /**
@@ -169,11 +167,10 @@ public class GLFWImage extends Struct {
          * Create a {@code GLFWImage.Buffer} instance.
          *
          * @param address      the address.
-         * @param allocator    the allocator of this address.
          * @param elementCount the element count
          */
-        public Buffer(MemorySegment address, SegmentAllocator allocator, long elementCount) {
-            super(address, allocator, MemoryLayout.sequenceLayout(elementCount, LAYOUT));
+        public Buffer(MemorySegment address, long elementCount) {
+            super(address, MemoryLayout.sequenceLayout(elementCount, LAYOUT));
             pWidth = layout().varHandle(PathElement.sequenceElement(), PathElement.groupElement("width"));
             pHeight = layout().varHandle(PathElement.sequenceElement(), PathElement.groupElement("height"));
             pPixels = layout().varHandle(PathElement.sequenceElement(), PathElement.groupElement("pixels"));

--- a/modules/overrungl.glfw/src/main/java/overrungl/glfw/GLFWVidMode.java
+++ b/modules/overrungl.glfw/src/main/java/overrungl/glfw/GLFWVidMode.java
@@ -66,21 +66,19 @@ public class GLFWVidMode extends Struct {
      * Create a {@code GLFWvidmode} instance.
      *
      * @param address   the address.
-     * @param allocator the allocator of this address.
      */
-    public GLFWVidMode(MemorySegment address, SegmentAllocator allocator) {
-        super(address, allocator, LAYOUT);
+    public GLFWVidMode(MemorySegment address) {
+        super(address, LAYOUT);
     }
 
     /**
      * Creates a struct instance with the given memory layout.
      *
-     * @param address   the address.
-     * @param allocator the allocator of this address.
-     * @param layout    the memory layout of this struct.
+     * @param address the address.
+     * @param layout  the memory layout of this struct.
      */
-    protected GLFWVidMode(MemorySegment address, SegmentAllocator allocator, MemoryLayout layout) {
-        super(address, allocator, layout);
+    protected GLFWVidMode(MemorySegment address, MemoryLayout layout) {
+        super(address, layout);
     }
 
     /**
@@ -90,7 +88,7 @@ public class GLFWVidMode extends Struct {
      * @return the instance
      */
     public static GLFWVidMode create(SegmentAllocator allocator) {
-        return new GLFWVidMode(allocator.allocate(LAYOUT), allocator);
+        return new GLFWVidMode(allocator.allocate(LAYOUT));
     }
 
     /**
@@ -101,7 +99,7 @@ public class GLFWVidMode extends Struct {
      * @return the instance
      */
     public static Buffer create(SegmentAllocator allocator, long count) {
-        return new Buffer(allocator.allocateArray(LAYOUT, count), allocator, count);
+        return new Buffer(allocator.allocateArray(LAYOUT, count), count);
     }
 
     /**
@@ -188,11 +186,10 @@ public class GLFWVidMode extends Struct {
          * Create a {@code GLFWvidmode.Buffer} instance.
          *
          * @param address      the address.
-         * @param allocator    the allocator of this address.
          * @param elementCount the element count
          */
-        public Buffer(MemorySegment address, SegmentAllocator allocator, long elementCount) {
-            super(address, allocator, MemoryLayout.sequenceLayout(elementCount, LAYOUT));
+        public Buffer(MemorySegment address, long elementCount) {
+            super(address, MemoryLayout.sequenceLayout(elementCount, LAYOUT));
             pWidth = layout().varHandle(PathElement.sequenceElement(), PathElement.groupElement("width"));
             pHeight = layout().varHandle(PathElement.sequenceElement(), PathElement.groupElement("height"));
             pRedBits = layout().varHandle(PathElement.sequenceElement(), PathElement.groupElement("redBits"));

--- a/modules/overrungl.nfd/src/main/java/overrungl/nfd/NFDEnumerator.java
+++ b/modules/overrungl.nfd/src/main/java/overrungl/nfd/NFDEnumerator.java
@@ -54,8 +54,8 @@ public final class NFDEnumerator extends Struct implements Iterable<String>, Aut
     };
     private final Kind kind;
 
-    private NFDEnumerator(Kind kind, MemorySegment address, SegmentAllocator allocator) {
-        super(address, allocator, LAYOUT);
+    private NFDEnumerator(Kind kind, MemorySegment address) {
+        super(address, LAYOUT);
         this.kind = kind;
     }
 
@@ -114,7 +114,7 @@ public final class NFDEnumerator extends Struct implements Iterable<String>, Aut
         final NFDResult result = NFD.pathSetGetEnum(pathSet, seg);
         return new Tuple2<>(result,
             result == NFDResult.OKAY ?
-                new NFDEnumerator(kind, seg, allocator) :
+                new NFDEnumerator(kind, seg) :
                 null);
     }
 

--- a/modules/overrungl.nfd/src/main/java/overrungl/nfd/NFDNFilterItem.java
+++ b/modules/overrungl.nfd/src/main/java/overrungl/nfd/NFDNFilterItem.java
@@ -50,22 +50,20 @@ public class NFDNFilterItem extends Struct {
     /**
      * Create a {@code NFDNFilterItem} instance.
      *
-     * @param address   the address.
-     * @param allocator the allocator of this address.
+     * @param address the address.
      */
-    public NFDNFilterItem(MemorySegment address, SegmentAllocator allocator) {
-        super(address, allocator, LAYOUT);
+    public NFDNFilterItem(MemorySegment address) {
+        super(address, LAYOUT);
     }
 
     /**
      * Creates a struct instance with the given memory layout.
      *
-     * @param address   the address.
-     * @param allocator the allocator of this address.
-     * @param layout    the memory layout of this struct.
+     * @param address the address.
+     * @param layout  the memory layout of this struct.
      */
-    protected NFDNFilterItem(MemorySegment address, SegmentAllocator allocator, MemoryLayout layout) {
-        super(address, allocator, layout);
+    protected NFDNFilterItem(MemorySegment address, MemoryLayout layout) {
+        super(address, layout);
     }
 
     /**
@@ -77,7 +75,7 @@ public class NFDNFilterItem extends Struct {
      * @return the instance
      */
     public static NFDNFilterItem create(SegmentAllocator allocator, String name, String spec) {
-        final NFDNFilterItem item = new NFDNFilterItem(allocator.allocate(LAYOUT), allocator);
+        final NFDNFilterItem item = new NFDNFilterItem(allocator.allocate(LAYOUT));
         pName.set(item.segment(), NFD.allocateString(name));
         pSpec.set(item.segment(), NFD.allocateString(spec));
         return item;
@@ -92,7 +90,7 @@ public class NFDNFilterItem extends Struct {
      */
     @SafeVarargs
     public static Buffer create(SegmentAllocator allocator, Pair<String>... items) {
-        final Buffer buffer = new Buffer(allocator.allocateArray(LAYOUT, items.length), allocator, items.length);
+        final Buffer buffer = new Buffer(allocator.allocateArray(LAYOUT, items.length), items.length);
         for (int i = 0, len = items.length; i < len; i++) {
             Pair<String> item = items[i];
             buffer.pName.set(buffer.segment(), (long) i, NFD.allocateString(item.key()));
@@ -144,11 +142,10 @@ public class NFDNFilterItem extends Struct {
          * Create a {@code NFDNFilterItem.Buffer} instance.
          *
          * @param address      the address.
-         * @param allocator    the allocator of this address.
          * @param elementCount the element count
          */
-        public Buffer(MemorySegment address, SegmentAllocator allocator, long elementCount) {
-            super(address, allocator, MemoryLayout.sequenceLayout(elementCount, LAYOUT));
+        public Buffer(MemorySegment address, long elementCount) {
+            super(address, MemoryLayout.sequenceLayout(elementCount, LAYOUT));
             pName = layout().varHandle(PathElement.sequenceElement(), PathElement.groupElement("name"));
             pSpec = layout().varHandle(PathElement.sequenceElement(), PathElement.groupElement("spec"));
         }

--- a/modules/overrungl.nfd/src/main/java/overrungl/nfd/NFDU8FilterItem.java
+++ b/modules/overrungl.nfd/src/main/java/overrungl/nfd/NFDU8FilterItem.java
@@ -50,22 +50,20 @@ public class NFDU8FilterItem extends Struct {
     /**
      * Create a {@code NFDU8FilterItem} instance.
      *
-     * @param address   the address.
-     * @param allocator the allocator of this address.
+     * @param address the address.
      */
-    public NFDU8FilterItem(MemorySegment address, SegmentAllocator allocator) {
-        super(address, allocator, LAYOUT);
+    public NFDU8FilterItem(MemorySegment address) {
+        super(address, LAYOUT);
     }
 
     /**
      * Creates a struct instance with the given memory layout.
      *
-     * @param address   the address.
-     * @param allocator the allocator of this address.
-     * @param layout    the memory layout of this struct.
+     * @param address the address.
+     * @param layout  the memory layout of this struct.
      */
-    protected NFDU8FilterItem(MemorySegment address, SegmentAllocator allocator, MemoryLayout layout) {
-        super(address, allocator, layout);
+    protected NFDU8FilterItem(MemorySegment address, MemoryLayout layout) {
+        super(address, layout);
     }
 
     /**
@@ -77,7 +75,7 @@ public class NFDU8FilterItem extends Struct {
      * @return the instance
      */
     public static NFDU8FilterItem create(SegmentAllocator allocator, String name, String spec) {
-        final NFDU8FilterItem item = new NFDU8FilterItem(allocator.allocate(LAYOUT), allocator);
+        final NFDU8FilterItem item = new NFDU8FilterItem(allocator.allocate(LAYOUT));
         pName.set(item.segment(), allocator.allocateUtf8String(name));
         pSpec.set(item.segment(), allocator.allocateUtf8String(spec));
         return item;
@@ -92,7 +90,7 @@ public class NFDU8FilterItem extends Struct {
      */
     @SafeVarargs
     public static Buffer create(SegmentAllocator allocator, Pair<String>... items) {
-        final Buffer buffer = new Buffer(allocator.allocateArray(LAYOUT, items.length), allocator, items.length);
+        final Buffer buffer = new Buffer(allocator.allocateArray(LAYOUT, items.length), items.length);
         for (int i = 0, len = items.length; i < len; i++) {
             Pair<String> item = items[i];
             buffer.pName.set(buffer.segment(), (long) i, allocator.allocateUtf8String(item.key()));
@@ -144,11 +142,10 @@ public class NFDU8FilterItem extends Struct {
          * Create a {@code NFDU8FilterItem.Buffer} instance.
          *
          * @param address      the address.
-         * @param allocator    the allocator of this address.
          * @param elementCount the element count
          */
-        public Buffer(MemorySegment address, SegmentAllocator allocator, long elementCount) {
-            super(address, allocator, MemoryLayout.sequenceLayout(elementCount, LAYOUT));
+        public Buffer(MemorySegment address, long elementCount) {
+            super(address, MemoryLayout.sequenceLayout(elementCount, LAYOUT));
             pName = layout().varHandle(PathElement.sequenceElement(), PathElement.groupElement("name"));
             pSpec = layout().varHandle(PathElement.sequenceElement(), PathElement.groupElement("spec"));
         }

--- a/modules/overrungl.opengl/src/main/java/overrungl/opengl/DrawArraysIndirectCommand.java
+++ b/modules/overrungl.opengl/src/main/java/overrungl/opengl/DrawArraysIndirectCommand.java
@@ -57,22 +57,20 @@ public class DrawArraysIndirectCommand extends Struct {
     /**
      * Create the pointer instance.
      *
-     * @param address   the address.
-     * @param allocator the allocator of this address.
+     * @param address the address.
      */
-    public DrawArraysIndirectCommand(MemorySegment address, SegmentAllocator allocator) {
-        super(address, allocator, LAYOUT);
+    public DrawArraysIndirectCommand(MemorySegment address) {
+        super(address, LAYOUT);
     }
 
     /**
      * Creates a struct instance with the given memory layout.
      *
-     * @param address   the address.
-     * @param allocator the allocator of this address.
-     * @param layout    the memory layout of this struct.
+     * @param address the address.
+     * @param layout  the memory layout of this struct.
      */
-    protected DrawArraysIndirectCommand(MemorySegment address, SegmentAllocator allocator, MemoryLayout layout) {
-        super(address, allocator, layout);
+    protected DrawArraysIndirectCommand(MemorySegment address, MemoryLayout layout) {
+        super(address, layout);
     }
 
     /**
@@ -82,7 +80,7 @@ public class DrawArraysIndirectCommand extends Struct {
      * @return the instance
      */
     public static DrawArraysIndirectCommand create(SegmentAllocator allocator) {
-        return new DrawArraysIndirectCommand(allocator.allocate(LAYOUT), allocator);
+        return new DrawArraysIndirectCommand(allocator.allocate(LAYOUT));
     }
 
     /**
@@ -93,7 +91,7 @@ public class DrawArraysIndirectCommand extends Struct {
      * @return the instance
      */
     public static Buffer create(SegmentAllocator allocator, long count) {
-        return new Buffer(allocator.allocateArray(LAYOUT, count), allocator, count);
+        return new Buffer(allocator.allocateArray(LAYOUT, count), count);
     }
 
     /**
@@ -181,11 +179,10 @@ public class DrawArraysIndirectCommand extends Struct {
          * Create the pointer instance.
          *
          * @param address      the address.
-         * @param allocator    the allocator of this address.
          * @param elementCount the element count
          */
-        public Buffer(MemorySegment address, SegmentAllocator allocator, long elementCount) {
-            super(address, allocator, MemoryLayout.sequenceLayout(elementCount, LAYOUT));
+        public Buffer(MemorySegment address, long elementCount) {
+            super(address, MemoryLayout.sequenceLayout(elementCount, LAYOUT));
             pCount = layout().varHandle(PathElement.sequenceElement(), PathElement.groupElement("count"));
             pPrimCount = layout().varHandle(PathElement.sequenceElement(), PathElement.groupElement("primCount"));
             pFirst = layout().varHandle(PathElement.sequenceElement(), PathElement.groupElement("first"));

--- a/modules/overrungl.opengl/src/main/java/overrungl/opengl/DrawElementsIndirectCommand.java
+++ b/modules/overrungl.opengl/src/main/java/overrungl/opengl/DrawElementsIndirectCommand.java
@@ -60,22 +60,20 @@ public class DrawElementsIndirectCommand extends Struct {
     /**
      * Create the pointer instance.
      *
-     * @param address   the address.
-     * @param allocator the allocator of this address.
+     * @param address the address.
      */
-    public DrawElementsIndirectCommand(MemorySegment address, SegmentAllocator allocator) {
-        super(address, allocator, LAYOUT);
+    public DrawElementsIndirectCommand(MemorySegment address) {
+        super(address, LAYOUT);
     }
 
     /**
      * Creates a struct instance with the given memory layout.
      *
-     * @param address   the address.
-     * @param allocator the allocator of this address.
-     * @param layout    the memory layout of this struct.
+     * @param address the address.
+     * @param layout  the memory layout of this struct.
      */
-    protected DrawElementsIndirectCommand(MemorySegment address, SegmentAllocator allocator, MemoryLayout layout) {
-        super(address, allocator, layout);
+    protected DrawElementsIndirectCommand(MemorySegment address, MemoryLayout layout) {
+        super(address, layout);
     }
 
     /**
@@ -85,7 +83,7 @@ public class DrawElementsIndirectCommand extends Struct {
      * @return the instance
      */
     public static DrawElementsIndirectCommand create(SegmentAllocator allocator) {
-        return new DrawElementsIndirectCommand(allocator.allocate(LAYOUT), allocator);
+        return new DrawElementsIndirectCommand(allocator.allocate(LAYOUT));
     }
 
     /**
@@ -96,7 +94,7 @@ public class DrawElementsIndirectCommand extends Struct {
      * @return the instance
      */
     public static Buffer create(SegmentAllocator allocator, long count) {
-        return new Buffer(allocator.allocateArray(LAYOUT, count), allocator, count);
+        return new Buffer(allocator.allocateArray(LAYOUT, count), count);
     }
 
     /**
@@ -202,11 +200,10 @@ public class DrawElementsIndirectCommand extends Struct {
          * Create the pointer instance.
          *
          * @param address      the address.
-         * @param allocator    the allocator of this address.
          * @param elementCount the element count
          */
-        public Buffer(MemorySegment address, SegmentAllocator allocator, long elementCount) {
-            super(address, allocator, MemoryLayout.sequenceLayout(elementCount, LAYOUT));
+        public Buffer(MemorySegment address, long elementCount) {
+            super(address, MemoryLayout.sequenceLayout(elementCount, LAYOUT));
             pCount = layout().varHandle(PathElement.sequenceElement(), PathElement.groupElement("count"));
             pPrimCount = layout().varHandle(PathElement.sequenceElement(), PathElement.groupElement("primCount"));
             pFirstIndex = layout().varHandle(PathElement.sequenceElement(), PathElement.groupElement("firstIndex"));

--- a/modules/overrungl.stb/src/main/java/overrungl/stb/STBIIoCallbacks.java
+++ b/modules/overrungl.stb/src/main/java/overrungl/stb/STBIIoCallbacks.java
@@ -58,11 +58,10 @@ public class STBIIoCallbacks extends Struct {
     /**
      * Create a {@code stbi_io_callbacks} instance.
      *
-     * @param address   the address.
-     * @param allocator the allocator of this address.
+     * @param address the address.
      */
-    public STBIIoCallbacks(MemorySegment address, SegmentAllocator allocator) {
-        super(address, allocator, LAYOUT);
+    public STBIIoCallbacks(MemorySegment address) {
+        super(address, LAYOUT);
     }
 
     /**
@@ -163,7 +162,7 @@ public class STBIIoCallbacks extends Struct {
      * @return the instance
      */
     public static STBIIoCallbacks create(SegmentAllocator allocator) {
-        return new STBIIoCallbacks(allocator.allocate(LAYOUT), allocator);
+        return new STBIIoCallbacks(allocator.allocate(LAYOUT));
     }
 
     /**


### PR DESCRIPTION
This PR removes the `allocator` parameter from `Pointer`.