### PR TITLE
Remove javadocs of native bindings

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,17 +51,6 @@ allprojects {
                         links("https://download.java.net/java/early_access/$jdkEarlyAccessDoc/docs/api/")
                     }
 
-                    tags(
-                        "glfw.callback_signature:m:Callback signature:",
-                        "glfw.errors:m:Errors:",
-                        "glfw.note:m:Note:",
-                        "glfw.pointer_lifetime:m:Pointer lifetime:",
-                        "glfw.remark:m:Remarks:",
-                        "glfw.reentrancy:m:Reentrancy:",
-                        "glfw.thread_safety:m:Thread safety:",
-                        "glfw.warning:m:Warning:",
-                    )
-
                     bottom =
                         """<a href="https://github.com/Over-Run/overrungl/issues">Report a bug or suggest an enhancement</a><br>""" +
                             "Copyright © $projLicenseYear Overrun Organization<br>" +

--- a/generators/glfw/src/main/kotlin/overrungl/glfw/GLFWGenerator.kt
+++ b/generators/glfw/src/main/kotlin/overrungl/glfw/GLFWGenerator.kt
@@ -51,763 +51,94 @@ val GLFWcursor_ptr = address c "GLFWcursor*"
 
 fun main() {
     //region Upcall
-    val GLFWallocatefun = Upcall(
-        glfwPackage,
-        "GLFWAllocateFun",
-        javadoc = """
-            The function pointer type for memory allocation callbacks.
-
-            This is the function pointer type for memory allocation callbacks.  A memory
-            allocation callback function has the following signature:
-            ```java
-            MemorySegment function_name(long size, MemorySegment user)
-            ```
-
-            @see GLFWAllocator
-        """.trimIndent()
-    ) {
-        targetMethod = "invoke"(
-            void_ptr,
-            size_t("size"),
-            void_ptr("user"),
-            javadoc = """
-                This function must return either a memory block at least `size` bytes long,
-                or `NULL` if allocation failed.  Note that not all parts of GLFW handle allocation
-                failures gracefully yet.
-
-                This function must support being called during [glfwInit][GLFW#glfwInit()] but before the library is
-                flagged as initialized, as well as during [glfwTerminate][GLFW#glfwTerminate()] after the library is no
-                longer flagged as initialized.
-
-                Any memory allocated via this function will be deallocated via the same allocator
-                during library termination or earlier.
-
-                Any memory allocated via this function must be suitably aligned for any object type.
-                If you are using C99 or earlier, this alignment is platform-dependent but will be the
-                same as what `malloc` provides.  If you are using C11 or later, this is the value of
-                `alignof(max_align_t)`.
-
-                The size will always be greater than zero.  Allocations of size zero are filtered out
-                before reaching the custom allocator.
-
-                If this function returns `NULL`, GLFW will emit [GLFW_OUT_OF_MEMORY][GLFW#GLFW_OUT_OF_MEMORY].
-
-                This function must not call any GLFW function.
-
-                @param size The minimum size, in bytes, of the memory block.
-                @param user The user-defined pointer from the allocator.
-                @return The address of the newly allocated memory block, or `NULL` if an
-                error occurred.
-
-                @glfw.pointer_lifetime The returned memory block must be valid at least until it
-                is deallocated.
-
-                @glfw.reentrancy This function should not call any GLFW function.
-
-                @glfw.thread_safety This function must support being called from any thread that calls GLFW
-                functions.
-            """.trimIndent()
-        )
+    val GLFWallocatefun = Upcall(glfwPackage, "GLFWAllocateFun") {
+        targetMethod = "invoke"(void_ptr, size_t("size"), void_ptr("user"))
     }.pointerType c "GLFWallocatefun"
 
-    val GLFWreallocatefun = Upcall(
-        glfwPackage,
-        "GLFWReallocateFun",
-        javadoc = """
-            The function pointer type for memory reallocation callbacks.
-
-            This is the function pointer type for memory reallocation callbacks.
-            A memory reallocation callback function has the following signature:
-            ```java
-            MemorySegment function_name(MemorySegment block, long size, MemorySegment user)
-            ```
-
-            @see GLFWAllocator
-        """.trimIndent()
-    ) {
-        targetMethod = "invoke"(
-            void_ptr,
-            void_ptr("block"),
-            size_t("size"),
-            void_ptr("user"),
-            javadoc = """
-                This function must return a memory block at least `size` bytes long, or
-                `NULL` if allocation failed.  Note that not all parts of GLFW handle allocation
-                failures gracefully yet.
-
-                This function must support being called during [glfwInit][GLFW#glfwInit()] but before the library is
-                flagged as initialized, as well as during [glfwTerminate][GLFW#glfwTerminate()] after the library is no
-                longer flagged as initialized.
-
-                Any memory allocated via this function will be deallocated via the same allocator
-                during library termination or earlier.
-
-                Any memory allocated via this function must be suitably aligned for any object type.
-                If you are using C99 or earlier, this alignment is platform-dependent but will be the
-                same as what `realloc` provides.  If you are using C11 or later, this is the value of
-                `alignof(max_align_t)`.
-
-                The block address will never be `NULL` and the size will always be greater than zero.
-                Reallocations of a block to size zero are converted into deallocations before reaching
-                the custom allocator.  Reallocations of `NULL` to a non-zero size are converted into
-                regular allocations before reaching the custom allocator.
-
-                If this function returns `NULL`, GLFW will emit [GLFW_OUT_OF_MEMORY][GLFW#GLFW_OUT_OF_MEMORY].
-
-                This function must not call any GLFW function.
-
-                @param block The address of the memory block to reallocate.
-                @param size The new minimum size, in bytes, of the memory block.
-                @param user The user-defined pointer from the allocator.
-                @return The address of the newly allocated or resized memory block, or
-                `NULL` if an error occurred.
-
-                @glfw.pointer_lifetime The returned memory block must be valid at least until it
-                is deallocated.
-
-                @glfw.reentrancy This function should not call any GLFW function.
-
-                @glfw.thread_safety This function must support being called from any thread that calls GLFW
-                functions.
-            """.trimIndent()
-        )
+    val GLFWreallocatefun = Upcall(glfwPackage, "GLFWReallocateFun") {
+        targetMethod = "invoke"(void_ptr, void_ptr("block"), size_t("size"), void_ptr("user"))
     }.pointerType c "GLFWreallocatefun"
 
-    val GLFWdeallocatefun = Upcall(
-        glfwPackage,
-        "GLFWDeallocateFun",
-        javadoc = """
-            The function pointer type for memory deallocation callbacks.
-
-            This is the function pointer type for memory deallocation callbacks.
-            A memory deallocation callback function has the following signature:
-            ```java
-            void function_name(MemorySegment block, MemorySegment user)
-            ```
-
-            @see GLFWAllocator
-        """.trimIndent()
-    ) {
-        targetMethod = "invoke"(
-            void,
-            void_ptr("block"),
-            void_ptr("user"),
-            javadoc = """
-                This function may deallocate the specified memory block.  This memory block
-                will have been allocated with the same allocator.
-
-                This function must support being called during [glfwInit][GLFW#glfwInit()] but before the library is
-                flagged as initialized, as well as during [glfwTerminate][GLFW#glfwTerminate()] after the library is no
-                longer flagged as initialized.
-
-                The block address will never be `NULL`.  Deallocations of `NULL` are filtered out
-                before reaching the custom allocator.
-
-                If this function returns `NULL`, GLFW will emit [GLFW_OUT_OF_MEMORY][GLFW#GLFW_OUT_OF_MEMORY].
-
-                This function must not call any GLFW function.
-
-                @param block The address of the memory block to deallocate.
-                @param user The user-defined pointer from the allocator.
-
-                @glfw.pointer_lifetime The specified memory block will not be accessed by GLFW
-                after this function is called.
-
-                @glfw.reentrancy This function should not call any GLFW function.
-
-                @glfw.thread_safety This function must support being called from any thread that calls GLFW
-                functions.
-            """.trimIndent()
-        )
+    val GLFWdeallocatefun = Upcall(glfwPackage, "GLFWDeallocateFun") {
+        targetMethod = "invoke"(void, void_ptr("block"), void_ptr("user"))
     }.pointerType c "GLFWdeallocatefun"
 
-    val GLFWerrorfun = Upcall(
-        glfwPackage,
-        "GLFWErrorFun",
-        javadoc = """
-            The function pointer type for error callbacks.
-
-            This is the function pointer type for error callbacks.  An error callback
-            function has the following signature:
-            ```java
-            void callback_name(int error_code, String description)
-            ```
-
-            @see GLFW#glfwSetErrorCallback(MemorySegment)
-        """.trimIndent()
-    ) {
-        val doc = """
-            Invoke
-
-            @param error_code An error code.  Future releases may add
-            more error codes.
-            @param description A UTF-8 encoded string describing the error.
-
-            @glfw.pointer_lifetime The error description string is valid until the callback
-            function returns.
-        """.trimIndent()
-        interfaceMethod = "invoke"(
-            void,
-            int("error_code"),
-            const_char_ptr("description"),
-            javadoc = doc
-        )
-        targetMethod = "invoke"(
-            void,
-            int("error_code"),
-            const_char_ptr("description"),
-            javadoc = doc,
-            overload = "invoke"
-        )
+    val GLFWerrorfun = Upcall(glfwPackage, "GLFWErrorFun") {
+        interfaceMethod = "invoke"(void, int("error_code"), const_char_ptr("description"))
+        targetMethod = "invoke"(void, int("error_code"), const_char_ptr("description"), overload = "invoke")
     }.pointerType c "GLFWerrorfun"
 
-    val GLFWwindowposfun = Upcall(
-        glfwPackage,
-        "GLFWWindowPosFun",
-        javadoc = """
-            The function pointer type for window position callbacks.
-
-            This is the function pointer type for window position callbacks.  A window
-            position callback function has the following signature:
-            ```java
-            void callback_name(MemorySegment window, int xpos, int ypos)
-            ```
-
-            @see GLFW#glfwSetWindowPosCallback(MemorySegment, MemorySegment)
-        """.trimIndent()
-    ) {
-        targetMethod = "invoke"(
-            void,
-            GLFWwindow_ptr("window"),
-            int("xpos"),
-            int("ypos"),
-            javadoc = """
-                Invoke
-
-                @param window The window that was moved.
-                @param xpos The new x-coordinate, in screen coordinates, of the
-                upper-left corner of the content area of the window.
-                @param ypos The new y-coordinate, in screen coordinates, of the
-                upper-left corner of the content area of the window.
-            """.trimIndent()
-        )
+    val GLFWwindowposfun = Upcall(glfwPackage, "GLFWWindowPosFun") {
+        targetMethod = "invoke"(void, GLFWwindow_ptr("window"), int("xpos"), int("ypos"))
     }.pointerType c "GLFWwindowposfun"
 
-    val GLFWwindowsizefun = Upcall(
-        glfwPackage,
-        "GLFWWindowSizeFun",
-        javadoc = """
-            The function pointer type for window size callbacks.
-
-            This is the function pointer type for window size callbacks.  A window size
-            callback function has the following signature:
-            ```java
-            void callback_name(MemorySegment window, int width, int height)
-            ```
-
-            @see GLFW#glfwSetWindowSizeCallback(MemorySegment, MemorySegment)
-        """.trimIndent()
-    ) {
-        targetMethod = "invoke"(
-            void,
-            GLFWwindow_ptr("window"),
-            int("width"),
-            int("height"),
-            javadoc = """
-                Invoke
-
-                @param window The window that was resized.
-                @param width The new width, in screen coordinates, of the window.
-                @param height The new height, in screen coordinates, of the window.
-            """.trimIndent()
-        )
+    val GLFWwindowsizefun = Upcall(glfwPackage, "GLFWWindowSizeFun") {
+        targetMethod = "invoke"(void, GLFWwindow_ptr("window"), int("width"), int("height"))
     }.pointerType c "GLFWwindowsizefun"
 
-    val GLFWwindowclosefun = Upcall(
-        glfwPackage,
-        "GLFWWindowCloseFun",
-        javadoc = """
-            The function pointer type for window close callbacks.
-
-            This is the function pointer type for window close callbacks.  A window
-            close callback function has the following signature:
-            ```java
-            void function_name(MemorySegment window)
-            ```
-
-            @see GLFW#glfwSetWindowCloseCallback(MemorySegment, MemorySegment)
-        """.trimIndent()
-    ) {
-        targetMethod = "invoke"(
-            void,
-            GLFWwindow_ptr("window"),
-            javadoc = """
-                Invoke
-
-                @param window The window that the user attempted to close.
-            """.trimIndent()
-        )
+    val GLFWwindowclosefun = Upcall(glfwPackage, "GLFWWindowCloseFun") {
+        targetMethod = "invoke"(void, GLFWwindow_ptr("window"))
     }.pointerType c "GLFWwindowclosefun"
 
-    val GLFWwindowrefreshfun = Upcall(
-        glfwPackage,
-        "GLFWWindowRefreshFun",
-        javadoc = """
-            The function pointer type for window content refresh callbacks.
-
-            This is the function pointer type for window content refresh callbacks.
-            A window content refresh callback function has the following signature:
-            ```java
-            void function_name(MemorySegment window);
-            ```
-
-            @see GLFW#glfwSetWindowRefreshCallback(MemorySegment, MemorySegment)
-        """.trimIndent()
-    ) {
-        targetMethod = "invoke"(
-            void,
-            GLFWwindow_ptr("window"),
-            javadoc = """
-                Invoke
-
-                @param window The window whose content needs to be refreshed.
-            """.trimIndent()
-        )
+    val GLFWwindowrefreshfun = Upcall(glfwPackage, "GLFWWindowRefreshFun") {
+        targetMethod = "invoke"(void, GLFWwindow_ptr("window"))
     }.pointerType c "GLFWwindowrefreshfun"
 
-    val GLFWwindowfocusfun = Upcall(
-        glfwPackage,
-        "GLFWWindowFocusFun",
-        javadoc = """
-            The function pointer type for window focus callbacks.
-
-            This is the function pointer type for window focus callbacks.  A window
-            focus callback function has the following signature:
-            ```java
-            void function_name(MemorySegment window, boolean focused)
-            ```
-
-            @see GLFW#glfwSetWindowFocusCallback(MemorySegment, MemorySegment)
-        """.trimIndent()
-    ) {
-        interfaceMethod = "invoke"(
-            void,
-            GLFWwindow_ptr("window"),
-            glfw_boolean("focused"),
-            javadoc = """
-                Invoke
-
-                @param window The window that gained or lost input focus.
-                @param focused `true` if the window was given input focus, or
-                `false` if it lost it.
-            """.trimIndent()
-        )
-        targetMethod = "invoke"(
-            void,
-            GLFWwindow_ptr("window"),
-            glfw_boolean("focused"),
-            javadoc = """
-                Invoke
-
-                @param window The window that gained or lost input focus.
-                @param focused `GLFW_TRUE` if the window was given input focus, or
-                `GLFW_FALSE` if it lost it.
-            """.trimIndent(),
-            overload = "invoke"
-        )
+    val GLFWwindowfocusfun = Upcall(glfwPackage, "GLFWWindowFocusFun") {
+        interfaceMethod = "invoke"(void, GLFWwindow_ptr("window"), glfw_boolean("focused"))
+        targetMethod = "invoke"(void, GLFWwindow_ptr("window"), glfw_boolean("focused"), overload = "invoke")
     }.pointerType c "GLFWwindowfocusfun"
 
-    val GLFWwindowiconifyfun = Upcall(
-        glfwPackage,
-        "GLFWWindowIconifyFun",
-        javadoc = """
-            The function pointer type for window iconify callbacks.
-
-            This is the function pointer type for window iconify callbacks.  A window
-            iconify callback function has the following signature:
-            ```java
-            void function_name(MemorySegment window, boolean iconified)
-            ```
-
-            @see GLFW#glfwSetWindowIconifyCallback(MemorySegment, MemorySegment)
-        """.trimIndent()
-    ) {
-        interfaceMethod = "invoke"(
-            void,
-            GLFWwindow_ptr("window"),
-            glfw_boolean("iconified"),
-            javadoc = """
-                Invoke
-
-                @param window The window that was iconified or restored.
-                @param iconified `true` if the window was iconified, or
-                `false` if it was restored.
-            """.trimIndent()
-        )
-        targetMethod = "invoke"(
-            void,
-            GLFWwindow_ptr("window"),
-            glfw_boolean("iconified"),
-            javadoc = """
-                Invoke
-
-                @param window The window that was iconified or restored.
-                @param iconified `GLFW_TRUE` if the window was iconified, or
-                `GLFW_FALSE` if it was restored.
-            """.trimIndent(),
-            overload = "invoke"
-        )
+    val GLFWwindowiconifyfun = Upcall(glfwPackage, "GLFWWindowIconifyFun") {
+        interfaceMethod = "invoke"(void, GLFWwindow_ptr("window"), glfw_boolean("iconified"))
+        targetMethod = "invoke"(void, GLFWwindow_ptr("window"), glfw_boolean("iconified"), overload = "invoke")
     }.pointerType c "GLFWwindowiconifyfun"
 
-    val GLFWwindowmaximizefun = Upcall(
-        glfwPackage,
-        "GLFWWindowMaximizeFun",
-        javadoc = """
-            The function pointer type for window maximize callbacks.
-
-            This is the function pointer type for window maximize callbacks.  A window
-            maximize callback function has the following signature:
-            ```java
-            void function_name(MemorySegment window, boolean maximized)
-            ```
-
-            @see GLFW#glfwSetWindowMaximizeCallback(MemorySegment, MemorySegment)
-        """.trimIndent()
-    ) {
-        interfaceMethod = "invoke"(
-            void,
-            GLFWwindow_ptr("window"),
-            glfw_boolean("maximized"),
-            javadoc = """
-                Invoke
-
-                @param window The window that was maximized or restored.
-                @param maximized `true` if the window was maximized, or
-                `false` if it was restored.
-            """.trimIndent()
-        )
-        targetMethod = "invoke"(
-            void,
-            GLFWwindow_ptr("window"),
-            glfw_boolean("maximized"),
-            javadoc = """
-                Invoke
-
-                @param window The window that was maximized or restored.
-                @param maximized `GLFW_TRUE` if the window was maximized, or
-                `GLFW_FALSE` if it was restored.
-            """.trimIndent(),
-            overload = "invoke"
-        )
+    val GLFWwindowmaximizefun = Upcall(glfwPackage, "GLFWWindowMaximizeFun") {
+        interfaceMethod = "invoke"(void, GLFWwindow_ptr("window"), glfw_boolean("maximized"))
+        targetMethod = "invoke"(void, GLFWwindow_ptr("window"), glfw_boolean("maximized"), overload = "invoke")
     }.pointerType c "GLFWwindowmaximizefun"
 
-    val GLFWframebuffersizefun = Upcall(
-        glfwPackage,
-        "GLFWFramebufferSizeFun",
-        javadoc = """
-            The function pointer type for framebuffer size callbacks.
-
-            This is the function pointer type for framebuffer size callbacks.
-            A framebuffer size callback function has the following signature:
-            ```java
-            void function_name(MemorySegment window, int width, int height)
-            ```
-
-            @see GLFW#glfwSetFramebufferSizeCallback(MemorySegment, MemorySegment)
-        """.trimIndent()
-    ) {
-        targetMethod = "invoke"(
-            void,
-            GLFWwindow_ptr("window"),
-            int("width"),
-            int("height"),
-            javadoc = """
-                Invoke
-
-                @param window The window whose framebuffer was resized.
-                @param width The new width, in pixels, of the framebuffer.
-                @param height The new height, in pixels, of the framebuffer.
-            """.trimIndent()
-        )
+    val GLFWframebuffersizefun = Upcall(glfwPackage, "GLFWFramebufferSizeFun") {
+        targetMethod = "invoke"(void, GLFWwindow_ptr("window"), int("width"), int("height"))
     }.pointerType c "GLFWframebuffersizefun"
 
-    val GLFWwindowcontentscalefun = Upcall(
-        glfwPackage,
-        "GLFWWindowContentScaleFun",
-        javadoc = """
-            The function pointer type for window content scale callbacks.
-
-            This is the function pointer type for window content scale callbacks.
-            A window content scale callback function has the following signature:
-            ```java
-            void function_name(MemorySegment window, float xscale, float yscale)
-            ```
-
-            @see GLFW#glfwSetWindowContentScaleCallback(MemorySegment, MemorySegment)
-        """.trimIndent()
-    ) {
-        targetMethod = "invoke"(
-            void,
-            GLFWwindow_ptr("window"),
-            float("xscale"),
-            float("yscale"),
-            javadoc = """
-                Invoke
-
-                @param window The window whose content scale changed.
-                @param xscale The new x-axis content scale of the window.
-                @param yscale The new y-axis content scale of the window.
-            """.trimIndent()
-        )
+    val GLFWwindowcontentscalefun = Upcall(glfwPackage, "GLFWWindowContentScaleFun") {
+        targetMethod = "invoke"(void, GLFWwindow_ptr("window"), float("xscale"), float("yscale"))
     }.pointerType c "GLFWwindowcontentscalefun"
 
-    val GLFWmousebuttonfun = Upcall(
-        glfwPackage,
-        "GLFWMouseButtonFun",
-        javadoc = """
-            The function pointer type for mouse button callbacks.
-
-            This is the function pointer type for mouse button callback functions.
-            A mouse button callback function has the following signature:
-            ```java
-            void function_name(MemorySegment window, int button, int action, int mods)
-            ```
-
-            @see GLFW#glfwSetMouseButtonCallback(MemorySegment, MemorySegment)
-        """.trimIndent()
-    ) {
-        targetMethod = "invoke"(
-            void,
-            GLFWwindow_ptr("window"),
-            int("button"),
-            int("action"),
-            int("mods"),
-            javadoc = """
-                Invoke
-
-                @param window The window that received the event.
-                @param button The mouse button that was pressed or
-                released.
-                @param action One of `GLFW_PRESS` or `GLFW_RELEASE`.  Future releases
-                may add more actions.
-                @param mods Bit field describing which modifier keys were
-                held down.
-            """.trimIndent()
-        )
+    val GLFWmousebuttonfun = Upcall(glfwPackage, "GLFWMouseButtonFun") {
+        targetMethod = "invoke"(void, GLFWwindow_ptr("window"), int("button"), int("action"), int("mods"))
     }.pointerType c "GLFWmousebuttonfun"
 
-    val GLFWcursorposfun = Upcall(
-        glfwPackage,
-        "GLFWCursorPosFun",
-        javadoc = """
-            The function pointer type for cursor position callbacks.
-
-            This is the function pointer type for cursor position callbacks.  A cursor
-            position callback function has the following signature:
-            ```java
-            void function_name(MemorySegment window, double xpos, double ypos);
-            ```
-
-            @see GLFW#glfwSetCursorPosCallback(MemorySegment, MemorySegment)
-        """.trimIndent()
-    ) {
-        targetMethod = "invoke"(
-            void,
-            GLFWwindow_ptr("window"),
-            double("xpos"),
-            double("ypos"),
-            javadoc = """
-                Invoke
-
-                @param window The window that received the event.
-                @param xpos The new cursor x-coordinate, relative to the left edge of
-                the content area.
-                @param ypos The new cursor y-coordinate, relative to the top edge of the
-                content area.
-            """.trimIndent()
-        )
+    val GLFWcursorposfun = Upcall(glfwPackage, "GLFWCursorPosFun") {
+        targetMethod = "invoke"(void, GLFWwindow_ptr("window"), double("xpos"), double("ypos"))
     }.pointerType c "GLFWcursorposfun"
 
-    val GLFWcursorenterfun = Upcall(
-        glfwPackage,
-        "GLFWCursorEnterFun",
-        javadoc = """
-            The function pointer type for cursor enter/leave callbacks.
-
-            This is the function pointer type for cursor enter/leave callbacks.
-            A cursor enter/leave callback function has the following signature:
-            ```java
-            void function_name(MemorySegment window, boolean entered)
-            ```
-
-            @see GLFW#glfwSetCursorEnterCallback(MemorySegment, MemorySegment)
-        """.trimIndent()
-    ) {
-        interfaceMethod = "invoke"(
-            void,
-            GLFWwindow_ptr("window"),
-            glfw_boolean("entered"),
-            javadoc = """
-                Invoke
-
-                @param window The window that received the event.
-                @param entered `GLFW_TRUE` if the cursor entered the window's content
-                area, or `GLFW_FALSE` if it left it.
-            """.trimIndent()
-        )
-        targetMethod = "invoke"(
-            void,
-            GLFWwindow_ptr("window"),
-            glfw_boolean("entered"),
-            javadoc = """
-                Invoke
-
-                @param window The window that received the event.
-                @param entered `GLFW_TRUE` if the cursor entered the window's content
-                area, or `GLFW_FALSE` if it left it.
-            """.trimIndent(),
-            overload = "invoke"
-        )
+    val GLFWcursorenterfun = Upcall(glfwPackage, "GLFWCursorEnterFun") {
+        interfaceMethod = "invoke"(void, GLFWwindow_ptr("window"), glfw_boolean("entered"))
+        targetMethod = "invoke"(void, GLFWwindow_ptr("window"), glfw_boolean("entered"), overload = "invoke")
     }.pointerType c "GLFWcursorenterfun"
 
-    val GLFWscrollfun = Upcall(
-        glfwPackage,
-        "GLFWScrollFun",
-        javadoc = """
-            The function pointer type for scroll callbacks.
-
-            This is the function pointer type for scroll callbacks.  A scroll callback
-            function has the following signature:
-            ```java
-            void function_name(MemorySegment window, double xoffset, double yoffset)
-            ```
-
-            @see GLFW#glfwSetScrollCallback(MemorySegment, MemorySegment)
-        """.trimIndent()
-    ) {
-        targetMethod = "invoke"(
-            void,
-            GLFWwindow_ptr("window"),
-            double("xoffset"),
-            double("yoffset"),
-            javadoc = """
-                Invoke
-
-                @param window The window that received the event.
-                @param xoffset The scroll offset along the x-axis.
-                @param yoffset The scroll offset along the y-axis.
-            """.trimIndent()
-        )
+    val GLFWscrollfun = Upcall(glfwPackage, "GLFWScrollFun") {
+        targetMethod = "invoke"(void, GLFWwindow_ptr("window"), double("xoffset"), double("yoffset"))
     }.pointerType c "GLFWscrollfun"
 
-    val GLFWkeyfun = Upcall(
-        glfwPackage,
-        "GLFWKeyFun",
-        javadoc = """
-            The function pointer type for keyboard key callbacks.
-
-            This is the function pointer type for keyboard key callbacks.  A keyboard
-            key callback function has the following signature:
-            ```java
-            void function_name(MemorySegment window, int key, int scancode, int action, int mods)
-            ```
-
-            @see GLFW#glfwSetKeyCallback(MemorySegment, MemorySegment)
-        """.trimIndent()
-    ) {
-        targetMethod = "invoke"(
-            void,
-            GLFWwindow_ptr("window"),
-            int("key"),
-            int("scancode"),
-            int("action"),
-            int("mods"),
-            javadoc = """
-                Invoke
-
-                @param window The window that received the event.
-                @param key The keyboard key that was pressed or released.
-                @param scancode The platform-specific scancode of the key.
-                @param action `GLFW_PRESS`, `GLFW_RELEASE` or `GLFW_REPEAT`.  Future
-                releases may add more actions.
-                @param mods Bit field describing which modifier keys were
-                held down.
-            """.trimIndent()
-        )
+    val GLFWkeyfun = Upcall(glfwPackage, "GLFWKeyFun") {
+        targetMethod = "invoke"(void, GLFWwindow_ptr("window"), int("key"), int("scancode"), int("action"), int("mods"))
     }.pointerType c "GLFWkeyfun"
 
-    val GLFWcharfun = Upcall(
-        glfwPackage,
-        "GLFWCharFun",
-        javadoc = """
-            The function pointer type for Unicode character callbacks.
-
-            This is the function pointer type for Unicode character callbacks.
-            A Unicode character callback function has the following signature:
-            ```java
-            void function_name(MemorySegment window, int codepoint)
-            ```
-
-            @see GLFW#glfwSetCharCallback(MemorySegment, MemorySegment)
-        """.trimIndent()
-    ) {
-        targetMethod = "invoke"(
-            void,
-            GLFWwindow_ptr("window"),
-            uint("codepoint"),
-            javadoc = """
-                Invoke
-
-                @param window The window that received the event.
-                @param codepoint The Unicode code point of the character.
-            """.trimIndent()
-        )
+    val GLFWcharfun = Upcall(glfwPackage, "GLFWCharFun") {
+        targetMethod = "invoke"(void, GLFWwindow_ptr("window"), uint("codepoint"))
     }.pointerType c "GLFWcharfun"
 
-    val GLFWdropfun = Upcall(
-        glfwPackage,
-        "GLFWDropFun",
-        javadoc = """
-            The function pointer type for path drop callbacks.
-
-            This is the function pointer type for path drop callbacks.  A path drop
-            callback function has the following signature:
-            ```
-            void function_name(MemorySegment window, String[] paths)
-            ```
-
-            @see GLFW#glfwSetDropCallback(MemorySegment, MemorySegment)
-        """.trimIndent()
-    ) {
-        interfaceMethod = "invoke"(
-            void,
-            GLFWwindow_ptr("window"),
-            string_u8_array("paths"),
-            javadoc = """
-                Invoke
-
-                @param window The window that received the event.
-                @param paths The UTF-8 encoded file and/or directory path names.
-
-                @glfw.pointer_lifetime The path array and its strings are valid until the
-                callback function returns.
-            """.trimIndent()
-        )
+    val GLFWdropfun = Upcall(glfwPackage, "GLFWDropFun") {
+        interfaceMethod = "invoke"(void, GLFWwindow_ptr("window"), string_u8_array("paths"))
         targetMethod = "invoke"(
             void,
             GLFWwindow_ptr("window"),
             int("path_count"),
             string_u8_array("paths"),
-            javadoc = """
-                Invoke
-
-                @param window The window that received the event.
-                @param path_count The number of dropped paths.
-                @param paths The UTF-8 encoded file and/or directory path names.
-
-                @glfw.pointer_lifetime The path array and its strings are valid until the
-                callback function returns.
-            """.trimIndent(),
             code = """
                 var a = new String[path_count];
                 Unmarshal.copy(paths, a);
@@ -821,264 +152,71 @@ fun main() {
         """.trimIndent()
     }.pointerType c "GLFWdropfun"
 
-    val GLFWmonitorfun = Upcall(
-        glfwPackage,
-        "GLFWMonitorFun",
-        javadoc = """
-            The function pointer type for monitor configuration callbacks.
-
-            This is the function pointer type for monitor configuration callbacks.
-            A monitor callback function has the following signature:
-            ```java
-            void function_name(MemorySegment monitor, int event)
-            ```
-
-            @see GLFW#glfwSetMonitorCallback(MemorySegment)
-        """.trimIndent()
-    ) {
-        targetMethod = "invoke"(
-            void,
-            GLFWmonitor_ptr("monitor"),
-            int("event"),
-            javadoc = """
-                Invoke
-
-                @param monitor The monitor that was connected or disconnected.
-                @param event One of `GLFW_CONNECTED` or `GLFW_DISCONNECTED`.  Future
-                releases may add more events.
-            """.trimIndent()
-        )
+    val GLFWmonitorfun = Upcall(glfwPackage, "GLFWMonitorFun") {
+        targetMethod = "invoke"(void, GLFWmonitor_ptr("monitor"), int("event"))
     }.pointerType c "GLFWmonitorfun"
 
-    val GLFWjoystickfun = Upcall(
-        glfwPackage,
-        "GLFWJoystickFun",
-        javadoc = """
-            The function pointer type for joystick configuration callbacks.
-
-            This is the function pointer type for joystick configuration callbacks.
-            A joystick configuration callback function has the following signature:
-            ```java
-            void function_name(int jid, int event)
-            ```
-
-            @see GLFW#glfwSetJoystickCallback(MemorySegment)
-        """.trimIndent()
-    ) {
-        targetMethod = "invoke"(
-            void,
-            int("jid"),
-            int("event"),
-            javadoc = """
-                Invoke
-
-                @param jid The joystick that was connected or disconnected.
-                @param event One of `GLFW_CONNECTED` or `GLFW_DISCONNECTED`.  Future
-                releases may add more events.
-            """.trimIndent()
-        )
+    val GLFWjoystickfun = Upcall(glfwPackage, "GLFWJoystickFun") {
+        targetMethod = "invoke"(void, int("jid"), int("event"))
     }.pointerType c "GLFWjoystickfun"
     //endregion
 
     //region Structs
-    val const_GLFWvidmode_ptr = Struct(
-        glfwPackage,
-        "GLFWVidMode",
-        cType = "GLFWvidmode",
-        javadoc = """
-            Video mode type.
-
-            This describes a single video mode.
-
-            ## See Also
-            - [glfwGetVideoMode][GLFW#glfwGetVideoMode(MemorySegment)]
-            - [glfwGetVideoModes][GLFW#glfwGetVideoModes(MemorySegment, MemorySegment)]
-        """.trimIndent()
-    ) {
-        int("width", javadoc = "The width, in screen coordinates, of the video mode.")
-        int("height", javadoc = "The height, in screen coordinates, of the video mode.")
-        int("redBits", javadoc = "The bit depth of the red channel of the video mode.")
-        int("greenBits", javadoc = "The bit depth of the green channel of the video mode.")
-        int("blueBits", javadoc = "The bit depth of the blue channel of the video mode.")
-        int("refreshRate", javadoc = "The refresh rate, in Hz, of the video mode.")
+    val const_GLFWvidmode_ptr = Struct(glfwPackage, "GLFWVidMode", cType = "GLFWvidmode") {
+        int("width")
+        int("height")
+        int("redBits")
+        int("greenBits")
+        int("blueBits")
+        int("refreshRate")
     }.pointerType c "const GLFWvidmode*"
 
-    val const_GLFWgammaramp_ptr = Struct(
-        glfwPackage,
-        "GLFWGammaRamp",
-        cType = "GLFWgammaramp",
-        javadoc = """
-            Gamma ramp.
-
-            This describes the gamma ramp for a monitor.
-
-            ## See Also
-            - [glfwGetGammaRamp][GLFW#glfwGetGammaRamp(MemorySegment)]
-            - [glfwSetGammaRamp][GLFW#glfwSetGammaRamp(MemorySegment, MemorySegment)]
-        """.trimIndent()
-    ) {
+    val const_GLFWgammaramp_ptr = Struct(glfwPackage, "GLFWGammaRamp", cType = "GLFWgammaramp") {
         val ushort_ptr = jshort_array c "unsigned short*"
-        ushort_ptr("red", javadoc = "An array of value describing the response of the red channel.")
-        ushort_ptr("green", javadoc = "An array of value describing the response of the green channel.")
-        ushort_ptr("blue", javadoc = "An array of value describing the response of the blue channel.")
-        uint("size", javadoc = "The number of elements in each array.")
+        ushort_ptr("red")
+        ushort_ptr("green")
+        ushort_ptr("blue")
+        uint("size")
     }.pointerType c "const GLFWgammaramp*"
 
-    val const_GLFWimage_ptr = Struct(
-        glfwPackage,
-        "GLFWImage",
-        cType = "GLFWimage",
-        javadoc = """
-            Image data.
-
-            This describes a single 2D image.  See the documentation for each related
-            function what the expected pixel format is.
-        """.trimIndent()
-    ) {
-        int("width", javadoc = "The width, in pixels, of this image.")
-        int("height", javadoc = "The height, in pixels, of this image.")
-        (address c "unsigned char*")(
-            "pixels",
-            javadoc = "The pixel data of this image, arranged left-to-right, top-to-bottom."
-        )
+    val const_GLFWimage_ptr = Struct(glfwPackage, "GLFWImage", cType = "GLFWimage") {
+        int("width")
+        int("height")
+        (address c "unsigned char*")("pixels")
     }.pointerType c "const GLFWimage*"
 
-    val GLFWgamepadstate_ptr = Struct(
-        glfwPackage,
-        "GLFWGamepadState",
-        cType = "GLFWgamepadstate",
-        javadoc = """
-            Gamepad input state
-
-            This describes the input state of a gamepad.
-
-            ## See Also
-            - [glfwGetGamepadState][GLFW#glfwGetGamepadState(int, MemorySegment)]
-        """.trimIndent()
-    ) {
-        fixedSize(
-            uchar,
-            "buttons",
-            15,
-            javadoc = """
-                The states of each gamepad button, `GLFW_PRESS`
-                or `GLFW_RELEASE`.
-            """.trimIndent()
-        )
-        fixedSize(
-            float,
-            "axes",
-            6,
-            javadoc = """
-                The states of each gamepad axis, in the range -1.0
-                to 1.0 inclusive.
-            """.trimIndent()
-        )
+    val GLFWgamepadstate_ptr = Struct(glfwPackage, "GLFWGamepadState", cType = "GLFWgamepadstate") {
+        fixedSize(uchar, "buttons", 15)
+        fixedSize(float, "axes", 6)
     }.pointerType c "GLFWgamepadstate*"
 
-    val const_GLFWallocator_ptr = Struct(
-        glfwPackage,
-        "GLFWAllocator",
-        cType = "GLFWallocator",
-        javadoc = """
-            Custom heap memory allocator.
-
-            This describes a custom heap memory allocator for GLFW.  To set an allocator, pass it
-            to [glfwInitAllocator][GLFW#glfwInitAllocator(MemorySegment)] before initializing the library.
-        """.trimIndent()
-    ) {
-        GLFWallocatefun(
-            "allocate",
-            javadoc = """
-                The memory allocation function.  See [GLFWAllocateFun] for details about
-                allocation function.
-            """.trimIndent()
-        )
-        GLFWreallocatefun(
-            "reallocate",
-            javadoc = """
-                The memory reallocation function.  See [GLFWReallocateFun] for details about
-                reallocation function.
-            """.trimIndent()
-        )
-        GLFWdeallocatefun(
-            "deallocate",
-            javadoc = """
-                The memory deallocation function.  See [GLFWDeallocateFun] for details about
-                deallocation function.
-            """.trimIndent()
-        )
-        void_ptr(
-            "user",
-            javadoc = """
-                The user pointer for this custom allocator.  This value will be passed to the
-                allocator functions.
-            """.trimIndent()
-        )
+    val const_GLFWallocator_ptr = Struct(glfwPackage, "GLFWAllocator", cType = "GLFWallocator") {
+        GLFWallocatefun("allocate")
+        GLFWreallocatefun("reallocate")
+        GLFWdeallocatefun("deallocate")
+        void_ptr("user")
     }.pointerType c "const GLFWallocator*"
     //endregion
 
     StaticDowncall(glfwPackage, "GLFW", symbolLookup = glfwLookup) {
         //region GLFW API tokens
 
-        int(javadoc = "GLFW version macros") {
-            "GLFW_VERSION_MAJOR"(
-                "3",
-                javadoc = """
-                    The major version number of the GLFW header.  This is incremented when the
-                    API is changed in non-compatible ways.
-                """.trimIndent()
-            )
-            "GLFW_VERSION_MINOR"(
-                "5",
-                javadoc = """
-                    The minor version number of the GLFW header.  This is incremented when
-                    features are added to the API but it remains backward-compatible.
-                """.trimIndent()
-            )
-            "GLFW_VERSION_REVISION"(
-                "0",
-                javadoc = """
-                    The revision number of the GLFW header.  This is incremented when a bug fix
-                    release is made that does not contain any API changes.
-                """.trimIndent()
-            )
+        int {
+            "GLFW_VERSION_MAJOR"("3")
+            "GLFW_VERSION_MINOR"("5")
+            "GLFW_VERSION_REVISION"("0")
         }
 
-        int(
-            "GLFW_TRUE" to "1",
-            javadoc = """
-                One.
+        int("GLFW_TRUE" to "1")
+        int("GLFW_FALSE" to "0")
 
-                This is only semantic sugar for the number 1.  You can instead use `1` or
-                `true` or `_True` or `GL_TRUE` or `VK_TRUE` or anything else that is equal
-                to one.
-            """.trimIndent()
-        )
-        int(
-            "GLFW_FALSE" to "0",
-            javadoc = """
-                Zero.
-
-                This is only semantic sugar for the number 0.  You can instead use `0` or
-                `false` or `_False` or `GL_FALSE` or `VK_FALSE` or anything else that is
-                equal to zero.
-            """.trimIndent()
-        )
-
-        int(javadoc = "Key and button actions") {
-            "GLFW_RELEASE"("0", javadoc = "The key or mouse button was released.")
-            "GLFW_PRESS"("1", javadoc = "The key or mouse button was pressed.")
-            "GLFW_REPEAT"("2", javadoc = "The key was held down until it repeated.")
+        int {
+            "GLFW_RELEASE"("0")
+            "GLFW_PRESS"("1")
+            "GLFW_REPEAT"("2")
         }
 
-        int(
-            javadoc = """
-            Joystick hat states.
-
-            See joystick hat input for how these are used.
-        """.trimIndent()
-        ) {
+        int {
             "GLFW_HAT_CENTERED"("0")
             "GLFW_HAT_UP"("1")
             "GLFW_HAT_RIGHT"("2")
@@ -1092,13 +230,13 @@ fun main() {
 
         int("GLFW_KEY_UNKNOWN" to "-1")
 
-        int(javadoc = "Printable keys") {
+        int {
             "GLFW_KEY_SPACE"("32")
-            "GLFW_KEY_APOSTROPHE"("39", javadoc = "`'`")
-            "GLFW_KEY_COMMA"("44", javadoc = "`,`")
-            "GLFW_KEY_MINUS"("45", javadoc = "`-`")
-            "GLFW_KEY_PERIOD"("46", javadoc = "`.`")
-            "GLFW_KEY_SLASH"("47", javadoc = "`/`")
+            "GLFW_KEY_APOSTROPHE"("39")
+            "GLFW_KEY_COMMA"("44")
+            "GLFW_KEY_MINUS"("45")
+            "GLFW_KEY_PERIOD"("46")
+            "GLFW_KEY_SLASH"("47")
             "GLFW_KEY_0"("48")
             "GLFW_KEY_1"("49")
             "GLFW_KEY_2"("50")
@@ -1109,8 +247,8 @@ fun main() {
             "GLFW_KEY_7"("55")
             "GLFW_KEY_8"("56")
             "GLFW_KEY_9"("57")
-            "GLFW_KEY_SEMICOLON"("59", javadoc = "`;`")
-            "GLFW_KEY_EQUAL"("61", javadoc = "`=`")
+            "GLFW_KEY_SEMICOLON"("59")
+            "GLFW_KEY_EQUAL"("61")
             "GLFW_KEY_A"("65")
             "GLFW_KEY_B"("66")
             "GLFW_KEY_C"("67")
@@ -1137,15 +275,15 @@ fun main() {
             "GLFW_KEY_X"("88")
             "GLFW_KEY_Y"("89")
             "GLFW_KEY_Z"("90")
-            "GLFW_KEY_LEFT_BRACKET"("91", javadoc = "`[`")
-            "GLFW_KEY_BACKSLASH"("92", javadoc = "`\\\\`")
-            "GLFW_KEY_RIGHT_BRACKET"("93", javadoc = "`]`")
-            "GLFW_KEY_GRAVE_ACCENT"("96", javadoc = "<code>`</code>")
-            "GLFW_KEY_WORLD_1"("161", javadoc = "non-US #1")
-            "GLFW_KEY_WORLD_2"("162", javadoc = "non-US #2")
+            "GLFW_KEY_LEFT_BRACKET"("91")
+            "GLFW_KEY_BACKSLASH"("92")
+            "GLFW_KEY_RIGHT_BRACKET"("93")
+            "GLFW_KEY_GRAVE_ACCENT"("96")
+            "GLFW_KEY_WORLD_1"("161")
+            "GLFW_KEY_WORLD_2"("162")
         }
 
-        int(javadoc = "Function keys") {
+        int {
             "GLFW_KEY_ESCAPE"("256")
             "GLFW_KEY_ENTER"("257")
             "GLFW_KEY_TAB"("258")
@@ -1220,44 +358,16 @@ fun main() {
 
         int("GLFW_KEY_LAST" to "GLFW_KEY_MENU")
 
-        int(
-            javadoc = """
-            Modifier key flags.
-
-            See key input for how these are used.
-        """.trimIndent()
-        ) {
-            "GLFW_MOD_SHIFT"("0x0001", javadoc = "If this bit is set one or more Shift keys were held down.")
-            "GLFW_MOD_CONTROL"("0x0002", javadoc = "If this bit is set one or more Control keys were held down.")
-            "GLFW_MOD_ALT"("0x0004", javadoc = "If this bit is set one or more Alt keys were held down.")
-            "GLFW_MOD_SUPER"("0x0008", javadoc = "If this bit is set one or more Super keys were held down.")
-            "GLFW_MOD_CAPS_LOCK"(
-                "0x0010",
-                javadoc = """
-                    If this bit is set the Caps Lock key is enabled.
-
-                    If this bit is set the Caps Lock key is enabled and the
-                    [GLFW_LOCK_KEY_MODS][#GLFW_LOCK_KEY_MODS] input mode is set.
-                """.trimIndent()
-            )
-            "GLFW_MOD_NUM_LOCK"(
-                "0x0020",
-                javadoc = """
-                    If this bit is set the Num Lock key is enabled.
-
-                    If this bit is set the Num Lock key is enabled and the
-                    [GLFW_LOCK_KEY_MODS][#GLFW_LOCK_KEY_MODS] input mode is set.
-                """.trimIndent()
-            )
+        int {
+            "GLFW_MOD_SHIFT"("0x0001")
+            "GLFW_MOD_CONTROL"("0x0002")
+            "GLFW_MOD_ALT"("0x0004")
+            "GLFW_MOD_SUPER"("0x0008")
+            "GLFW_MOD_CAPS_LOCK"("0x0010")
+            "GLFW_MOD_NUM_LOCK"("0x0020")
         }
 
-        int(
-            javadoc = """
-            Mouse button IDs.
-
-            See mouse button input for how these are used.
-        """.trimIndent()
-        ) {
+        int {
             "GLFW_MOUSE_BUTTON_1"("0")
             "GLFW_MOUSE_BUTTON_2"("1")
             "GLFW_MOUSE_BUTTON_3"("2")
@@ -1272,13 +382,7 @@ fun main() {
             "GLFW_MOUSE_BUTTON_MIDDLE"("GLFW_MOUSE_BUTTON_3")
         }
 
-        int(
-            javadoc = """
-            Joystick IDs.
-
-            See joystick input for how these are used.
-        """.trimIndent()
-        ) {
+        int {
             "GLFW_JOYSTICK_1"("0")
             "GLFW_JOYSTICK_2"("1")
             "GLFW_JOYSTICK_3"("2")
@@ -1298,13 +402,7 @@ fun main() {
             "GLFW_JOYSTICK_LAST"("GLFW_JOYSTICK_16")
         }
 
-        int(
-            javadoc = """
-            Gamepad buttons.
-
-            See gamepad for how these are used.
-        """.trimIndent()
-        ) {
+        int {
             "GLFW_GAMEPAD_BUTTON_A"("0")
             "GLFW_GAMEPAD_BUTTON_B"("1")
             "GLFW_GAMEPAD_BUTTON_X"("2")
@@ -1328,13 +426,7 @@ fun main() {
             "GLFW_GAMEPAD_BUTTON_TRIANGLE"("GLFW_GAMEPAD_BUTTON_Y")
         }
 
-        int(
-            javadoc = """
-            Gamepad axes.
-
-            See gamepad for how these are used.
-        """.trimIndent()
-        ) {
+        int {
             "GLFW_GAMEPAD_AXIS_LEFT_X"("0")
             "GLFW_GAMEPAD_AXIS_LEFT_Y"("1")
             "GLFW_GAMEPAD_AXIS_RIGHT_X"("2")
@@ -1344,329 +436,81 @@ fun main() {
             "GLFW_GAMEPAD_AXIS_LAST"("GLFW_GAMEPAD_AXIS_RIGHT_TRIGGER")
         }
 
-        int(
-            javadoc = """
-            Error codes.
-
-            See error handling for how these are used.
-        """.trimIndent()
-        ) {
-            "GLFW_NO_ERROR"(
-                "0",
-                javadoc = """
-                    No error has occurred.
-
-                    ###### Analysis
-                    Yay.
-                """.trimIndent()
-            )
-            "GLFW_NOT_INITIALIZED"(
-                "0x00010001",
-                javadoc = """
-                    GLFW has not been initialized.
-
-                    This occurs if a GLFW function was called that must not be called unless the
-                    library is initialized.
-
-                    ###### Analysis
-                    Application programmer error.  Initialize GLFW before calling any
-                    function that requires initialization.
-                """.trimIndent()
-            )
-            "GLFW_NO_CURRENT_CONTEXT"(
-                "0x00010002",
-                javadoc = """
-                    No context is current for this thread.
-
-                    This occurs if a GLFW function was called that needs and operates on the
-                    current OpenGL or OpenGL ES context but no context is current on the calling
-                    thread.  One such function is [glfwSwapInterval][#glfwSwapInterval(int)].
-
-                    ###### Analysis
-                    Application programmer error.  Ensure a context is current before
-                    calling functions that require a current context.
-                """.trimIndent()
-            )
-            "GLFW_INVALID_ENUM"(
-                "0x00010003",
-                javadoc = """
-                    One of the arguments to the function was an invalid enum value.
-
-                    One of the arguments to the function was an invalid enum value, for example
-                    requesting [GLFW_RED_BITS][#GLFW_RED_BITS] with [glfwGetWindowAttrib][#glfwGetWindowAttrib(MemorySegment, int)].
-
-                    ###### Analysis
-                    Application programmer error.  Fix the offending call.
-                """.trimIndent()
-            )
-            "GLFW_INVALID_VALUE"(
-                "0x00010004",
-                javadoc = """
-                    One of the arguments to the function was an invalid value.
-
-                    One of the arguments to the function was an invalid value, for example
-                    requesting a non-existent OpenGL or OpenGL ES version like 2.7.
-
-                    Requesting a valid but unavailable OpenGL or OpenGL ES version will instead
-                    result in a [GLFW_VERSION_UNAVAILABLE][#GLFW_VERSION_UNAVAILABLE] error.
-
-                    ###### Analysis
-                    Application programmer error.  Fix the offending call.
-                """.trimIndent()
-            )
-            "GLFW_OUT_OF_MEMORY"(
-                "0x00010005",
-                javadoc = """
-                    A memory allocation failed.
-
-                    ###### Analysis
-                    A bug in GLFW or the underlying operating system.  Report the bug
-                    to our [issue tracker](https://github.com/glfw/glfw/issues).
-                """.trimIndent()
-            )
-            "GLFW_API_UNAVAILABLE"(
-                "0x00010006",
-                javadoc = """
-                    GLFW could not find support for the requested API on the system.
-
-                    ###### Analysis
-                    The installed graphics driver does not support the requested
-                    API, or does not support it via the chosen context creation API.
-                    Below are a few examples.
-
-                    Some pre-installed Windows graphics drivers do not support OpenGL.  AMD only
-                    supports OpenGL ES via EGL, while Nvidia and Intel only support it via
-                    a WGL or GLX extension.  macOS does not provide OpenGL ES at all.  The Mesa
-                    EGL, OpenGL and OpenGL ES libraries do not interface with the Nvidia binary
-                    driver.  Older graphics drivers do not support Vulkan.
-                """.trimIndent()
-            )
-            "GLFW_VERSION_UNAVAILABLE"(
-                "0x00010007",
-                javadoc = """
-                    The requested OpenGL or OpenGL ES version is not available.
-
-                    The requested OpenGL or OpenGL ES version (including any requested context
-                    or framebuffer hints) is not available on this machine.
-
-                    ###### Analysis
-                    The machine does not support your requirements.  If your
-                    application is sufficiently flexible, downgrade your requirements and try
-                    again.  Otherwise, inform the user that their machine does not match your
-                    requirements.
-                """.trimIndent()
-            )
-            "GLFW_PLATFORM_ERROR"(
-                "0x00010008",
-                javadoc = """
-                    A platform-specific error occurred that does not match any of the more
-                    specific categories.
-
-                    ###### Analysis
-                    A bug or configuration error in GLFW, the underlying operating
-                    system or its drivers, or a lack of required resources.  Report the issue to
-                    our [issue tracker](https://github.com/glfw/glfw/issues).
-                """.trimIndent()
-            )
-            "GLFW_FORMAT_UNAVAILABLE"(
-                "0x00010009",
-                javadoc = """
-                    The requested format is not supported or available.
-
-                    If emitted during window creation, the requested pixel format is not
-                    supported.
-
-                    If emitted when querying the clipboard, the contents of the clipboard could
-                    not be converted to the requested format.
-
-                    ###### Analysis
-                    If emitted during window creation, one or more
-                    hard constraints did not match any of the
-                    available pixel formats.  If your application is sufficiently flexible,
-                    downgrade your requirements and try again.  Otherwise, inform the user that
-                    their machine does not match your requirements.
-
-                    If emitted when querying the clipboard, ignore the error or report it to
-                    the user, as appropriate.
-                """.trimIndent()
-            )
-            "GLFW_NO_WINDOW_CONTEXT"(
-                "0x0001000A",
-                javadoc = """
-                    The specified window does not have an OpenGL or OpenGL ES context.
-
-                    A window that does not have an OpenGL or OpenGL ES context was passed to
-                    a function that requires it to have one.
-
-                    ###### Analysis
-                    Application programmer error.  Fix the offending call.
-                """.trimIndent()
-            )
-            "GLFW_CURSOR_UNAVAILABLE"(
-                "0x0001000B",
-                javadoc = """
-                    The specified cursor shape is not available.
-
-                    The specified standard cursor shape is not available, either because the
-                    current platform cursor theme does not provide it or because it is not
-                    available on the platform.
-
-                    ###### Analysis
-                    Platform or system settings limitation.  Pick another
-                    standard cursor shape or create a
-                    custom cursor.
-                """.trimIndent()
-            )
-            "GLFW_FEATURE_UNAVAILABLE"(
-                "0x0001000C",
-                javadoc = """
-                    The requested feature is not provided by the platform.
-
-                    The requested feature is not provided by the platform, so GLFW is unable to
-                    implement it.  The documentation for each function notes if it could emit
-                    this error.
-
-                    ###### Analysis
-                    Platform or platform version limitation.  The error can be ignored
-                    unless the feature is critical to the application.
-
-                    A function call that emits this error has no effect other than the error and
-                    updating any existing out parameters.
-                """.trimIndent()
-            )
-            "GLFW_FEATURE_UNIMPLEMENTED"(
-                "0x0001000D",
-                javadoc = """
-                    The requested feature is not implemented for the platform.
-
-                    The requested feature has not yet been implemented in GLFW for this platform.
-
-                    ###### Analysis
-                    An incomplete implementation of GLFW for this platform, hopefully
-                    fixed in a future release.  The error can be ignored unless the feature is
-                    critical to the application.
-
-                    A function call that emits this error has no effect other than the error and
-                    updating any existing out parameters.
-                """.trimIndent()
-            )
-            "GLFW_PLATFORM_UNAVAILABLE"(
-                "0x0001000E",
-                javadoc = """
-                    Platform unavailable or no matching platform was found.
-
-                    If emitted during initialization, no matching platform was found.  If the
-                    [GLFW_PLATFORM][#GLFW_PLATFORM] init hint was set to `GLFW_ANY_PLATFORM`, GLFW could not detect any of
-                    the platforms supported by this library binary, except for the Null platform.  If the
-                    init hint was set to a specific platform, it is either not supported by this library
-                    binary or GLFW was not able to detect it.
-
-                    If emitted by a native access function, GLFW was initialized for a different platform
-                    than the function is for.
-
-                    ###### Analysis
-                    Failure to detect any platform usually only happens on non-macOS Unix
-                    systems, either when no window system is running or the program was run from
-                    a terminal that does not have the necessary environment variables.  Fall back to
-                    a different platform if possible or notify the user that no usable platform was
-                    detected.
-
-                    Failure to detect a specific platform may have the same cause as above or be because
-                    support for that platform was not compiled in.  Call [glfwPlatformSupported][#glfwPlatformSupported(int)] to
-                    check whether a specific platform is supported by a library binary.
-                """.trimIndent()
-            )
+        int {
+            "GLFW_NO_ERROR"("0")
+            "GLFW_NOT_INITIALIZED"("0x00010001")
+            "GLFW_NO_CURRENT_CONTEXT"("0x00010002")
+            "GLFW_INVALID_ENUM"("0x00010003")
+            "GLFW_INVALID_VALUE"("0x00010004")
+            "GLFW_OUT_OF_MEMORY"("0x00010005")
+            "GLFW_API_UNAVAILABLE"("0x00010006")
+            "GLFW_VERSION_UNAVAILABLE"("0x00010007")
+            "GLFW_PLATFORM_ERROR"("0x00010008")
+            "GLFW_FORMAT_UNAVAILABLE"("0x00010009")
+            "GLFW_NO_WINDOW_CONTEXT"("0x0001000A")
+            "GLFW_CURSOR_UNAVAILABLE"("0x0001000B")
+            "GLFW_FEATURE_UNAVAILABLE"("0x0001000C")
+            "GLFW_FEATURE_UNIMPLEMENTED"("0x0001000D")
+            "GLFW_PLATFORM_UNAVAILABLE"("0x0001000E")
         }
 
-        int("GLFW_FOCUSED" to "0x00020001", javadoc = "Input focus window hint and attribute")
-        int("GLFW_ICONIFIED" to "0x00020002", javadoc = "Window iconification window attribute")
-        int("GLFW_RESIZABLE" to "0x00020003", javadoc = "Window resize-ability window hint and attribute")
-        int("GLFW_VISIBLE" to "0x00020004", javadoc = "Window visibility window hint and attribute")
-        int("GLFW_DECORATED" to "0x00020005", javadoc = "Window decoration window hint and attribute")
-        int("GLFW_AUTO_ICONIFY" to "0x00020006", javadoc = "Window auto-iconification window hint and attribute")
-        int("GLFW_FLOATING" to "0x00020007", javadoc = "Window decoration window hint and attribute")
-        int("GLFW_MAXIMIZED" to "0x00020008", javadoc = "Window maximization window hint and attribute")
-        int("GLFW_CENTER_CURSOR" to "0x00020009", javadoc = "Cursor centering window hint")
-        int(
-            "GLFW_TRANSPARENT_FRAMEBUFFER" to "0x0002000A",
-            javadoc = "Window framebuffer transparency hint and attribute"
-        )
-        int("GLFW_HOVERED" to "0x0002000B", javadoc = "Mouse cursor hover window attribute.")
-        int("GLFW_FOCUS_ON_SHOW" to "0x0002000C", javadoc = "Input focus on calling show window hint and attribute")
+        int("GLFW_FOCUSED" to "0x00020001")
+        int("GLFW_ICONIFIED" to "0x00020002")
+        int("GLFW_RESIZABLE" to "0x00020003")
+        int("GLFW_VISIBLE" to "0x00020004")
+        int("GLFW_DECORATED" to "0x00020005")
+        int("GLFW_AUTO_ICONIFY" to "0x00020006")
+        int("GLFW_FLOATING" to "0x00020007")
+        int("GLFW_MAXIMIZED" to "0x00020008")
+        int("GLFW_CENTER_CURSOR" to "0x00020009")
+        int("GLFW_TRANSPARENT_FRAMEBUFFER" to "0x0002000A")
+        int("GLFW_HOVERED" to "0x0002000B")
+        int("GLFW_FOCUS_ON_SHOW" to "0x0002000C")
 
-        int("GLFW_MOUSE_PASSTHROUGH" to "0x0002000D", javadoc = "Mouse input transparency window hint and attribute")
+        int("GLFW_MOUSE_PASSTHROUGH" to "0x0002000D")
 
-        int("GLFW_POSITION_X" to "0x0002000E", javadoc = "Initial position x-coordinate window hint.")
-        int("GLFW_POSITION_Y" to "0x0002000F", javadoc = "Initial position y-coordinate window hint.")
+        int("GLFW_POSITION_X" to "0x0002000E")
+        int("GLFW_POSITION_Y" to "0x0002000F")
 
-        int("GLFW_RED_BITS" to "0x00021001", javadoc = "Framebuffer bit depth hint.")
-        int("GLFW_GREEN_BITS" to "0x00021002", javadoc = "Framebuffer bit depth hint.")
-        int("GLFW_BLUE_BITS" to "0x00021003", javadoc = "Framebuffer bit depth hint.")
-        int("GLFW_ALPHA_BITS" to "0x00021004", javadoc = "Framebuffer bit depth hint.")
-        int("GLFW_DEPTH_BITS" to "0x00021005", javadoc = "Framebuffer bit depth hint.")
-        int("GLFW_STENCIL_BITS" to "0x00021006", javadoc = "Framebuffer bit depth hint.")
-        int("GLFW_ACCUM_RED_BITS" to "0x00021007", javadoc = "Framebuffer bit depth hint.")
-        int("GLFW_ACCUM_GREEN_BITS" to "0x00021008", javadoc = "Framebuffer bit depth hint.")
-        int("GLFW_ACCUM_BLUE_BITS" to "0x00021009", javadoc = "Framebuffer bit depth hint.")
-        int("GLFW_ACCUM_ALPHA_BITS" to "0x0002100A", javadoc = "Framebuffer bit depth hint.")
-        int("GLFW_AUX_BUFFERS" to "0x0002100B", javadoc = "Framebuffer auxiliary buffer hint.")
-        int("GLFW_STEREO" to "0x0002100C", javadoc = "OpenGL stereoscopic rendering hint.")
-        int("GLFW_SAMPLES" to "0x0002100D", javadoc = "Framebuffer MSAA samples hint.")
-        int("GLFW_SRGB_CAPABLE" to "0x0002100E", javadoc = "Framebuffer sRGB hint.")
-        int("GLFW_REFRESH_RATE" to "0x0002100F", javadoc = "Monitor refresh rate hint.")
-        int("GLFW_DOUBLEBUFFER" to "0x00021010", javadoc = "Framebuffer double buffering hint and attribute.")
+        int("GLFW_RED_BITS" to "0x00021001")
+        int("GLFW_GREEN_BITS" to "0x00021002")
+        int("GLFW_BLUE_BITS" to "0x00021003")
+        int("GLFW_ALPHA_BITS" to "0x00021004")
+        int("GLFW_DEPTH_BITS" to "0x00021005")
+        int("GLFW_STENCIL_BITS" to "0x00021006")
+        int("GLFW_ACCUM_RED_BITS" to "0x00021007")
+        int("GLFW_ACCUM_GREEN_BITS" to "0x00021008")
+        int("GLFW_ACCUM_BLUE_BITS" to "0x00021009")
+        int("GLFW_ACCUM_ALPHA_BITS" to "0x0002100A")
+        int("GLFW_AUX_BUFFERS" to "0x0002100B")
+        int("GLFW_STEREO" to "0x0002100C")
+        int("GLFW_SAMPLES" to "0x0002100D")
+        int("GLFW_SRGB_CAPABLE" to "0x0002100E")
+        int("GLFW_REFRESH_RATE" to "0x0002100F")
+        int("GLFW_DOUBLEBUFFER" to "0x00021010")
 
-        int("GLFW_CLIENT_API" to "0x00022001", javadoc = "Context client API hint and attribute.")
-        int(
-            "GLFW_CONTEXT_VERSION_MAJOR" to "0x00022002",
-            javadoc = "Context client API major version hint and attribute."
-        )
-        int(
-            "GLFW_CONTEXT_VERSION_MINOR" to "0x00022003",
-            javadoc = "Context client API minor version hint and attribute."
-        )
-        int("GLFW_CONTEXT_REVISION" to "0x00022004", javadoc = "Context client API revision number attribute.")
-        int("GLFW_CONTEXT_ROBUSTNESS" to "0x00022005", javadoc = "Context robustness hint and attribute.")
-        int("GLFW_OPENGL_FORWARD_COMPAT" to "0x00022006", javadoc = "OpenGL forward-compatibility hint and attribute.")
-        int("GLFW_CONTEXT_DEBUG" to "0x00022007", javadoc = "Debug mode context hint and attribute.")
-        int(
-            "GLFW_OPENGL_DEBUG_CONTEXT" to "GLFW_CONTEXT_DEBUG",
-            javadoc = """
-                Legacy name for compatibility.
-
-                This is an alias for compatibility with earlier versions.
-            """.trimIndent()
-        )
-        int("GLFW_OPENGL_PROFILE" to "0x00022008", javadoc = "OpenGL profile hint and attribute.")
-        int("GLFW_CONTEXT_RELEASE_BEHAVIOR" to "0x00022009", javadoc = "Context flush-on-release hint and attribute.")
-        int("GLFW_CONTEXT_NO_ERROR" to "0x0002200A", javadoc = "Context error suppression hint and attribute.")
-        int("GLFW_CONTEXT_CREATION_API" to "0x0002200B", javadoc = "Context creation API hint and attribute.")
-        int("GLFW_SCALE_TO_MONITOR" to "0x0002200C", javadoc = "Window content area scaling window hint.")
-        int("GLFW_SCALE_FRAMEBUFFER" to "0x0002200D", javadoc = "Window framebuffer scaling window hint.")
-        int(
-            "GLFW_COCOA_RETINA_FRAMEBUFFER" to "0x00023001",
-            javadoc = """
-                Legacy name for compatibility.
-
-                This is an alias for the
-                [GLFW_SCALE_FRAMEBUFFER][#GLFW_SCALE_FRAMEBUFFER] window hint for
-                compatibility with earlier versions.
-            """.trimIndent()
-        )
-        int("GLFW_COCOA_FRAME_NAME" to "0x00023002", javadoc = "macOS specific window hint.")
-        int("GLFW_COCOA_GRAPHICS_SWITCHING" to "0x00023003", javadoc = "macOS specific window hint.")
-        int("GLFW_X11_CLASS_NAME" to "0x00024001", javadoc = "X11 specific window hint.")
-        int("GLFW_X11_INSTANCE_NAME" to "0x00024002", javadoc = "X11 specific window hint.")
-        int("GLFW_WIN32_KEYBOARD_MENU" to "0x00025001", javadoc = "Win32 specific window hint.")
-        int("GLFW_WIN32_SHOWDEFAULT" to "0x00025002", javadoc = "Win32 specific window hint.")
-        int(
-            "GLFW_WAYLAND_APP_ID" to "0x00026001",
-            javadoc = """
-                Wayland specific window hint.
-
-                Allows specification of the Wayland app_id.
-            """.trimIndent()
-        )
+        int("GLFW_CLIENT_API" to "0x00022001")
+        int("GLFW_CONTEXT_VERSION_MAJOR" to "0x00022002")
+        int("GLFW_CONTEXT_VERSION_MINOR" to "0x00022003")
+        int("GLFW_CONTEXT_REVISION" to "0x00022004")
+        int("GLFW_CONTEXT_ROBUSTNESS" to "0x00022005")
+        int("GLFW_OPENGL_FORWARD_COMPAT" to "0x00022006")
+        int("GLFW_CONTEXT_DEBUG" to "0x00022007")
+        int("GLFW_OPENGL_DEBUG_CONTEXT" to "GLFW_CONTEXT_DEBUG")
+        int("GLFW_OPENGL_PROFILE" to "0x00022008")
+        int("GLFW_CONTEXT_RELEASE_BEHAVIOR" to "0x00022009")
+        int("GLFW_CONTEXT_NO_ERROR" to "0x0002200A")
+        int("GLFW_CONTEXT_CREATION_API" to "0x0002200B")
+        int("GLFW_SCALE_TO_MONITOR" to "0x0002200C")
+        int("GLFW_SCALE_FRAMEBUFFER" to "0x0002200D")
+        int("GLFW_COCOA_RETINA_FRAMEBUFFER" to "0x00023001")
+        int("GLFW_COCOA_FRAME_NAME" to "0x00023002")
+        int("GLFW_COCOA_GRAPHICS_SWITCHING" to "0x00023003")
+        int("GLFW_X11_CLASS_NAME" to "0x00024001")
+        int("GLFW_X11_INSTANCE_NAME" to "0x00024002")
+        int("GLFW_WIN32_KEYBOARD_MENU" to "0x00025001")
+        int("GLFW_WIN32_SHOWDEFAULT" to "0x00025002")
+        int("GLFW_WAYLAND_APP_ID" to "0x00026001")
 
         int {
             "GLFW_NO_API"("0")
@@ -1733,138 +577,34 @@ fun main() {
             "GLFW_ANY_POSITION"("0x80000000")
         }
 
-        int(
-            javadoc = """
-            Standard system cursor shapes.
-
-            These are the standard cursor shapes] that can be
-            requested from the platform (window system).
-        """.trimIndent()
-        ) {
-            "GLFW_ARROW_CURSOR"("0x00036001", javadoc = "The regular arrow cursor shape.")
-            "GLFW_IBEAM_CURSOR"("0x00036002", javadoc = "The text input I-beam cursor shape.")
-            "GLFW_CROSSHAIR_CURSOR"("0x00036003", javadoc = "The crosshair cursor shape.")
-            "GLFW_POINTING_HAND_CURSOR"("0x00036004", javadoc = "The pointing hand cursor shape.")
-            "GLFW_RESIZE_EW_CURSOR"(
-                "0x00036005",
-                javadoc = """
-                    The horizontal resize/move arrow shape.
-
-                    The horizontal resize/move arrow shape.  This is usually a horizontal
-                    double-headed arrow.
-                """.trimIndent()
-            )
-            "GLFW_RESIZE_NS_CURSOR"(
-                "0x00036006",
-                javadoc = """
-                    The vertical resize/move arrow shape.
-
-                    The vertical resize/move shape.  This is usually a vertical double-headed
-                    arrow.
-                """.trimIndent()
-            )
-            "GLFW_RESIZE_NWSE_CURSOR"(
-                "0x00036007",
-                javadoc = """
-                    The top-left to bottom-right diagonal resize/move arrow shape.
-
-                    The top-left to bottom-right diagonal resize/move shape.  This is usually
-                    a diagonal double-headed arrow.
-
-                    ###### Note
-                    - __macOS:__ This shape is provided by a private system API and may fail
-                        with [GLFW_CURSOR_UNAVAILABLE][#GLFW_CURSOR_UNAVAILABLE] in the future.
-                    - __Wayland:__ This shape is provided by a newer standard not supported by
-                        all cursor themes.
-                    - __X11:__ This shape is provided by a newer standard not supported by all
-                        cursor themes.
-                """.trimIndent()
-            )
-            "GLFW_RESIZE_NESW_CURSOR"(
-                "0x00036008",
-                javadoc = """
-                    The top-right to bottom-left diagonal resize/move arrow shape.
-
-                    The top-right to bottom-left diagonal resize/move shape.  This is usually
-                    a diagonal double-headed arrow.
-
-                    ###### Note
-                    - __macOS:__ This shape is provided by a private system API and may fail
-                        with [GLFW_CURSOR_UNAVAILABLE][#GLFW_CURSOR_UNAVAILABLE] in the future.
-                    - __Wayland:__ This shape is provided by a newer standard not supported by
-                        all cursor themes.
-                    - __X11:__ This shape is provided by a newer standard not supported by all
-                        cursor themes.
-                """.trimIndent()
-            )
-            "GLFW_RESIZE_ALL_CURSOR"(
-                "0x00036009",
-                javadoc = """
-                    The omni-directional resize/move cursor shape.
-
-                    The omni-directional resize cursor/move shape.  This is usually either
-                    a combined horizontal and vertical double-headed arrow or a grabbing hand.
-                """.trimIndent()
-            )
-            "GLFW_NOT_ALLOWED_CURSOR"(
-                "0x0003600A",
-                javadoc = """
-                    The operation-not-allowed shape.
-
-                    The operation-not-allowed shape.  This is usually a circle with a diagonal
-                    line through it.
-
-                    ###### Note
-                    - __Wayland:__ This shape is provided by a newer standard not supported by
-                        all cursor themes.
-                    - __X11:__ This shape is provided by a newer standard not supported by all
-                        cursor themes.
-                """.trimIndent()
-            )
-            "GLFW_HRESIZE_CURSOR"(
-                "GLFW_RESIZE_EW_CURSOR",
-                javadoc = """
-                    Legacy name for compatibility.
-
-                    This is an alias for compatibility with earlier versions.
-                """.trimIndent()
-            )
-            "GLFW_VRESIZE_CURSOR"(
-                "GLFW_RESIZE_NS_CURSOR",
-                javadoc = """
-                    Legacy name for compatibility.
-
-                    This is an alias for compatibility with earlier versions.
-                """.trimIndent()
-            )
-            "GLFW_HAND_CURSOR"(
-                "GLFW_POINTING_HAND_CURSOR",
-                javadoc = """
-                    Legacy name for compatibility.
-
-                    This is an alias for compatibility with earlier versions.
-                """.trimIndent()
-            )
+        int {
+            "GLFW_ARROW_CURSOR"("0x00036001")
+            "GLFW_IBEAM_CURSOR"("0x00036002")
+            "GLFW_CROSSHAIR_CURSOR"("0x00036003")
+            "GLFW_POINTING_HAND_CURSOR"("0x00036004")
+            "GLFW_RESIZE_EW_CURSOR"("0x00036005")
+            "GLFW_RESIZE_NS_CURSOR"("0x00036006")
+            "GLFW_RESIZE_NWSE_CURSOR"("0x00036007")
+            "GLFW_RESIZE_NESW_CURSOR"("0x00036008")
+            "GLFW_RESIZE_ALL_CURSOR"("0x00036009")
+            "GLFW_NOT_ALLOWED_CURSOR"("0x0003600A")
+            "GLFW_HRESIZE_CURSOR"("GLFW_RESIZE_EW_CURSOR")
+            "GLFW_VRESIZE_CURSOR"("GLFW_RESIZE_NS_CURSOR")
+            "GLFW_HAND_CURSOR"("GLFW_POINTING_HAND_CURSOR")
         }
 
         int("GLFW_CONNECTED" to "0x00040001")
         int("GLFW_DISCONNECTED" to "0x00040002")
 
-        int("GLFW_JOYSTICK_HAT_BUTTONS" to "0x00050001", javadoc = "Joystick hat buttons init hint.")
-        int("GLFW_ANGLE_PLATFORM_TYPE" to "0x00050002", javadoc = "ANGLE rendering backend init hint.")
-        int("GLFW_PLATFORM" to "0x00050003", javadoc = "Platform selection init hint.")
-        int("GLFW_COCOA_CHDIR_RESOURCES" to "0x00051001", javadoc = "macOS specific init hint.")
-        int("GLFW_COCOA_MENUBAR" to "0x00051002", javadoc = "macOS specific init hint.")
-        int("GLFW_X11_XCB_VULKAN_SURFACE" to "0x00052001", javadoc = "X11 specific init hint.")
-        int("GLFW_WAYLAND_LIBDECOR" to "0x00053001", javadoc = "Wayland specific init hint.")
+        int("GLFW_JOYSTICK_HAT_BUTTONS" to "0x00050001")
+        int("GLFW_ANGLE_PLATFORM_TYPE" to "0x00050002")
+        int("GLFW_PLATFORM" to "0x00050003")
+        int("GLFW_COCOA_CHDIR_RESOURCES" to "0x00051001")
+        int("GLFW_COCOA_MENUBAR" to "0x00051002")
+        int("GLFW_X11_XCB_VULKAN_SURFACE" to "0x00052001")
+        int("GLFW_WAYLAND_LIBDECOR" to "0x00053001")
 
-        int(
-            javadoc = """
-            Hint value that enables automatic platform selection.
-
-            Hint value for [GLFW_PLATFORM][#GLFW_PLATFORM] that enables automatic platform selection.
-        """.trimIndent()
-        ) {
+        int {
             "GLFW_ANY_PLATFORM"("0x00060000")
             "GLFW_PLATFORM_WIN32"("0x00060001")
             "GLFW_PLATFORM_COCOA"("0x00060002")
@@ -1879,421 +619,49 @@ fun main() {
 
         //region GLFW API functions
 
-        +"glfwInit"(
-            glfw_boolean,
-            entrypoint = "glfwInit",
-            javadoc = """
-                Initializes the GLFW library.
-
-                This function initializes the GLFW library.  Before most GLFW functions can
-                be used, GLFW must be initialized, and before an application terminates GLFW
-                should be terminated in order to free any resources allocated during or
-                after initialization.
-
-                If this function fails, it calls [glfwTerminate][#glfwTerminate()] before returning.  If it
-                succeeds, you should call [glfwTerminate][#glfwTerminate()] before the application exits.
-
-                Additional calls to this function after successful initialization but before
-                termination will return `GLFW_TRUE` immediately.
-
-                The [GLFW_PLATFORM][#GLFW_PLATFORM] init hint controls which platforms are considered during
-                initialization.  This also depends on which platforms the library was compiled to
-                support.
-
-                @return `GLFW_TRUE` if successful, or `GLFW_FALSE` if an
-                error occurred.
-
-                @glfw.errors Possible errors include [GLFW_PLATFORM_UNAVAILABLE][#GLFW_PLATFORM_UNAVAILABLE] and
-                [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-
-                @glfw.remark
-                - __macOS:__ This function will change the current directory of the
-                    application to the `Contents/Resources` subdirectory of the application's
-                    bundle, if present.  This can be disabled with the
-                    [GLFW_COCOA_CHDIR_RESOURCES][#GLFW_COCOA_CHDIR_RESOURCES] init hint.
-
-                    This function will create the main menu and dock icon for the
-                    application.  If GLFW finds a `MainMenu.nib` it is loaded and assumed to
-                    contain a menu bar.  Otherwise a minimal menu bar is created manually with
-                    common commands like Hide, Quit and About.  The About entry opens a minimal
-                    about dialog with information from the application's bundle.  The menu bar
-                    and dock icon can be disabled entirely with the [GLFW_COCOA_MENUBAR][#GLFW_COCOA_MENUBAR] init
-                    hint.
-                - __Wayland, X11:__ If the library was compiled with support for both
-                    Wayland and X11, and the [GLFW_PLATFORM][#GLFW_PLATFORM] init hint is set to
-                    `GLFW_ANY_PLATFORM`, the `XDG_SESSION_TYPE` environment variable affects
-                    which platform is picked.  If the environment variable is not set, or is set
-                    to something other than `wayland` or `x11`, the regular detection mechanism
-                    will be used instead.
-                - __X11:__ This function will set the `LC_CTYPE` category of the
-                    application locale according to the current environment if that category is
-                    still "C".  This is because the "C" locale breaks Unicode text input.
-
-                @glfw.thread_safety This function must only be called from the main thread.
-
-                @see #glfwInitHint(int, int) glfwInitHint
-                @see #glfwInitAllocator(MemorySegment) glfwInitAllocator
-                @see #glfwTerminate() glfwTerminate
-            """.trimIndent(),
-            addNow = false
-        ).overload()
-
-        "glfwTerminate"(
-            void,
-            entrypoint = "glfwTerminate",
-            javadoc = """
-                Terminates the GLFW library.
-
-                This function destroys all remaining windows and cursors, restores any
-                modified gamma ramps and frees any other allocated resources.  Once this
-                function is called, you must again call [glfwInit][#glfwInit()] successfully before
-                you will be able to use most GLFW functions.
-
-                If GLFW has been successfully initialized, this function should be called
-                before the application exits.  If initialization fails, there is no need to
-                call this function, as it is called by [glfwInit][#glfwInit()] before it returns
-                failure.
-
-                This function has no effect if GLFW is not initialized.
-
-                @glfw.errors Possible errors include [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-
-                @glfw.remark This function may be called before [glfwInit][#glfwInit()].
-
-                @glfw.warning The contexts of any remaining windows must not be current on any
-                other thread when this function is called.
-
-                @glfw.reentrancy This function must not be called from a callback.
-
-                @glfw.thread_safety This function must only be called from the main thread.
-
-                @see #glfwInit() glfwInit
-            """.trimIndent()
-        )
-
-        "glfwInitHint"(
-            void,
-            int("hint"),
-            int("value"),
-            entrypoint = "glfwInitHint",
-            javadoc = """
-                Sets the specified init hint to the desired value.
-
-                This function sets hints for the next initialization of GLFW.
-
-                The values you set hints to are never reset by GLFW, but they only take
-                effect during initialization.  Once GLFW has been initialized, any values
-                you set will be ignored until the library is terminated and initialized
-                again.
-
-                Some hints are platform specific.  These may be set on any platform but they
-                will only affect their specific platform.  Other platforms will ignore them.
-                Setting these hints requires no platform specific headers or functions.
-
-                @param hint The init hint to set.
-                @param value The new value of the init hint.
-
-                @glfw.errors Possible errors include [GLFW_INVALID_ENUM][#GLFW_INVALID_ENUM] and
-                [GLFW_INVALID_VALUE][#GLFW_INVALID_VALUE].
-
-                @glfw.remark This function may be called before [glfwInit][#glfwInit()].
-
-                @glfw.thread_safety This function must only be called from the main thread.
-
-                @see #glfwInit() glfwInit
-            """.trimIndent()
-        )
-
-        +"glfwInitAllocator"(
-            void,
-            const_GLFWallocator_ptr("allocator"),
-            entrypoint = "glfwInitAllocator",
-            javadoc = """
-                Sets the init allocator to the desired value.
-
-                To use the default allocator, call this function with a `NULL` argument.
-
-                If you specify an allocator struct, every member must be a valid function
-                pointer.  If any member is `NULL`, this function will emit
-                [GLFW_INVALID_VALUE][#GLFW_INVALID_VALUE] and the init allocator will be unchanged.
-
-                The functions in the allocator must fulfil a number of requirements.  See the
-                documentation for [GLFWAllocateFun], [GLFWReallocateFun] and
-                [GLFWDeallocateFun] for details.
-
-                @param allocator The allocator to use at the next initialization, or
-                `NULL` to use the default one.
-
-                @glfw.errors Possible errors include [GLFW_INVALID_VALUE][#GLFW_INVALID_VALUE].
-
-                @glfw.pointer_lifetime The specified allocator is copied before this function
-                returns.
-
-                @glfw.thread_safety This function must only be called from the main thread.
-
-                @see #glfwInit() glfwInit
-            """.trimIndent()
-        ).overload()
-
+        +"glfwInit"(glfw_boolean, entrypoint = "glfwInit", addNow = false).overload()
+        "glfwTerminate"(void, entrypoint = "glfwTerminate")
+        "glfwInitHint"(void, int("hint"), int("value"), entrypoint = "glfwInitHint")
+        +"glfwInitAllocator"(void, const_GLFWallocator_ptr("allocator"), entrypoint = "glfwInitAllocator").overload()
         +"glfwGetVersion"(
             void,
             int_ptr("major").ref(),
             int_ptr("minor").ref(),
             int_ptr("rev").ref(),
-            entrypoint = "glfwGetVersion",
-            javadoc = """
-                Retrieves the version of the GLFW library.
-
-                This function retrieves the major, minor and revision numbers of the GLFW
-                library.  It is intended for when you are using GLFW as a shared library and
-                want to ensure that you are using the minimum required version.
-
-                Any or all of the version arguments may be `NULL`.
-
-                @param major Where to store the major version number, or `NULL`.
-                @param minor Where to store the minor version number, or `NULL`.
-                @param rev Where to store the revision number, or `NULL`.
-
-                @glfw.errors None.
-
-                @glfw.remark This function may be called before [glfwInit][#glfwInit()].
-
-                @glfw.thread_safety This function may be called from any thread.
-
-                @see #glfwGetVersionString() glfwGetVersionString
-            """.trimIndent()
+            entrypoint = "glfwGetVersion"
         ).overload()
-
         +"glfwGetVersionString_"(
             const_char_ptr,
-            entrypoint = "glfwGetVersionString",
-            javadoc = """
-                Returns a string describing the compile-time configuration.
-
-                This function returns the compile-time generated
-                version string of the GLFW library binary.  It describes
-                the version, platforms, compiler and any platform or operating system specific
-                compile-time options.  It should not be confused with the OpenGL or OpenGL ES version
-                string, queried with `glGetString`.
-
-                __Do not use the version string__ to parse the GLFW library version.  The
-                [glfwGetVersion][#glfwGetVersion(MemorySegment, MemorySegment, MemorySegment)] function provides the version of the running library
-                binary in numerical format.
-
-                __Do not use the version string__ to parse what platforms are supported.  The
-                [glfwPlatformSupported][#glfwPlatformSupported(int)] function lets you query platform support.
-
-                @return The ASCII encoded GLFW version string.
-
-                @glfw.errors None.
-
-                @glfw.remark This function may be called before [glfwInit][#glfwInit()].
-
-                @glfw.pointer_lifetime The returned string is static and compile-time generated.
-
-                @glfw.thread_safety This function may be called from any thread.
-
-                @see #glfwGetVersion(MemorySegment, MemorySegment, MemorySegment) glfwGetVersion
-            """.trimIndent()
+            entrypoint = "glfwGetVersionString"
         ).overload(name = "glfwGetVersionString")
-
         +"glfwGetError"(
             int,
             (string_u8_array c "const char**")("description").ref(),
-            entrypoint = "glfwGetError",
-            javadoc = """
-                Returns and clears the last error for the calling thread.
-
-                This function returns and clears the error code of the last
-                error that occurred on the calling thread, and optionally a UTF-8 encoded
-                human-readable description of it.  If no error has occurred since the last
-                call, it returns [GLFW_NO_ERROR][#GLFW_NO_ERROR] (zero) and the description pointer is
-                set to `NULL`.
-
-                @param description Where to store the error description pointer, or `NULL`.
-                @return The last error code for the calling thread, or [GLFW_NO_ERROR][#GLFW_NO_ERROR]
-                (zero).
-
-                @glfw.errors None.
-
-                @glfw.pointer_lifetime The returned string is allocated and freed by GLFW.  You
-                should not free it yourself.  It is guaranteed to be valid only until the
-                next error occurs or the library is terminated.
-
-                @glfw.remark This function may be called before [glfwInit][#glfwInit()].
-
-                @glfw.thread_safety This function may be called from any thread.
-
-                @see #glfwSetErrorCallback(MemorySegment) glfwSetErrorCallback
-            """.trimIndent()
+            entrypoint = "glfwGetError"
         ).overload()
-
         +"glfwSetErrorCallback"(
             address c "GLFWerrorfun",
             GLFWerrorfun("callback"),
-            entrypoint = "glfwSetErrorCallback",
-            javadoc = """
-                Sets the error callback.
-
-                This function sets the error callback, which is called with an error code
-                and a human-readable description each time a GLFW error occurs.
-
-                The error code is set before the callback is called.  Calling
-                [glfwGetError][#glfwGetError(MemorySegment)] from the error callback will return the same value as the error
-                code argument.
-
-                The error callback is called on the thread where the error occurred.  If you
-                are using GLFW from multiple threads, your error callback needs to be
-                written accordingly.
-
-                Because the description string may have been generated specifically for that
-                error, it is not guaranteed to be valid after the callback has returned.  If
-                you wish to use it after the callback returns, you need to make a copy.
-
-                Once set, the error callback remains set even after the library has been
-                terminated.
-
-                @param callback The new callback, or `NULL` to remove the currently set
-                callback.
-                @return The previously set callback, or `NULL` if no callback was set.
-
-                @glfw.callback_signature
-                For more information about the callback parameters, see the
-                [callback pointer type][GLFWErrorFun].
-
-                @glfw.errors None.
-
-                @glfw.remark This function may be called before [glfwInit][#glfwInit()].
-
-                @glfw.thread_safety This function must only be called from the main thread.
-
-                @see #glfwGetError(MemorySegment) glfwGetError
-            """.trimIndent()
+            entrypoint = "glfwSetErrorCallback"
         ).callbackOverload("Arena.global()")
-
-        "glfwGetPlatform"(
-            int,
-            entrypoint = "glfwGetPlatform",
-            javadoc = """
-                Returns the currently selected platform.
-
-                This function returns the platform that was selected during initialization.  The
-                returned value will be one of `GLFW_PLATFORM_WIN32`, `GLFW_PLATFORM_COCOA`,
-                `GLFW_PLATFORM_WAYLAND`, `GLFW_PLATFORM_X11` or `GLFW_PLATFORM_NULL`.
-
-                @return The currently selected platform, or zero if an error occurred.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-
-                @glfw.thread_safety This function may be called from any thread.
-
-                @see #glfwPlatformSupported(int) glfwPlatformSupported
-            """.trimIndent()
-        )
-
+        "glfwGetPlatform"(int, entrypoint = "glfwGetPlatform")
         +"glfwPlatformSupported"(
             glfw_boolean,
             int("platform"),
             entrypoint = "glfwPlatformSupported",
-            javadoc = """
-                Returns whether the library includes support for the specified platform.
-
-                This function returns whether the library was compiled with support for the specified
-                platform.  The platform must be one of `GLFW_PLATFORM_WIN32`, `GLFW_PLATFORM_COCOA`,
-                `GLFW_PLATFORM_WAYLAND`, `GLFW_PLATFORM_X11` or `GLFW_PLATFORM_NULL`.
-
-                @param platform The platform to query.
-                @return `GLFW_TRUE` if the platform is supported, or `GLFW_FALSE` otherwise.
-
-                @glfw.errors Possible errors include [GLFW_INVALID_ENUM][#GLFW_INVALID_ENUM].
-
-                @glfw.remark This function may be called before [glfwInit][#glfwInit()].
-
-                @glfw.thread_safety This function may be called from any thread.
-
-                @see #glfwGetPlatform() glfwGetPlatform
-            """.trimIndent(),
             addNow = false
         ).overload()
 
         //region Monitor
-        "glfwGetMonitors"(
-            (address c "GLFWmonitor**"),
-            int_ptr("count").ref(),
-            entrypoint = "glfwGetMonitors",
-            javadoc = """
-                Returns the currently connected monitors.
-
-                This function returns an array of handles for all currently connected
-                monitors.  The primary monitor is always first in the returned array.  If no
-                monitors were found, this function returns `NULL`.
-
-                @param count Where to store the number of monitors in the returned
-                array.  This is set to zero if an error occurred.
-                @return An array of monitor handles, or `NULL` if no monitors were found or
-                if an error occurred.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-
-                @glfw.pointer_lifetime The returned array is allocated and freed by GLFW.  You
-                should not free it yourself.  It is guaranteed to be valid only until the
-                monitor configuration changes or the library is terminated.
-
-                @glfw.thread_safety This function must only be called from the main thread.
-
-                @see #glfwGetPrimaryMonitor() glfwGetPrimaryMonitor
-            """.trimIndent()
-        )
-
-        "glfwGetPrimaryMonitor"(
-            GLFWmonitor_ptr,
-            entrypoint = "glfwGetPrimaryMonitor",
-            javadoc = """
-                Returns the primary monitor.
-
-                This function returns the primary monitor.  This is usually the monitor
-                where elements like the task bar or global menu bar are located.
-
-                @return The primary monitor, or `NULL` if no monitors were found or if an
-                error occurred.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-
-                @glfw.thread_safety This function must only be called from the main thread.
-
-                @glfw.remark The primary monitor is always first in the array returned by @ref
-                glfwGetMonitors.
-
-                @see #glfwGetMonitors(MemorySegment) glfwGetMonitors
-            """.trimIndent()
-        )
-
+        "glfwGetMonitors"((address c "GLFWmonitor**"), int_ptr("count").ref(), entrypoint = "glfwGetMonitors")
+        "glfwGetPrimaryMonitor"(GLFWmonitor_ptr, entrypoint = "glfwGetPrimaryMonitor")
         +"glfwGetMonitorPos"(
             void,
             GLFWmonitor_ptr("monitor"),
             int_ptr("xpos").ref(),
             int_ptr("ypos").ref(),
-            entrypoint = "glfwGetMonitorPos",
-            javadoc = """
-                Returns the position of the monitor's viewport on the virtual screen.
-
-                This function returns the position, in screen coordinates, of the upper-left
-                corner of the specified monitor.
-
-                Any or all of the position arguments may be `NULL`.  If an error occurs, all
-                non-`NULL` position arguments will be set to zero.
-
-                @param monitor The monitor to query.
-                @param xpos Where to store the monitor x-coordinate, or `NULL`.
-                @param ypos Where to store the monitor y-coordinate, or `NULL`.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-                [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-
-                @glfw.thread_safety This function must only be called from the main thread.
-            """.trimIndent()
+            entrypoint = "glfwGetMonitorPos"
         ).overload()
-
         +"glfwGetMonitorWorkarea"(
             void,
             GLFWmonitor_ptr("monitor"),
@@ -2301,202 +669,36 @@ fun main() {
             int_ptr("ypos").ref(),
             int_ptr("width").ref(),
             int_ptr("height").ref(),
-            entrypoint = "glfwGetMonitorWorkarea",
-            javadoc = """
-                Retrieves the work area of the monitor.
-
-                This function returns the position, in screen coordinates, of the upper-left
-                corner of the work area of the specified monitor along with the work area
-                size in screen coordinates. The work area is defined as the area of the
-                monitor not occluded by the window system task bar where present. If no
-                task bar exists then the work area is the monitor resolution in screen
-                coordinates.
-
-                Any or all of the position and size arguments may be `NULL`.  If an error
-                occurs, all non-`NULL` position and size arguments will be set to zero.
-
-                @param monitor The monitor to query.
-                @param xpos Where to store the monitor x-coordinate, or `NULL`.
-                @param ypos Where to store the monitor y-coordinate, or `NULL`.
-                @param width Where to store the monitor width, or `NULL`.
-                @param height Where to store the monitor height, or `NULL`.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-                [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-
-                @glfw.thread_safety This function must only be called from the main thread.
-            """.trimIndent()
+            entrypoint = "glfwGetMonitorWorkarea"
         ).overload()
-
         +"glfwGetMonitorPhysicalSize"(
             void,
             GLFWmonitor_ptr("monitor"),
             int_ptr("widthMM").ref(),
             int_ptr("heightMM").ref(),
-            entrypoint = "glfwGetMonitorPhysicalSize",
-            javadoc = """
-                Returns the physical size of the monitor.
-
-                This function returns the size, in millimetres, of the display area of the
-                specified monitor.
-
-                Some platforms do not provide accurate monitor size information, either
-                because the monitor [EDID](https://en.wikipedia.org/wiki/Extended_display_identification_data) data is incorrect or because the driver does
-                not report it accurately.
-
-                Any or all of the size arguments may be `NULL`.  If an error occurs, all
-                non-`NULL` size arguments will be set to zero.
-
-                @param monitor The monitor to query.
-                @param widthMM Where to store the width, in millimetres, of the
-                monitor's display area, or `NULL`.
-                @param heightMM Where to store the height, in millimetres, of the
-                monitor's display area, or `NULL`.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-
-                @glfw.remark __Windows:__ On Windows 8 and earlier the physical size is calculated from
-                the current resolution and system DPI instead of querying the monitor EDID data.
-
-                @glfw.thread_safety This function must only be called from the main thread.
-            """.trimIndent()
+            entrypoint = "glfwGetMonitorPhysicalSize"
         ).overload()
-
         +"glfwGetMonitorContentScale"(
             void,
             GLFWmonitor_ptr("monitor"),
             float_ptr("xscale").ref(),
             float_ptr("yscale").ref(),
-            entrypoint = "glfwGetMonitorContentScale",
-            javadoc = """
-                Retrieves the content scale for the specified monitor.
-
-                This function retrieves the content scale for the specified monitor.  The
-                content scale is the ratio between the current DPI and the platform's
-                default DPI.  This is especially important for text and any UI elements.  If
-                the pixel dimensions of your UI scaled by this look appropriate on your
-                machine then it should appear at a reasonable size on other machines
-                regardless of their DPI and scaling settings.  This relies on the system DPI
-                and scaling settings being somewhat correct.
-
-                The content scale may depend on both the monitor resolution and pixel
-                density and on user settings.  It may be very different from the raw DPI
-                calculated from the physical size and current resolution.
-
-                @param monitor The monitor to query.
-                @param xscale Where to store the x-axis content scale, or `NULL`.
-                @param yscale Where to store the y-axis content scale, or `NULL`.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-                [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-
-                @glfw.remark __Wayland:__ Fractional scaling information is not yet available for
-                monitors, so this function only returns integer content scales.
-
-                @glfw.thread_safety This function must only be called from the main thread.
-
-                @see #glfwGetWindowContentScale(MemorySegment, MemorySegment, MemorySegment) glfwGetWindowContentScale
-            """.trimIndent()
+            entrypoint = "glfwGetMonitorContentScale"
         ).overload()
-
-        +"glfwGetMonitorName_"(
-            const_char_ptr,
-            GLFWmonitor_ptr("monitor"),
-            entrypoint = "glfwGetMonitorName",
-            javadoc = """
-                Returns the name of the specified monitor.
-
-                This function returns a human-readable name, encoded as UTF-8, of the
-                specified monitor.  The name typically reflects the make and model of the
-                monitor and is not guaranteed to be unique among the connected monitors.
-
-                @param monitor The monitor to query.
-                @return The UTF-8 encoded name of the monitor, or `NULL` if an
-                error occurred.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-                @glfw.pointer_lifetime The returned string is allocated and freed by GLFW.  You
-                should not free it yourself.  It is valid until the specified monitor is
-                disconnected or the library is terminated.
-                @glfw.thread_safety This function must only be called from the main thread.
-            """.trimIndent()
-        ).overload(name = "glfwGetMonitorName")
-
+        +"glfwGetMonitorName_"(const_char_ptr, GLFWmonitor_ptr("monitor"), entrypoint = "glfwGetMonitorName").overload(
+            name = "glfwGetMonitorName"
+        )
         "glfwSetMonitorUserPointer"(
             void,
             GLFWmonitor_ptr("monitor"),
             void_ptr("pointer"),
-            entrypoint = "glfwSetMonitorUserPointer",
-            javadoc = """
-                Sets the user pointer of the specified monitor.
-
-                This function sets the user-defined pointer of the specified monitor.  The
-                current value is retained until the monitor is disconnected.  The initial
-                value is `NULL`.
-
-                This function may be called from the monitor callback, even for a monitor
-                that is being disconnected.
-
-                @param monitor The monitor whose pointer to set.
-                @param pointer The new value.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-
-                @glfw.thread_safety This function may be called from any thread.  Access is not
-                synchronized.
-
-                @see #glfwGetMonitorUserPointer(MemorySegment) glfwGetMonitorUserPointer
-            """.trimIndent()
+            entrypoint = "glfwSetMonitorUserPointer"
         )
-
-        "glfwGetMonitorUserPointer"(
-            void_ptr,
-            GLFWmonitor_ptr("monitor"),
-            entrypoint = "glfwGetMonitorUserPointer",
-            javadoc = """
-                Returns the user pointer of the specified monitor.
-
-                This function returns the current value of the user-defined pointer of the
-                specified monitor.  The initial value is `NULL`.
-
-                This function may be called from the monitor callback, even for a monitor
-                that is being disconnected.
-
-                @param monitor The monitor whose pointer to return.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-
-                @glfw.thread_safety This function may be called from any thread.  Access is not
-                synchronized.
-
-                @see #glfwSetMonitorUserPointer(MemorySegment, MemorySegment) glfwSetMonitorUserPointer
-            """.trimIndent()
-        )
-
+        "glfwGetMonitorUserPointer"(void_ptr, GLFWmonitor_ptr("monitor"), entrypoint = "glfwGetMonitorUserPointer")
         +"glfwSetMonitorCallback"(
             address c "GLFWmonitorfun",
             GLFWmonitorfun("callback"),
-            entrypoint = "glfwSetMonitorCallback",
-            javadoc = """
-                Sets the monitor configuration callback.
-
-                This function sets the monitor configuration callback, or removes the
-                currently set callback.  This is called when a monitor is connected to or
-                disconnected from the system.
-
-                @param callback The new callback, or `NULL` to remove the currently set
-                callback.
-                @return The previously set callback, or `NULL` if no callback was set or the
-                library had not been initialized.
-
-                @glfw.callback_signature
-                For more information about the callback parameters, see the
-                [function pointer type][GLFWMonitorFun].
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-
-                @glfw.thread_safety This function must only be called from the main thread.
-            """.trimIndent()
+            entrypoint = "glfwSetMonitorCallback"
         ).callbackOverload("Arena.global()")
         //endregion
 
@@ -2504,258 +706,33 @@ fun main() {
             address c "const GLFWvidmode*",
             GLFWmonitor_ptr("monitor"),
             int_ptr("count").ref(),
-            entrypoint = "glfwGetVideoModes",
-            javadoc = """
-                Returns the available video modes for the specified monitor.
-
-                This function returns an array of all video modes supported by the specified
-                monitor.  The returned array is sorted in ascending order, first by color
-                bit depth (the sum of all channel depths), then by resolution area (the
-                product of width and height), then resolution width and finally by refresh
-                rate.
-
-                @param monitor The monitor to query.
-                @param count Where to store the number of video modes in the returned
-                array.  This is set to zero if an error occurred.
-                @return An array of video modes, or `NULL` if an
-                error occurred.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-                [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-
-                @glfw.pointer_lifetime The returned array is allocated and freed by GLFW.  You
-                should not free it yourself.  It is valid until the specified monitor is
-                disconnected, this function is called again for that monitor or the library
-                is terminated.
-
-                @glfw.thread_safety This function must only be called from the main thread.
-
-                @see #glfwGetVideoMode(MemorySegment) glfwGetVideoMode
-            """.trimIndent()
+            entrypoint = "glfwGetVideoModes"
         )
-
         +"glfwGetVideoMode_"(
             const_GLFWvidmode_ptr,
             GLFWmonitor_ptr("monitor"),
-            entrypoint = "glfwGetVideoMode",
-            javadoc = """
-                Returns the current mode of the specified monitor.
-
-                This function returns the current video mode of the specified monitor.  If
-                you have created a full screen window for that monitor, the return value
-                will depend on whether that window is iconified.
-
-                @param monitor The monitor to query.
-                @return The current mode of the monitor, or `NULL` if an
-                error occurred.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-                [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-
-                @glfw.pointer_lifetime The returned array is allocated and freed by GLFW.  You
-                should not free it yourself.  It is valid until the specified monitor is
-                disconnected or the library is terminated.
-
-                @glfw.thread_safety This function must only be called from the main thread.
-
-                @see #glfwGetVideoModes(MemorySegment, MemorySegment) glfwGetVideoModes
-            """.trimIndent()
+            entrypoint = "glfwGetVideoMode"
         ).overload(name = "glfwGetVideoMode")
-
-        "glfwSetGamma"(
-            void,
-            GLFWmonitor_ptr("monitor"),
-            float("gamma"),
-            entrypoint = "glfwSetGamma",
-            javadoc = """
-                Generates a gamma ramp and sets it for the specified monitor.
-
-                This function generates an appropriately sized gamma ramp from the specified
-                exponent and then calls [glfwSetGammaRamp][#glfwSetGammaRamp(MemorySegment, MemorySegment)] with it.  The value must be
-                a finite number greater than zero.
-
-                The software controlled gamma ramp is applied _in addition_ to the hardware
-                gamma correction, which today is usually an approximation of sRGB gamma.
-                This means that setting a perfectly linear ramp, or gamma 1.0, will produce
-                the default (usually sRGB-like) behavior.
-
-                For gamma correct rendering with OpenGL or OpenGL ES, see the
-                [GLFW_SRGB_CAPABLE][#GLFW_SRGB_CAPABLE] hint.
-
-                @param monitor The monitor whose gamma ramp to set.
-                @param gamma The desired exponent.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED], [GLFW_INVALID_VALUE][#GLFW_INVALID_VALUE],
-                [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR] and [GLFW_FEATURE_UNAVAILABLE][#GLFW_FEATURE_UNAVAILABLE] (see remarks).
-
-                @glfw.remark __Wayland:__ Gamma handling is a privileged protocol, this function
-                will thus never be implemented and emits [GLFW_FEATURE_UNAVAILABLE][#GLFW_FEATURE_UNAVAILABLE].
-
-                @glfw.thread_safety This function must only be called from the main thread.
-            """.trimIndent()
-        )
-
+        "glfwSetGamma"(void, GLFWmonitor_ptr("monitor"), float("gamma"), entrypoint = "glfwSetGamma")
         +"glfwGetGammaRamp_"(
             const_GLFWgammaramp_ptr,
             GLFWmonitor_ptr("monitor"),
-            entrypoint = "glfwGetGammaRamp",
-            javadoc = """
-                Returns the current gamma ramp for the specified monitor.
-
-                This function returns the current gamma ramp of the specified monitor.
-
-                @param monitor The monitor to query.
-                @return The current gamma ramp, or `NULL` if an
-                error occurred.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED], [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR]
-                and [GLFW_FEATURE_UNAVAILABLE][#GLFW_FEATURE_UNAVAILABLE] (see remarks).
-
-                @glfw.remark __Wayland:__ Gamma handling is a privileged protocol, this function
-                will thus never be implemented and emits [GLFW_FEATURE_UNAVAILABLE][#GLFW_FEATURE_UNAVAILABLE] while
-                returning `NULL`.
-
-                @glfw.pointer_lifetime The returned structure and its arrays are allocated and
-                freed by GLFW.  You should not free them yourself.  They are valid until the
-                specified monitor is disconnected, this function is called again for that
-                monitor or the library is terminated.
-
-                @glfw.thread_safety This function must only be called from the main thread.
-            """.trimIndent()
+            entrypoint = "glfwGetGammaRamp"
         ).overload(name = "glfwGetGammaRamp")
-
         +"glfwSetGammaRamp"(
             void,
             GLFWmonitor_ptr("monitor"),
             const_GLFWgammaramp_ptr("ramp"),
-            entrypoint = "glfwSetGammaRamp",
-            javadoc = """
-                Sets the current gamma ramp for the specified monitor.
-
-                This function sets the current gamma ramp for the specified monitor.  The
-                original gamma ramp for that monitor is saved by GLFW the first time this
-                function is called and is restored by [glfwTerminate][#glfwTerminate()].
-
-                The software controlled gamma ramp is applied _in addition_ to the hardware
-                gamma correction, which today is usually an approximation of sRGB gamma.
-                This means that setting a perfectly linear ramp, or gamma 1.0, will produce
-                the default (usually sRGB-like) behavior.
-
-                For gamma correct rendering with OpenGL or OpenGL ES, see the
-                [GLFW_SRGB_CAPABLE][#GLFW_SRGB_CAPABLE] hint.
-
-                @param monitor The monitor whose gamma ramp to set.
-                @param ramp The gamma ramp to use.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED], [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR]
-                and [GLFW_FEATURE_UNAVAILABLE][#GLFW_FEATURE_UNAVAILABLE] (see remarks).
-
-                @glfw.remark The size of the specified gamma ramp should match the size of the
-                current ramp for that monitor.
-                - __Windows:__ The gamma ramp size must be 256.
-                - __Wayland:__ Gamma handling is a privileged protocol, this function
-                    will thus never be implemented and emits [GLFW_FEATURE_UNAVAILABLE][#GLFW_FEATURE_UNAVAILABLE].
-
-                @glfw.pointer_lifetime The specified gamma ramp is copied before this function
-                returns.
-
-                @glfw.thread_safety This function must only be called from the main thread.
-            """.trimIndent()
+            entrypoint = "glfwSetGammaRamp"
         ).overload()
-
-        "glfwDefaultWindowHints"(
-            void,
-            entrypoint = "glfwDefaultWindowHints",
-            javadoc = """
-                Resets all window hints to their default values.
-
-                This function resets all window hints to their
-                default values.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-
-                @glfw.thread_safety This function must only be called from the main thread.
-
-                @see #glfwWindowHint(int, int) glfwWindowHint
-                @see #glfwWindowHintString(int, MemorySegment) glfwWindowHintString
-            """.trimIndent()
-        )
-
-        "glfwWindowHint"(
-            void,
-            int("hint"),
-            int("value"),
-            entrypoint = "glfwWindowHint",
-            javadoc = """
-                Sets the specified window hint to the desired value.
-
-                This function sets hints for the next call to [glfwCreateWindow][#glfwCreateWindow(int, int, MemorySegment, MemorySegment, MemorySegment)].  The
-                hints, once set, retain their values until changed by a call to this
-                function or [glfwDefaultWindowHints][#glfwDefaultWindowHints()], or until the library is terminated.
-
-                Only integer value hints can be set with this function.  String value hints
-                are set with [glfwWindowHintString][#glfwWindowHintString(int, MemorySegment)].
-
-                This function does not check whether the specified hint values are valid.
-                If you set hints to invalid values this will instead be reported by the next
-                call to [glfwCreateWindow][#glfwCreateWindow(int, int, MemorySegment, MemorySegment, MemorySegment)].
-
-                Some hints are platform specific.  These may be set on any platform but they
-                will only affect their specific platform.  Other platforms will ignore them.
-                Setting these hints requires no platform specific headers or functions.
-
-                @param hint The window hint to set.
-                @param value The new value of the window hint.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-                [GLFW_INVALID_ENUM][#GLFW_INVALID_ENUM].
-
-                @glfw.thread_safety This function must only be called from the main thread.
-
-                @see #glfwWindowHintString(int, MemorySegment) glfwWindowHintString
-                @see #glfwDefaultWindowHints() glfwDefaultWindowHints
-            """.trimIndent()
-        )
-
+        "glfwDefaultWindowHints"(void, entrypoint = "glfwDefaultWindowHints")
+        "glfwWindowHint"(void, int("hint"), int("value"), entrypoint = "glfwWindowHint")
         +"glfwWindowHintString"(
             void,
             int("hint"),
             const_char_ptr("value"),
-            entrypoint = "glfwWindowHintString",
-            javadoc = """
-                Sets the specified window hint to the desired value.
-
-                This function sets hints for the next call to [glfwCreateWindow][#glfwCreateWindow(int, int, MemorySegment, MemorySegment, MemorySegment)].  The
-                hints, once set, retain their values until changed by a call to this
-                function or [glfwDefaultWindowHints][#glfwDefaultWindowHints()], or until the library is terminated.
-
-                Only string type hints can be set with this function.  Integer value hints
-                are set with [glfwWindowHint][#glfwWindowHint(int, int)].
-
-                This function does not check whether the specified hint values are valid.
-                If you set hints to invalid values this will instead be reported by the next
-                call to [glfwCreateWindow][#glfwCreateWindow(int, int, MemorySegment, MemorySegment, MemorySegment)].
-
-                Some hints are platform specific.  These may be set on any platform but they
-                will only affect their specific platform.  Other platforms will ignore them.
-                Setting these hints requires no platform specific headers or functions.
-
-                @param hint The window hint to set.
-                @param value The new value of the window hint.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-                [GLFW_INVALID_ENUM][#GLFW_INVALID_ENUM].
-
-                @glfw.pointer_lifetime The specified string is copied before this function
-                returns.
-
-                @glfw.thread_safety This function must only be called from the main thread.
-
-                @see #glfwWindowHint(int, int) glfwWindowHint
-                @see #glfwDefaultWindowHints() glfwDefaultWindowHints
-            """.trimIndent()
+            entrypoint = "glfwWindowHintString"
         ).overload()
-
         +"glfwCreateWindow"(
             GLFWwindow_ptr,
             int("width"),
@@ -2763,418 +740,53 @@ fun main() {
             const_char_ptr("title"),
             GLFWmonitor_ptr("monitor"),
             GLFWwindow_ptr("share"),
-            entrypoint = "glfwCreateWindow",
-            javadoc = """
-                Creates a window and its associated context.
-
-                This function creates a window and its associated OpenGL or OpenGL ES
-                context.  Most of the options controlling how the window and its context
-                should be created are specified with window hints.
-
-                Successful creation does not change which context is current.  Before you
-                can use the newly created context, you need to
-                make it current.  For information about the `share`
-                parameter, see context_sharing.
-
-                The created window, framebuffer and context may differ from what you
-                requested, as not all parameters and hints are
-                hard constraints.  This includes the size of the
-                window, especially for full screen windows.  To query the actual attributes
-                of the created window, framebuffer and context, see
-                [glfwGetWindowAttrib][#glfwGetWindowAttrib(MemorySegment, int)], [glfwGetWindowSize][#glfwGetWindowSize(MemorySegment, MemorySegment, MemorySegment)] and [glfwGetFramebufferSize][#glfwGetFramebufferSize(MemorySegment, MemorySegment, MemorySegment)].
-
-                To create a full screen window, you need to specify the monitor the window
-                will cover.  If no monitor is specified, the window will be windowed mode.
-                Unless you have a way for the user to choose a specific monitor, it is
-                recommended that you pick the primary monitor.  For more information on how
-                to query connected monitors, see monitor_monitors.
-
-                For full screen windows, the specified size becomes the resolution of the
-                window's _desired video mode_.  As long as a full screen window is not
-                iconified, the supported video mode most closely matching the desired video
-                mode is set for the specified monitor.  For more information about full
-                screen windows, including the creation of so called _windowed full screen_
-                or _borderless full screen_ windows, see window_windowed_full_screen.
-
-                Once you have created the window, you can switch it between windowed and
-                full screen mode with [glfwSetWindowMonitor][#glfwSetWindowMonitor(MemorySegment, MemorySegment, int, int, int, int, int)].  This will not affect its
-                OpenGL or OpenGL ES context.
-
-                By default, newly created windows use the placement recommended by the
-                window system.  To create the window at a specific position, set the
-                [GLFW_POSITION_X][#GLFW_POSITION_X] and [GLFW_POSITION_Y][#GLFW_POSITION_Y] window hints before creation.  To
-                restore the default behavior, set either or both hints back to
-                `GLFW_ANY_POSITION`.
-
-                As long as at least one full screen window is not iconified, the screensaver
-                is prohibited from starting.
-
-                Window systems put limits on window sizes.  Very large or very small window
-                dimensions may be overridden by the window system on creation.  Check the
-                actual size after creation.
-
-                The swap interval is not set during window creation and
-                the initial value may vary depending on driver settings and defaults.
-
-                @param width The desired width, in screen coordinates, of the window.
-                This must be greater than zero.
-                @param height The desired height, in screen coordinates, of the window.
-                This must be greater than zero.
-                @param title The initial, UTF-8 encoded window title.
-                @param monitor The monitor to use for full screen mode, or `NULL` for
-                windowed mode.
-                @param share The window whose context to share resources with, or `NULL`
-                to not share resources.
-                @return The handle of the created window, or `NULL` if an
-                error occurred.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED],
-                [GLFW_INVALID_ENUM][#GLFW_INVALID_ENUM], [GLFW_INVALID_VALUE][#GLFW_INVALID_VALUE], [GLFW_API_UNAVAILABLE][#GLFW_API_UNAVAILABLE],
-                [GLFW_VERSION_UNAVAILABLE][#GLFW_VERSION_UNAVAILABLE], [GLFW_FORMAT_UNAVAILABLE][#GLFW_FORMAT_UNAVAILABLE],
-                [GLFW_NO_WINDOW_CONTEXT][#GLFW_NO_WINDOW_CONTEXT] and [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-
-                @glfw.remark
-                - __Windows:__ Window creation will fail if the Microsoft GDI software
-                    OpenGL implementation is the only one available.
-
-                    If the executable has an icon resource named `GLFW_ICON,` it
-                    will be set as the initial icon for the window.  If no such icon is present,
-                    the `IDI_APPLICATION` icon will be used instead.  To set a different icon,
-                    see [glfwSetWindowIcon][#glfwSetWindowIcon(MemorySegment, int, MemorySegment)].
-
-                    The context to share resources with must not be current on
-                    any other thread.
-                - __macOS:__ The OS only supports core profile contexts for OpenGL
-                    versions 3.2 and later.  Before creating an OpenGL context of version 3.2 or
-                    later you must set the [GLFW_OPENGL_PROFILE][#GLFW_OPENGL_PROFILE]
-                    hint accordingly.  OpenGL 3.0 and 3.1 contexts are not supported at all
-                    on macOS.
-
-                    The GLFW window has no icon, as it is not a document
-                    window, but the dock icon will be the same as the application bundle's icon.
-                    For more information on bundles, see the
-                    [Bundle Programming Guide](https://developer.apple.com/library/mac/documentation/CoreFoundation/Conceptual/CFBundles/) in the Mac Developer Library.
-
-                    The window frame will not be rendered at full resolution on
-                    Retina displays unless the
-                    [GLFW_SCALE_FRAMEBUFFER][#GLFW_SCALE_FRAMEBUFFER]
-                    hint is `GLFW_TRUE` and the `NSHighResolutionCapable` key is enabled in the
-                    application bundle's `Info.plist`.  For more information, see
-                    [High Resolution Guidelines for OS X](https://developer.apple.com/library/mac/documentation/GraphicsAnimation/Conceptual/HighResolutionOSX/Explained/Explained.html) in the Mac Developer
-                    Library.  The GLFW test and example programs use a custom `Info.plist`
-                    template for this, which can be found as `CMake/Info.plist.in` in the source
-                    tree.
-
-                    When activating frame autosaving with
-                    [GLFW_COCOA_FRAME_NAME][#GLFW_COCOA_FRAME_NAME], the specified
-                    window size and position may be overridden by previously saved values.
-                - __Wayland:__ GLFW uses [libdecor](https://gitlab.freedesktop.org/libdecor/libdecor) where available to create its window
-                    decorations.  This in turn uses server-side XDG decorations where available
-                    and provides high quality client-side decorations on compositors like GNOME.
-                    If both XDG decorations and libdecor are unavailable, GLFW falls back to
-                    a very simple set of window decorations that only support moving, resizing
-                    and the window manager's right-click menu.
-                - __X11:__ Some window managers will not respect the placement of
-                    initially hidden windows.
-
-                    Due to the asynchronous nature of X11, it may take a moment for
-                    a window to reach its requested state.  This means you may not be able to
-                    query the final size, position or other attributes directly after window
-                    creation.
-
-                    The class part of the `WM_CLASS` window property will by
-                    default be set to the window title passed to this function.  The instance
-                    part will use the contents of the `RESOURCE_NAME` environment variable, if
-                    present and not empty, or fall back to the window title.  Set the
-                    [GLFW_X11_CLASS_NAME][#GLFW_X11_CLASS_NAME] and
-                    [GLFW_X11_INSTANCE_NAME][#GLFW_X11_INSTANCE_NAME] window hints to
-                    override this.
-
-                @glfw.thread_safety This function must only be called from the main thread.
-
-                @see #glfwDestroyWindow(MemorySegment) glfwDestroyWindow
-            """.trimIndent()
+            entrypoint = "glfwCreateWindow"
         ).overload()
-
-        "glfwDestroyWindow"(
-            void,
-            GLFWwindow_ptr("window"),
-            entrypoint = "glfwDestroyWindow",
-            javadoc = """
-                Destroys the specified window and its context.
-
-                This function destroys the specified window and its context.  On calling
-                this function, no further callbacks will be called for that window.
-
-                If the context of the specified window is current on the main thread, it is
-                detached before being destroyed.
-
-                @param window The window to destroy.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-                [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-
-                @glfw.note The context of the specified window must not be current on any other
-                thread when this function is called.
-
-                @glfw.reentrancy This function must not be called from a callback.
-
-                @glfw.thread_safety This function must only be called from the main thread.
-
-                @see #glfwCreateWindow(int, int, MemorySegment, MemorySegment, MemorySegment) glfwCreateWindow
-            """.trimIndent()
-        )
-
+        "glfwDestroyWindow"(void, GLFWwindow_ptr("window"), entrypoint = "glfwDestroyWindow")
         +"glfwWindowShouldClose"(
             glfw_boolean,
             GLFWwindow_ptr("window"),
             entrypoint = "glfwWindowShouldClose",
-            javadoc = """
-                Checks the close flag of the specified window.
-
-                This function returns the value of the close flag of the specified window.
-
-                @param window The window to query.
-                @return The value of the close flag.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-
-                @glfw.thread_safety This function may be called from any thread.  Access is not
-                synchronized.
-            """.trimIndent(),
             addNow = false
         ).overload()
-
         +"glfwSetWindowShouldClose"(
             void,
             GLFWwindow_ptr("window"),
             glfw_boolean("value"),
             entrypoint = "glfwSetWindowShouldClose",
-            javadoc = """
-                Sets the close flag of the specified window.
-
-                This function sets the value of the close flag of the specified window.
-                This can be used to override the user's attempt to close the window, or
-                to signal that it should be closed.
-
-                @param window The window whose flag to change.
-                @param value The new value.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-
-                @glfw.thread_safety This function may be called from any thread.  Access is not
-                synchronized.
-            """.trimIndent(),
             addNow = false
         ).overload()
-
-        +"glfwGetWindowTitle_"(
-            const_char_ptr,
-            GLFWwindow_ptr("window"),
-            entrypoint = "glfwGetWindowTitle",
-            javadoc = """
-                Returns the title of the specified window.
-
-                This function returns the window title, encoded as UTF-8, of the specified
-                window.  This is the title set previously by [glfwCreateWindow][#glfwCreateWindow(int, int, MemorySegment, MemorySegment, MemorySegment)]
-                or [glfwSetWindowTitle][#glfwSetWindowTitle(MemorySegment, MemorySegment)].
-
-                @param window The window to query.
-                @return The UTF-8 encoded window title, or `NULL` if an
-                error occurred.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-
-                @glfw.remark The returned title is currently a copy of the title last set by
-                [glfwCreateWindow][#glfwCreateWindow(int, int, MemorySegment, MemorySegment, MemorySegment)] or [glfwSetWindowTitle][#glfwSetWindowTitle(MemorySegment, MemorySegment)].  It does not include any
-                additional text which may be appended by the platform or another program.
-
-                @glfw.pointer_lifetime The returned string is allocated and freed by GLFW.  You
-                should not free it yourself.  It is valid until the next call to
-                `glfwGetWindowTitle` or [glfwSetWindowTitle][#glfwSetWindowTitle(MemorySegment, MemorySegment)], or until the library is
-                terminated.
-
-                @glfw.thread_safety This function must only be called from the main thread.
-
-                @see #glfwSetWindowTitle(MemorySegment, MemorySegment) glfwSetWindowTitle
-            """.trimIndent()
-        ).overload(name = "glfwGetWindowTitle")
-
+        +"glfwGetWindowTitle_"(const_char_ptr, GLFWwindow_ptr("window"), entrypoint = "glfwGetWindowTitle").overload(
+            name = "glfwGetWindowTitle"
+        )
         +"glfwSetWindowTitle"(
             void,
             GLFWwindow_ptr("window"),
             const_char_ptr("title"),
-            entrypoint = "glfwSetWindowTitle",
-            javadoc = """
-                Sets the title of the specified window.
-
-                This function sets the window title, encoded as UTF-8, of the specified
-                window.
-
-                @param window The window whose title to change.
-                @param title The UTF-8 encoded window title.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-                [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-
-                @glfw.remark __macOS:__ The window title will not be updated until the next time you
-                process events.
-
-                @glfw.thread_safety This function must only be called from the main thread.
-
-                @see #glfwGetWindowTitle(MemorySegment) glfwGetWindowTitle
-            """.trimIndent()
+            entrypoint = "glfwSetWindowTitle"
         ).overload()
-
         +"glfwSetWindowIcon"(
             void,
             GLFWwindow_ptr("window"),
             int("count"),
             const_GLFWimage_ptr("images"),
-            entrypoint = "glfwSetWindowIcon",
-            javadoc = """
-                Sets the icon for the specified window.
-
-                This function sets the icon of the specified window.  If passed an array of
-                candidate images, those of or closest to the sizes desired by the system are
-                selected.  If no images are specified, the window reverts to its default
-                icon.
-
-                The pixels are 32-bit, little-endian, non-premultiplied RGBA, i.e. eight
-                bits per channel with the red channel first.  They are arranged canonically
-                as packed sequential rows, starting from the top-left corner.
-
-                The desired image sizes varies depending on platform and system settings.
-                The selected images will be rescaled as needed.  Good sizes include 16x16,
-                32x32 and 48x48.
-
-                @param window The window whose icon to set.
-                @param count The number of images in the specified array, or zero to
-                revert to the default window icon.
-                @param images The images to create the icon from.  This is ignored if
-                count is zero.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED],
-                [GLFW_INVALID_VALUE][#GLFW_INVALID_VALUE], [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR] and
-                [GLFW_FEATURE_UNAVAILABLE][#GLFW_FEATURE_UNAVAILABLE] (see remarks).
-
-                @glfw.pointer_lifetime The specified image data is copied before this function
-                returns.
-
-                @glfw.remark
-                - __macOS:__ Regular windows do not have icons on macOS.  This function
-                    will emit [GLFW_FEATURE_UNAVAILABLE][#GLFW_FEATURE_UNAVAILABLE].  The dock icon will be the same as
-                    the application bundle's icon.  For more information on bundles, see the
-                    [Bundle Programming Guide](https://developer.apple.com/library/mac/documentation/CoreFoundation/Conceptual/CFBundles/) in the Mac Developer Library.
-                - __Wayland:__ There is no existing protocol to change an icon, the
-                    window will thus inherit the one defined in the application's desktop file.
-                    This function will emit [GLFW_FEATURE_UNAVAILABLE][#GLFW_FEATURE_UNAVAILABLE].
-
-                @glfw.thread_safety This function must only be called from the main thread.
-            """.trimIndent()
+            entrypoint = "glfwSetWindowIcon"
         ).overload()
-
         +"glfwGetWindowPos"(
             void,
             GLFWwindow_ptr("window"),
             int_ptr("xpos").ref(),
             int_ptr("ypos").ref(),
-            entrypoint = "glfwGetWindowPos",
-            javadoc = """
-                Retrieves the position of the content area of the specified window.
-
-                This function retrieves the position, in screen coordinates, of the
-                upper-left corner of the content area of the specified window.
-
-                Any or all of the position arguments may be `NULL`.  If an error occurs, all
-                non-`NULL` position arguments will be set to zero.
-
-                @param window The window to query.
-                @param xpos Where to store the x-coordinate of the upper-left corner of
-                the content area, or `NULL`.
-                @param ypos Where to store the y-coordinate of the upper-left corner of
-                the content area, or `NULL`.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED],
-                [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR] and [GLFW_FEATURE_UNAVAILABLE][#GLFW_FEATURE_UNAVAILABLE] (see remarks).
-
-                @glfw.remark __Wayland:__ There is no way for an application to retrieve the global
-                position of its windows.  This function will emit
-                [GLFW_FEATURE_UNAVAILABLE][#GLFW_FEATURE_UNAVAILABLE].
-
-                @glfw.thread_safety This function must only be called from the main thread.
-
-                @see #glfwSetWindowPos(MemorySegment, int, int) glfwSetWindowPos
-            """.trimIndent()
+            entrypoint = "glfwGetWindowPos"
         ).overload()
-
-        "glfwSetWindowPos"(
-            void,
-            GLFWwindow_ptr("window"),
-            int("xpos"),
-            int("ypos"),
-            entrypoint = "glfwSetWindowPos",
-            javadoc = """
-                Sets the position of the content area of the specified window.
-
-                This function sets the position, in screen coordinates, of the upper-left
-                corner of the content area of the specified windowed mode window.  If the
-                window is a full screen window, this function does nothing.
-
-                __Do not use this function__ to move an already visible window unless you
-                have very good reasons for doing so, as it will confuse and annoy the user.
-
-                The window manager may put limits on what positions are allowed.  GLFW
-                cannot and should not override these limits.
-
-                @param window The window to query.
-                @param xpos The x-coordinate of the upper-left corner of the content area.
-                @param ypos The y-coordinate of the upper-left corner of the content area.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED],
-                [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR] and [GLFW_FEATURE_UNAVAILABLE][#GLFW_FEATURE_UNAVAILABLE] (see remarks).
-
-                @glfw.remark __Wayland:__ There is no way for an application to set the global
-                position of its windows.  This function will emit
-                [GLFW_FEATURE_UNAVAILABLE][#GLFW_FEATURE_UNAVAILABLE].
-
-                @glfw.thread_safety This function must only be called from the main thread.
-
-                @see #glfwGetWindowPos(MemorySegment, MemorySegment, MemorySegment) glfwGetWindowPos
-            """.trimIndent()
-        )
-
+        "glfwSetWindowPos"(void, GLFWwindow_ptr("window"), int("xpos"), int("ypos"), entrypoint = "glfwSetWindowPos")
         +"glfwGetWindowSize"(
             void,
             GLFWwindow_ptr("window"),
             int_ptr("width").ref(),
             int_ptr("height").ref(),
-            entrypoint = "glfwGetWindowSize",
-            javadoc = """
-                Retrieves the size of the content area of the specified window.
-
-                This function retrieves the size, in screen coordinates, of the content area
-                of the specified window.  If you wish to retrieve the size of the
-                framebuffer of the window in pixels, see [glfwGetFramebufferSize][#glfwGetFramebufferSize(MemorySegment, MemorySegment, MemorySegment)].
-
-                Any or all of the size arguments may be `NULL`.  If an error occurs, all
-                non-`NULL` size arguments will be set to zero.
-
-                @param window The window whose size to retrieve.
-                @param width Where to store the width, in screen coordinates, of the
-                content area, or `NULL`.
-                @param height Where to store the height, in screen coordinates, of the
-                content area, or `NULL`.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-                [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-
-                @glfw.thread_safety This function must only be called from the main thread.
-
-                @see #glfwSetWindowSize(MemorySegment, int, int) glfwSetWindowSize
-            """.trimIndent()
+            entrypoint = "glfwGetWindowSize"
         ).overload()
-
         "glfwSetWindowSizeLimits"(
             void,
             GLFWwindow_ptr("window"),
@@ -3182,159 +794,29 @@ fun main() {
             int("minheight"),
             int("maxwidth"),
             int("maxheight"),
-            entrypoint = "glfwSetWindowSizeLimits",
-            javadoc = """
-                Sets the size limits of the specified window.
-
-                This function sets the size limits of the content area of the specified
-                window.  If the window is full screen, the size limits only take effect
-                once it is made windowed.  If the window is not resizable, this function
-                does nothing.
-
-                The size limits are applied immediately to a windowed mode window and may
-                cause it to be resized.
-
-                The maximum dimensions must be greater than or equal to the minimum
-                dimensions and all must be greater than or equal to zero.
-
-                @param window The window to set limits for.
-                @param minwidth The minimum width, in screen coordinates, of the content
-                area, or `GLFW_DONT_CARE`.
-                @param minheight The minimum height, in screen coordinates, of the
-                content area, or `GLFW_DONT_CARE`.
-                @param maxwidth The maximum width, in screen coordinates, of the content
-                area, or `GLFW_DONT_CARE`.
-                @param maxheight The maximum height, in screen coordinates, of the
-                content area, or `GLFW_DONT_CARE`.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED],
-                [GLFW_INVALID_VALUE][#GLFW_INVALID_VALUE] and [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-
-                @glfw.remark If you set size limits and an aspect ratio that conflict, the
-                results are undefined.
-                - __Wayland:__ The size limits will not be applied until the window is
-                actually resized, either by the user or by the compositor.
-
-                @glfw.thread_safety This function must only be called from the main thread.
-
-                @see #glfwSetWindowAspectRatio(MemorySegment, int, int) glfwSetWindowAspectRatio
-            """.trimIndent()
+            entrypoint = "glfwSetWindowSizeLimits"
         )
-
         "glfwSetWindowAspectRatio"(
             void,
             GLFWwindow_ptr("window"),
             int("numer"),
             int("denom"),
-            entrypoint = "glfwSetWindowAspectRatio",
-            javadoc = """
-                Sets the aspect ratio of the specified window.
-
-                This function sets the required aspect ratio of the content area of the
-                specified window.  If the window is full screen, the aspect ratio only takes
-                effect once it is made windowed.  If the window is not resizable, this
-                function does nothing.
-
-                The aspect ratio is specified as a numerator and a denominator and both
-                values must be greater than zero.  For example, the common 16:9 aspect ratio
-                is specified as 16 and 9, respectively.
-
-                If the numerator and denominator is set to `GLFW_DONT_CARE` then the aspect
-                ratio limit is disabled.
-
-                The aspect ratio is applied immediately to a windowed mode window and may
-                cause it to be resized.
-
-                @param window The window to set limits for.
-                @param numer The numerator of the desired aspect ratio, or
-                `GLFW_DONT_CARE`.
-                @param denom The denominator of the desired aspect ratio, or
-                `GLFW_DONT_CARE`.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED],
-                [GLFW_INVALID_VALUE][#GLFW_INVALID_VALUE] and [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-
-                @glfw.remark If you set size limits and an aspect ratio that conflict, the
-                results are undefined.
-                - __Wayland:__ The aspect ratio will not be applied until the window is
-                actually resized, either by the user or by the compositor.
-
-                @glfw.thread_safety This function must only be called from the main thread.
-
-                @see #glfwSetWindowSizeLimits(MemorySegment, int, int, int, int) glfwSetWindowSizeLimits
-            """.trimIndent()
+            entrypoint = "glfwSetWindowAspectRatio"
         )
-
         "glfwSetWindowSize"(
             void,
             GLFWwindow_ptr("window"),
             int("width"),
             int("height"),
-            entrypoint = "glfwSetWindowSize",
-            javadoc = """
-                Sets the size of the content area of the specified window.
-
-                This function sets the size, in screen coordinates, of the content area of
-                the specified window.
-
-                For full screen windows, this function updates the resolution of its desired
-                video mode and switches to the video mode closest to it, without affecting
-                the window's context.  As the context is unaffected, the bit depths of the
-                framebuffer remain unchanged.
-
-                If you wish to update the refresh rate of the desired video mode in addition
-                to its resolution, see [glfwSetWindowMonitor][#glfwSetWindowMonitor(MemorySegment, MemorySegment, int, int, int, int, int)].
-
-                The window manager may put limits on what sizes are allowed.  GLFW cannot
-                and should not override these limits.
-
-                @param window The window to resize.
-                @param width The desired width, in screen coordinates, of the window
-                content area.
-                @param height The desired height, in screen coordinates, of the window
-                content area.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-                [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-
-                @glfw.thread_safety This function must only be called from the main thread.
-
-                @see #glfwGetWindowSize(MemorySegment, MemorySegment, MemorySegment) glfwGetWindowSize
-                @see #glfwSetWindowMonitor(MemorySegment, MemorySegment, int, int, int, int, int) glfwSetWindowMonitor
-            """.trimIndent()
+            entrypoint = "glfwSetWindowSize"
         )
-
         +"glfwGetFramebufferSize"(
             void,
             GLFWwindow_ptr("window"),
             int_ptr("width").ref(),
             int_ptr("height").ref(),
-            entrypoint = "glfwGetFramebufferSize",
-            javadoc = """
-                Retrieves the size of the framebuffer of the specified window.
-
-                This function retrieves the size, in pixels, of the framebuffer of the
-                specified window.  If you wish to retrieve the size of the window in screen
-                coordinates, see [glfwGetWindowSize][#glfwGetWindowSize(MemorySegment, MemorySegment, MemorySegment)].
-
-                Any or all of the size arguments may be `NULL`.  If an error occurs, all
-                non-`NULL` size arguments will be set to zero.
-
-                @param window The window whose framebuffer to query.
-                @param width Where to store the width, in pixels, of the framebuffer,
-                or `NULL`.
-                @param height Where to store the height, in pixels, of the framebuffer,
-                or `NULL`.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-                [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-
-                @glfw.thread_safety This function must only be called from the main thread.
-
-                @see #glfwSetFramebufferSizeCallback(MemorySegment, MemorySegment) glfwSetFramebufferSizeCallback
-            """.trimIndent()
+            entrypoint = "glfwGetFramebufferSize"
         ).overload()
-
         +"glfwGetWindowFrameSize"(
             void,
             GLFWwindow_ptr("window"),
@@ -3342,354 +824,25 @@ fun main() {
             int_ptr("top").ref(),
             int_ptr("right").ref(),
             int_ptr("bottom").ref(),
-            entrypoint = "glfwGetWindowFrameSize",
-            javadoc = """
-                Retrieves the size of the frame of the window.
-
-                This function retrieves the size, in screen coordinates, of each edge of the
-                frame of the specified window.  This size includes the title bar, if the
-                window has one.  The size of the frame may vary depending on the
-                window-related hints used to create it.
-
-                Because this function retrieves the size of each window frame edge and not
-                the offset along a particular coordinate axis, the retrieved values will
-                always be zero or positive.
-
-                Any or all of the size arguments may be `NULL`.  If an error occurs, all
-                non-`NULL` size arguments will be set to zero.
-
-                @param window The window whose frame size to query.
-                @param left Where to store the size, in screen coordinates, of the left
-                edge of the window frame, or `NULL`.
-                @param top Where to store the size, in screen coordinates, of the top
-                edge of the window frame, or `NULL`.
-                @param right Where to store the size, in screen coordinates, of the
-                right edge of the window frame, or `NULL`.
-                @param bottom Where to store the size, in screen coordinates, of the
-                bottom edge of the window frame, or `NULL`.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-                [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-
-                @glfw.thread_safety This function must only be called from the main thread.
-            """.trimIndent()
+            entrypoint = "glfwGetWindowFrameSize"
         ).overload()
-
         +"glfwGetWindowContentScale"(
             void,
             GLFWwindow_ptr("window"),
             float_ptr("xscale").ref(),
             float_ptr("yscale").ref(),
-            entrypoint = "glfwGetWindowContentScale",
-            javadoc = """
-                Retrieves the content scale for the specified window.
-
-                This function retrieves the content scale for the specified window.  The
-                content scale is the ratio between the current DPI and the platform's
-                default DPI.  This is especially important for text and any UI elements.  If
-                the pixel dimensions of your UI scaled by this look appropriate on your
-                machine then it should appear at a reasonable size on other machines
-                regardless of their DPI and scaling settings.  This relies on the system DPI
-                and scaling settings being somewhat correct.
-
-                On platforms where each monitors can have its own content scale, the window
-                content scale will depend on which monitor the system considers the window
-                to be on.
-
-                @param window The window to query.
-                @param xscale Where to store the x-axis content scale, or `NULL`.
-                @param yscale Where to store the y-axis content scale, or `NULL`.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-                [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-
-                @glfw.thread_safety This function must only be called from the main thread.
-
-                @see #glfwSetWindowContentScaleCallback(MemorySegment, MemorySegment) glfwSetWindowContentScaleCallback
-                @see #glfwGetMonitorContentScale(MemorySegment, MemorySegment, MemorySegment) glfwGetMonitorContentScale
-            """.trimIndent()
+            entrypoint = "glfwGetWindowContentScale"
         ).overload()
-
-        "glfwGetWindowOpacity"(
-            float,
-            GLFWwindow_ptr("window"),
-            entrypoint = "glfwGetWindowOpacity",
-            javadoc = """
-                Returns the opacity of the whole window.
-
-                This function returns the opacity of the window, including any decorations.
-
-                The opacity (or alpha) value is a positive finite number between zero and
-                one, where zero is fully transparent and one is fully opaque.  If the system
-                does not support whole window transparency, this function always returns one.
-
-                The initial opacity value for newly created windows is one.
-
-                @param window The window to query.
-                @return The opacity value of the specified window.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-                [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-
-                @glfw.thread_safety This function must only be called from the main thread.
-
-                @see #glfwSetWindowOpacity(MemorySegment, float) glfwSetWindowOpacity
-            """.trimIndent()
-        )
-
-        "glfwSetWindowOpacity"(
-            void,
-            GLFWwindow_ptr("window"),
-            float("opacity"),
-            entrypoint = "glfwSetWindowOpacity",
-            javadoc = """
-                Sets the opacity of the whole window.
-
-                This function sets the opacity of the window, including any decorations.
-
-                The opacity (or alpha) value is a positive finite number between zero and
-                one, where zero is fully transparent and one is fully opaque.
-
-                The initial opacity value for newly created windows is one.
-
-                A window created with framebuffer transparency may not use whole window
-                transparency.  The results of doing this are undefined.
-
-                @param window The window to set the opacity for.
-                @param opacity The desired opacity of the specified window.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED],
-                [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR] and [GLFW_FEATURE_UNAVAILABLE][#GLFW_FEATURE_UNAVAILABLE] (see remarks).
-
-                @glfw.remark __Wayland:__ There is no way to set an opacity factor for a window.
-                This function will emit [GLFW_FEATURE_UNAVAILABLE][#GLFW_FEATURE_UNAVAILABLE].
-
-                @glfw.thread_safety This function must only be called from the main thread.
-
-                @see #glfwGetWindowOpacity(MemorySegment) glfwGetWindowOpacity
-            """.trimIndent()
-        )
-
-        "glfwIconifyWindow"(
-            void,
-            GLFWwindow_ptr("window"),
-            entrypoint = "glfwIconifyWindow",
-            javadoc = """
-                Iconifies the specified window.
-
-                This function iconifies (minimizes) the specified window if it was
-                previously restored.  If the window is already iconified, this function does
-                nothing.
-
-                If the specified window is a full screen window, GLFW restores the original
-                video mode of the monitor.  The window's desired video mode is set again
-                when the window is restored.
-
-                @param window The window to iconify.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-                [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-
-                @glfw.remark __Wayland:__ Once a window is iconified, [glfwRestoreWindow][#glfwRestoreWindow(MemorySegment)] won't
-                be able to restore it.  This is a design decision of the xdg-shell
-                protocol.
-
-                @glfw.thread_safety This function must only be called from the main thread.
-
-                @see #glfwRestoreWindow(MemorySegment) glfwRestoreWindow
-                @see #glfwMaximizeWindow(MemorySegment) glfwMaximizeWindow
-            """.trimIndent()
-        )
-
-        "glfwRestoreWindow"(
-            void,
-            GLFWwindow_ptr("window"),
-            entrypoint = "glfwRestoreWindow",
-            javadoc = """
-                Restores the specified window.
-
-                This function restores the specified window if it was previously iconified
-                (minimized) or maximized.  If the window is already restored, this function
-                does nothing.
-
-                If the specified window is an iconified full screen window, its desired
-                video mode is set again for its monitor when the window is restored.
-
-                @param window The window to restore.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-                [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-
-                @glfw.thread_safety This function must only be called from the main thread.
-
-                @see #glfwIconifyWindow(MemorySegment) glfwIconifyWindow
-                @see #glfwMaximizeWindow(MemorySegment) glfwMaximizeWindow
-            """.trimIndent()
-        )
-
-        "glfwMaximizeWindow"(
-            void,
-            GLFWwindow_ptr("window"),
-            entrypoint = "glfwMaximizeWindow",
-            javadoc = """
-                Maximizes the specified window.
-
-                This function maximizes the specified window if it was previously not
-                maximized.  If the window is already maximized, this function does nothing.
-
-                If the specified window is a full screen window, this function does nothing.
-
-                @param window The window to maximize.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-                [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-
-                @glfw.thread_safety This function may only be called from the main thread.
-
-                @see #glfwIconifyWindow(MemorySegment) glfwIconifyWindow
-                @see #glfwRestoreWindow(MemorySegment) glfwRestoreWindow
-            """.trimIndent()
-        )
-
-        "glfwShowWindow"(
-            void,
-            GLFWwindow_ptr("window"),
-            entrypoint = "glfwShowWindow",
-            javadoc = """
-                Makes the specified window visible.
-
-                This function makes the specified window visible if it was previously
-                hidden.  If the window is already visible or is in full screen mode, this
-                function does nothing.
-
-                By default, windowed mode windows are focused when shown
-                Set the [GLFW_FOCUS_ON_SHOW][#GLFW_FOCUS_ON_SHOW] window hint
-                to change this behavior for all newly created windows, or change the
-                behavior for an existing window with [glfwSetWindowAttrib][#glfwSetWindowAttrib(MemorySegment, int, int)].
-
-                @param window The window to make visible.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-                [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-
-                @glfw.remark __Wayland:__ Because Wayland wants every frame of the desktop to be
-                complete, this function does not immediately make the window visible.
-                Instead it will become visible the next time the window framebuffer is
-                updated after this call.
-
-                @glfw.thread_safety This function must only be called from the main thread.
-
-                @see #glfwHideWindow(MemorySegment) glfwHideWindow
-            """.trimIndent()
-        )
-
-        "glfwHideWindow"(
-            void,
-            GLFWwindow_ptr("window"),
-            entrypoint = "glfwHideWindow",
-            javadoc = """
-                Hides the specified window.
-
-                This function hides the specified window if it was previously visible.  If
-                the window is already hidden or is in full screen mode, this function does
-                nothing.
-
-                @param window The window to hide.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-                [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-
-                @glfw.thread_safety This function must only be called from the main thread.
-
-                @see #glfwShowWindow(MemorySegment) glfwShowWindow
-            """.trimIndent()
-        )
-
-        "glfwFocusWindow"(
-            void,
-            GLFWwindow_ptr("window"),
-            entrypoint = "glfwFocusWindow",
-            javadoc = """
-                Brings the specified window to front and sets input focus.
-
-                This function brings the specified window to front and sets input focus.
-                The window should already be visible and not iconified.
-
-                By default, both windowed and full screen mode windows are focused when
-                initially created.  Set the [GLFW_FOCUSED][#GLFW_FOCUSED] to
-                disable this behavior.
-
-                Also by default, windowed mode windows are focused when shown
-                with [glfwShowWindow][#glfwShowWindow(MemorySegment)]. Set the
-                [GLFW_FOCUS_ON_SHOW][#GLFW_FOCUS_ON_SHOW] to disable this behavior.
-
-                __Do not use this function__ to steal focus from other applications unless
-                you are certain that is what the user wants.  Focus stealing can be
-                extremely disruptive.
-
-                For a less disruptive way of getting the user's attention, see
-                attention requests.
-
-                @param window The window to give input focus.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-                [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-
-                @glfw.remark __Wayland:__ The compositor will likely ignore focus requests unless
-                another window created by the same application already has input focus.
-
-                @glfw.thread_safety This function must only be called from the main thread.
-            """.trimIndent()
-        )
-
-        "glfwRequestWindowAttention"(
-            void,
-            GLFWwindow_ptr("window"),
-            entrypoint = "glfwRequestWindowAttention",
-            javadoc = """
-                Requests user attention to the specified window.
-
-                This function requests user attention to the specified window.  On
-                platforms where this is not supported, attention is requested to the
-                application as a whole.
-
-                Once the user has given attention, usually by focusing the window or
-                application, the system will end the request automatically.
-
-                @param window The window to request attention to.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-                [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-
-                @glfw.remark __macOS:__ Attention is requested to the application as a whole, not the
-                specific window.
-
-                @glfw.thread_safety This function must only be called from the main thread.
-            """.trimIndent()
-        )
-
-        "glfwGetWindowMonitor"(
-            GLFWmonitor_ptr,
-            GLFWwindow_ptr("window"),
-            entrypoint = "glfwGetWindowMonitor",
-            javadoc = """
-                Returns the monitor that the window uses for full screen mode.
-
-                This function returns the handle of the monitor that the specified window is
-                in full screen on.
-
-                @param window The window to query.
-                @return The monitor, or `NULL` if the window is in windowed mode or an
-                error occurred.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-
-                @glfw.thread_safety This function must only be called from the main thread.
-
-                @see #glfwSetWindowMonitor(MemorySegment, MemorySegment, int, int, int, int, int) glfwSetWindowMonitor
-            """.trimIndent()
-        )
-
+        "glfwGetWindowOpacity"(float, GLFWwindow_ptr("window"), entrypoint = "glfwGetWindowOpacity")
+        "glfwSetWindowOpacity"(void, GLFWwindow_ptr("window"), float("opacity"), entrypoint = "glfwSetWindowOpacity")
+        "glfwIconifyWindow"(void, GLFWwindow_ptr("window"), entrypoint = "glfwIconifyWindow")
+        "glfwRestoreWindow"(void, GLFWwindow_ptr("window"), entrypoint = "glfwRestoreWindow")
+        "glfwMaximizeWindow"(void, GLFWwindow_ptr("window"), entrypoint = "glfwMaximizeWindow")
+        "glfwShowWindow"(void, GLFWwindow_ptr("window"), entrypoint = "glfwShowWindow")
+        "glfwHideWindow"(void, GLFWwindow_ptr("window"), entrypoint = "glfwHideWindow")
+        "glfwFocusWindow"(void, GLFWwindow_ptr("window"), entrypoint = "glfwFocusWindow")
+        "glfwRequestWindowAttention"(void, GLFWwindow_ptr("window"), entrypoint = "glfwRequestWindowAttention")
+        "glfwGetWindowMonitor"(GLFWmonitor_ptr, GLFWwindow_ptr("window"), entrypoint = "glfwGetWindowMonitor")
         "glfwSetWindowMonitor"(
             void,
             GLFWwindow_ptr("window"),
@@ -3699,1661 +852,133 @@ fun main() {
             int("width"),
             int("height"),
             int("refreshRate"),
-            entrypoint = "glfwSetWindowMonitor",
-            javadoc = """
-                Sets the mode, monitor, video mode and placement of a window.
-
-                This function sets the monitor that the window uses for full screen mode or,
-                if the monitor is `NULL`, makes it windowed mode.
-
-                When setting a monitor, this function updates the width, height and refresh
-                rate of the desired video mode and switches to the video mode closest to it.
-                The window position is ignored when setting a monitor.
-
-                When the monitor is `NULL`, the position, width and height are used to
-                place the window content area.  The refresh rate is ignored when no monitor
-                is specified.
-
-                If you only wish to update the resolution of a full screen window or the
-                size of a windowed mode window, see [glfwSetWindowSize][#glfwSetWindowSize(MemorySegment, int, int)].
-
-                When a window transitions from full screen to windowed mode, this function
-                restores any previous window settings such as whether it is decorated,
-                floating, resizable, has size or aspect ratio limits, etc.
-
-                @param window The window whose monitor, size or video mode to set.
-                @param monitor The desired monitor, or `NULL` to set windowed mode.
-                @param xpos The desired x-coordinate of the upper-left corner of the
-                content area.
-                @param ypos The desired y-coordinate of the upper-left corner of the
-                content area.
-                @param width The desired with, in screen coordinates, of the content
-                area or video mode.
-                @param height The desired height, in screen coordinates, of the content
-                area or video mode.
-                @param refreshRate The desired refresh rate, in Hz, of the video mode,
-                or `GLFW_DONT_CARE`.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-                [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-
-                @glfw.remark The OpenGL or OpenGL ES context will not be destroyed or otherwise
-                affected by any resizing or mode switching, although you may need to update
-                your viewport if the framebuffer size has changed.
-                - __Wayland:__ The desired window position is ignored, as there is no way
-                    for an application to set this property.
-
-                @glfw.thread_safety This function must only be called from the main thread.
-            """.trimIndent()
+            entrypoint = "glfwSetWindowMonitor"
         )
-
-        "glfwGetWindowAttrib"(
-            int,
-            GLFWwindow_ptr("window"),
-            int("attrib"),
-            entrypoint = "glfwGetWindowAttrib",
-            javadoc = """
-                Returns an attribute of the specified window.
-
-                This function returns the value of an attribute of the specified window or
-                its OpenGL or OpenGL ES context.
-
-                @param window The window to query.
-                @param attrib The window attribute whose value to
-                return.
-                @return The value of the attribute, or zero if an
-                error occurred.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED],
-                [GLFW_INVALID_ENUM][#GLFW_INVALID_ENUM] and [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-
-                @glfw.remark Framebuffer related hints are not window attributes.  See
-                window_attribs_fb for more information.
-
-                Zero is a valid value for many window and context related
-                attributes so you cannot use a return value of zero as an indication of
-                errors.  However, this function should not fail as long as it is passed
-                valid arguments and the library has been initialized.
-                - __Wayland:__ The Wayland protocol provides no way to check whether a
-                window is iconfied, so [GLFW_ICONIFIED][#GLFW_ICONIFIED] always returns `GLFW_FALSE`.
-
-                @glfw.thread_safety This function must only be called from the main thread.
-
-                @see #glfwSetWindowAttrib(MemorySegment, int, int) glfwSetWindowAttrib
-            """.trimIndent()
-        )
-
+        "glfwGetWindowAttrib"(int, GLFWwindow_ptr("window"), int("attrib"), entrypoint = "glfwGetWindowAttrib")
         "glfwSetWindowAttrib"(
             void,
             GLFWwindow_ptr("window"),
             int("attrib"),
             int("value"),
-            entrypoint = "glfwSetWindowAttrib",
-            javadoc = """
-                Sets an attribute of the specified window.
-
-                This function sets the value of an attribute of the specified window.
-
-                The supported attributes are [GLFW_DECORATED][#GLFW_DECORATED],
-                [GLFW_RESIZABLE][#GLFW_RESIZABLE],
-                [GLFW_FLOATING][#GLFW_FLOATING],
-                [GLFW_AUTO_ICONIFY][#GLFW_AUTO_ICONIFY] and
-                [GLFW_FOCUS_ON_SHOW][#GLFW_FOCUS_ON_SHOW].
-                [GLFW_MOUSE_PASSTHROUGH][#GLFW_MOUSE_PASSTHROUGH]
-
-                Some of these attributes are ignored for full screen windows.  The new
-                value will take effect if the window is later made windowed.
-
-                Some of these attributes are ignored for windowed mode windows.  The new
-                value will take effect if the window is later made full screen.
-
-                @param window The window to set the attribute for.
-                @param attrib A supported window attribute.
-                @param value `GLFW_TRUE` or `GLFW_FALSE`.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED],
-                [GLFW_INVALID_ENUM][#GLFW_INVALID_ENUM], [GLFW_INVALID_VALUE][#GLFW_INVALID_VALUE], [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR] and
-                [GLFW_FEATURE_UNAVAILABLE][#GLFW_FEATURE_UNAVAILABLE] (see remarks).
-
-                @glfw.remark Calling glfwGetWindowAttrib will always return the latest
-                value, even if that value is ignored by the current mode of the window.
-                - __Wayland:__ The [GLFW_FLOATING][#GLFW_FLOATING] window attribute is
-                not supported.  Setting this will emit [GLFW_FEATURE_UNAVAILABLE][#GLFW_FEATURE_UNAVAILABLE].
-
-                @glfw.thread_safety This function must only be called from the main thread.
-
-                @see #glfwGetWindowAttrib(MemorySegment, int) glfwGetWindowAttrib
-            """.trimIndent()
+            entrypoint = "glfwSetWindowAttrib"
         )
-
         "glfwSetWindowUserPointer"(
             void,
             GLFWwindow_ptr("window"),
             void_ptr("pointer"),
-            entrypoint = "glfwSetWindowUserPointer",
-            javadoc = """
-                Sets the user pointer of the specified window.
-
-                This function sets the user-defined pointer of the specified window.  The
-                current value is retained until the window is destroyed.  The initial value
-                is `NULL`.
-
-                @param window The window whose pointer to set.
-                @param pointer The new value.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-
-                @glfw.thread_safety This function may be called from any thread.  Access is not
-                synchronized.
-
-                @see #glfwGetWindowUserPointer(MemorySegment) glfwGetWindowUserPointer
-            """.trimIndent()
+            entrypoint = "glfwSetWindowUserPointer"
         )
-
-        "glfwGetWindowUserPointer"(
-            void_ptr,
-            GLFWwindow_ptr("window"),
-            entrypoint = "glfwGetWindowUserPointer",
-            javadoc = """
-                Returns the user pointer of the specified window.
-
-                This function returns the current value of the user-defined pointer of the
-                specified window.  The initial value is `NULL`.
-
-                @param window The window whose pointer to return.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-
-                @glfw.thread_safety This function may be called from any thread.  Access is not
-                synchronized.
-
-                @see #glfwSetWindowUserPointer(MemorySegment, MemorySegment) glfwSetWindowUserPointer
-            """.trimIndent()
-        )
+        "glfwGetWindowUserPointer"(void_ptr, GLFWwindow_ptr("window"), entrypoint = "glfwGetWindowUserPointer")
 
         //region Callback 1
-        windowCallback(
-            "glfwSetWindowPosCallback",
-            GLFWwindowposfun,
-            javadoc = """
-                Sets the position callback for the specified window.
-
-                This function sets the position callback of the specified window, which is
-                called when the window is moved.  The callback is provided with the
-                position, in screen coordinates, of the upper-left corner of the content
-                area of the window.
-
-                @param window The window whose callback to set.
-                @param callback The new callback, or `NULL` to remove the currently set
-                callback.
-                @return The previously set callback, or `NULL` if no callback was set or the
-                library had not been initialized.
-
-                @glfw.callback_signature
-                For more information about the callback parameters, see the
-                [function pointer type][GLFWWindowPosFun].
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-
-                @glfw.remark __Wayland:__ This callback will never be called, as there is no way for
-                an application to know its global position.
-
-                @glfw.thread_safety This function must only be called from the main thread.
-            """.trimIndent()
-        )
-
-        windowCallback(
-            "glfwSetWindowSizeCallback",
-            GLFWwindowsizefun,
-            javadoc = """
-                Sets the size callback for the specified window.
-
-                This function sets the size callback of the specified window, which is
-                called when the window is resized.  The callback is provided with the size,
-                in screen coordinates, of the content area of the window.
-
-                @param window The window whose callback to set.
-                @param callback The new callback, or `NULL` to remove the currently set
-                callback.
-                @return The previously set callback, or `NULL` if no callback was set or the
-                library had not been initialized.
-
-                @glfw.callback_signature
-                For more information about the callback parameters, see the
-                [function pointer type][GLFWWindowSizeFun].
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-
-                @glfw.thread_safety This function must only be called from the main thread.
-            """.trimIndent()
-        )
-
-        windowCallback(
-            "glfwSetWindowCloseCallback",
-            GLFWwindowclosefun,
-            javadoc = """
-                Sets the close callback for the specified window.
-
-                This function sets the close callback of the specified window, which is
-                called when the user attempts to close the window, for example by clicking
-                the close widget in the title bar.
-
-                The close flag is set before this callback is called, but you can modify it
-                at any time with [glfwSetWindowShouldClose][#glfwSetWindowShouldClose(MemorySegment, boolean)].
-
-                The close callback is not triggered by [glfwDestroyWindow][#glfwDestroyWindow(MemorySegment)].
-
-                @param window The window whose callback to set.
-                @param callback The new callback, or `NULL` to remove the currently set
-                callback.
-                @return The previously set callback, or `NULL` if no callback was set or the
-                library had not been initialized.
-
-                @glfw.callback_signature
-                For more information about the callback parameters, see the
-                [function pointer type][GLFWWindowCloseFun].
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-
-                @glfw.remark __macOS:__ Selecting Quit from the application menu will trigger the
-                close callback for all windows.
-
-                @glfw.thread_safety This function must only be called from the main thread.
-            """.trimIndent()
-        )
-
-        windowCallback(
-            "glfwSetWindowRefreshCallback",
-            GLFWwindowrefreshfun,
-            javadoc = """
-                Sets the refresh callback for the specified window.
-
-                This function sets the refresh callback of the specified window, which is
-                called when the content area of the window needs to be redrawn, for example
-                if the window has been exposed after having been covered by another window.
-
-                On compositing window systems such as Aero, Compiz, Aqua or Wayland, where
-                the window contents are saved off-screen, this callback may be called only
-                very infrequently or never at all.
-
-                @param window The window whose callback to set.
-                @param callback The new callback, or `NULL` to remove the currently set
-                callback.
-                @return The previously set callback, or `NULL` if no callback was set or the
-                library had not been initialized.
-
-                @glfw.callback_signature
-                For more information about the callback parameters, see the
-                [function pointer type][GLFWWindowRefreshFun].
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-
-                @glfw.thread_safety This function must only be called from the main thread.
-            """.trimIndent()
-        )
-
-        windowCallback(
-            "glfwSetWindowFocusCallback",
-            GLFWwindowfocusfun,
-            javadoc = """
-                Sets the focus callback for the specified window.
-
-                This function sets the focus callback of the specified window, which is
-                called when the window gains or loses input focus.
-
-                After the focus callback is called for a window that lost input focus,
-                synthetic key and mouse button release events will be generated for all such
-                that had been pressed.  For more information, see [glfwSetKeyCallback][#glfwSetKeyCallback(MemorySegment, MemorySegment)]
-                and [glfwSetMouseButtonCallback][#glfwSetMouseButtonCallback(MemorySegment, MemorySegment)].
-
-                @param window The window whose callback to set.
-                @param callback The new callback, or `NULL` to remove the currently set
-                callback.
-                @return The previously set callback, or `NULL` if no callback was set or the
-                library had not been initialized.
-
-                @glfw.callback_signature
-                For more information about the callback parameters, see the
-                [function pointer type][GLFWWindowFocusFun].
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-
-                @glfw.thread_safety This function must only be called from the main thread.
-            """.trimIndent()
-        )
-
-        windowCallback(
-            "glfwSetWindowIconifyCallback",
-            GLFWwindowiconifyfun,
-            javadoc = """
-                Sets the iconify callback for the specified window.
-
-                This function sets the iconification callback of the specified window, which
-                is called when the window is iconified or restored.
-
-                @param window The window whose callback to set.
-                @param callback The new callback, or `NULL` to remove the currently set
-                callback.
-                @return The previously set callback, or `NULL` if no callback was set or the
-                library had not been initialized.
-
-                @glfw.callback_signature
-                For more information about the callback parameters, see the
-                [function pointer type][GLFWWindowIconifyFun].
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-
-                @glfw.thread_safety This function must only be called from the main thread.
-            """.trimIndent()
-        )
-
-        windowCallback(
-            "glfwSetWindowMaximizeCallback",
-            GLFWwindowmaximizefun,
-            javadoc = """
-                Sets the maximize callback for the specified window.
-
-                This function sets the maximization callback of the specified window, which
-                is called when the window is maximized or restored.
-
-                @param window The window whose callback to set.
-                @param callback The new callback, or `NULL` to remove the currently set
-                callback.
-                @return The previously set callback, or `NULL` if no callback was set or the
-                library had not been initialized.
-
-                @glfw.callback_signature
-                For more information about the callback parameters, see the
-                [function pointer type][GLFWWindowMaximizeFun].
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-
-                @glfw.thread_safety This function must only be called from the main thread.
-            """.trimIndent()
-        )
-
-        windowCallback(
-            "glfwSetFramebufferSizeCallback",
-            GLFWframebuffersizefun,
-            javadoc = """
-                Sets the framebuffer resize callback for the specified window.
-
-                This function sets the framebuffer resize callback of the specified window,
-                which is called when the framebuffer of the specified window is resized.
-
-                @param window The window whose callback to set.
-                @param callback The new callback, or `NULL` to remove the currently set
-                callback.
-                @return The previously set callback, or `NULL` if no callback was set or the
-                library had not been initialized.
-
-                @glfw.callback_signature
-                For more information about the callback parameters, see the
-                [function pointer type][GLFWFramebufferSizeFun].
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-
-                @glfw.thread_safety This function must only be called from the main thread.
-            """.trimIndent()
-        )
-
-        windowCallback(
-            "glfwSetWindowContentScaleCallback",
-            GLFWwindowcontentscalefun,
-            javadoc = """
-                Sets the window content scale callback for the specified window.
-
-                This function sets the window content scale callback of the specified window,
-                which is called when the content scale of the specified window changes.
-
-                @param window The window whose callback to set.
-                @param callback The new callback, or `NULL` to remove the currently set
-                callback.
-                @return The previously set callback, or `NULL` if no callback was set or the
-                library had not been initialized.
-
-                @glfw.callback_signature
-                For more information about the callback parameters, see the
-                [function pointer type][GLFWWindowContentScaleFun].
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-
-                @glfw.thread_safety This function must only be called from the main thread.
-            """.trimIndent()
-        )
+        windowCallback("glfwSetWindowPosCallback", GLFWwindowposfun)
+        windowCallback("glfwSetWindowSizeCallback", GLFWwindowsizefun)
+        windowCallback("glfwSetWindowCloseCallback", GLFWwindowclosefun)
+        windowCallback("glfwSetWindowRefreshCallback", GLFWwindowrefreshfun)
+        windowCallback("glfwSetWindowFocusCallback", GLFWwindowfocusfun)
+        windowCallback("glfwSetWindowIconifyCallback", GLFWwindowiconifyfun)
+        windowCallback("glfwSetWindowMaximizeCallback", GLFWwindowmaximizefun)
+        windowCallback("glfwSetFramebufferSizeCallback", GLFWframebuffersizefun)
+        windowCallback("glfwSetWindowContentScaleCallback", GLFWwindowcontentscalefun)
         //endregion
 
-        "glfwPollEvents"(
-            void,
-            entrypoint = "glfwPollEvents",
-            javadoc = """
-                Processes all pending events.
-
-                This function processes only those events that are already in the event
-                queue and then returns immediately.  Processing events will cause the window
-                and input callbacks associated with those events to be called.
-
-                On some platforms, a window move, resize or menu operation will cause event
-                processing to block.  This is due to how event processing is designed on
-                those platforms.  You can use the
-                window refresh callback to redraw the contents of
-                your window when necessary during such operations.
-
-                Do not assume that callbacks you set will _only_ be called in response to
-                event processing functions like this one.  While it is necessary to poll for
-                events, window systems that require GLFW to register callbacks of its own
-                can pass events to GLFW in response to many window system function calls.
-                GLFW will pass those events on to the application callbacks before
-                returning.
-
-                Event processing is not required for joystick input to work.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-                [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-
-                @glfw.reentrancy This function must not be called from a callback.
-
-                @glfw.thread_safety This function must only be called from the main thread.
-
-                @see #glfwWaitEvents() glfwWaitEvents
-                @see #glfwWaitEventsTimeout(double) glfwWaitEventsTimeout
-            """.trimIndent()
-        )
-
-        "glfwWaitEvents"(
-            void,
-            entrypoint = "glfwWaitEvents",
-            javadoc = """
-                Waits until events are queued and processes them.
-
-                This function puts the calling thread to sleep until at least one event is
-                available in the event queue.  Once one or more events are available,
-                it behaves exactly like [glfwPollEvents][#glfwPollEvents()], i.e. the events in the queue
-                are processed and the function then returns immediately.  Processing events
-                will cause the window and input callbacks associated with those events to be
-                called.
-
-                Since not all events are associated with callbacks, this function may return
-                without a callback having been called even if you are monitoring all
-                callbacks.
-
-                On some platforms, a window move, resize or menu operation will cause event
-                processing to block.  This is due to how event processing is designed on
-                those platforms.  You can use the
-                window refresh callback to redraw the contents of
-                your window when necessary during such operations.
-
-                Do not assume that callbacks you set will _only_ be called in response to
-                event processing functions like this one.  While it is necessary to poll for
-                events, window systems that require GLFW to register callbacks of its own
-                can pass events to GLFW in response to many window system function calls.
-                GLFW will pass those events on to the application callbacks before
-                returning.
-
-                Event processing is not required for joystick input to work.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-                [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-
-                @glfw.reentrancy This function must not be called from a callback.
-
-                @glfw.thread_safety This function must only be called from the main thread.
-
-                @see #glfwPollEvents() glfwPollEvents
-                @see #glfwWaitEventsTimeout(double) glfwWaitEventsTimeout
-            """.trimIndent()
-        )
-
-        "glfwWaitEventsTimeout"(
-            void,
-            double("timeout"),
-            entrypoint = "glfwWaitEventsTimeout",
-            javadoc = """
-                Waits with timeout until events are queued and processes them.
-
-                This function puts the calling thread to sleep until at least one event is
-                available in the event queue, or until the specified timeout is reached.  If
-                one or more events are available, it behaves exactly like
-                [glfwPollEvents][#glfwPollEvents()], i.e. the events in the queue are processed and the function
-                then returns immediately.  Processing events will cause the window and input
-                callbacks associated with those events to be called.
-
-                The timeout value must be a positive finite number.
-
-                Since not all events are associated with callbacks, this function may return
-                without a callback having been called even if you are monitoring all
-                callbacks.
-
-                On some platforms, a window move, resize or menu operation will cause event
-                processing to block.  This is due to how event processing is designed on
-                those platforms.  You can use the
-                window refresh callback to redraw the contents of
-                your window when necessary during such operations.
-
-                Do not assume that callbacks you set will _only_ be called in response to
-                event processing functions like this one.  While it is necessary to poll for
-                events, window systems that require GLFW to register callbacks of its own
-                can pass events to GLFW in response to many window system function calls.
-                GLFW will pass those events on to the application callbacks before
-                returning.
-
-                Event processing is not required for joystick input to work.
-
-                @param timeout The maximum amount of time, in seconds, to wait.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED],
-                [GLFW_INVALID_VALUE][#GLFW_INVALID_VALUE] and [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-
-                @glfw.reentrancy This function must not be called from a callback.
-
-                @glfw.thread_safety This function must only be called from the main thread.
-
-                @see #glfwPollEvents() glfwPollEvents
-                @see #glfwWaitEvents() glfwWaitEvents
-            """.trimIndent()
-        )
-
-        "glfwPostEmptyEvent"(
-            void,
-            entrypoint = "glfwPostEmptyEvent",
-            javadoc = """
-                Posts an empty event to the event queue.
-
-                This function posts an empty event from the current thread to the event
-                queue, causing [glfwWaitEvents][#glfwWaitEvents()] or [glfwWaitEventsTimeout][#glfwWaitEventsTimeout(double)] to return.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-                [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-
-                @glfw.thread_safety This function may be called from any thread.
-
-                @see #glfwWaitEvents() glfwWaitEvents
-                @see #glfwWaitEventsTimeout(double) glfwWaitEventsTimeout
-            """.trimIndent()
-        )
-
-        "glfwGetInputMode"(
-            int,
-            GLFWwindow_ptr("window"),
-            int("mode"),
-            entrypoint = "glfwGetInputMode",
-            javadoc = """
-                Returns the value of an input option for the specified window.
-
-                This function returns the value of an input option for the specified window.
-                The mode must be one of [GLFW_CURSOR][#GLFW_CURSOR], [GLFW_STICKY_KEYS][#GLFW_STICKY_KEYS],
-                [GLFW_STICKY_MOUSE_BUTTONS][#GLFW_STICKY_MOUSE_BUTTONS], [GLFW_LOCK_KEY_MODS][#GLFW_LOCK_KEY_MODS] or
-                [GLFW_RAW_MOUSE_MOTION][#GLFW_RAW_MOUSE_MOTION].
-
-                @param window The window to query.
-                @param mode One of `GLFW_CURSOR`, `GLFW_STICKY_KEYS`,
-                `GLFW_STICKY_MOUSE_BUTTONS`, `GLFW_LOCK_KEY_MODS` or
-                `GLFW_RAW_MOUSE_MOTION`.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-                [GLFW_INVALID_ENUM][#GLFW_INVALID_ENUM].
-
-                @glfw.thread_safety This function must only be called from the main thread.
-
-                @see #glfwSetInputMode(MemorySegment, int, int) glfwSetInputMode
-            """.trimIndent()
-        )
-
-        "glfwSetInputMode"(
-            void,
-            GLFWwindow_ptr("window"),
-            int("mode"),
-            int("value"),
-            entrypoint = "glfwSetInputMode",
-            javadoc = """
-                Sets an input option for the specified window.
-
-                This function sets an input mode option for the specified window.  The mode
-                must be one of [GLFW_CURSOR][#GLFW_CURSOR], [GLFW_STICKY_KEYS][#GLFW_STICKY_KEYS],
-                [GLFW_STICKY_MOUSE_BUTTONS][#GLFW_STICKY_MOUSE_BUTTONS], [GLFW_LOCK_KEY_MODS][#GLFW_LOCK_KEY_MODS]
-                [GLFW_RAW_MOUSE_MOTION][#GLFW_RAW_MOUSE_MOTION], or [GLFW_UNLIMITED_MOUSE_BUTTONS][#GLFW_UNLIMITED_MOUSE_BUTTONS].
-
-                If the mode is `GLFW_CURSOR`, the value must be one of the following cursor
-                modes:
-                - `GLFW_CURSOR_NORMAL` makes the cursor visible and behaving normally.
-                - `GLFW_CURSOR_HIDDEN` makes the cursor invisible when it is over the
-                  content area of the window but does not restrict the cursor from leaving.
-                - `GLFW_CURSOR_DISABLED` hides and grabs the cursor, providing virtual
-                  and unlimited cursor movement.  This is useful for implementing for
-                  example 3D camera controls.
-                - `GLFW_CURSOR_CAPTURED` makes the cursor visible and confines it to the
-                  content area of the window.
-
-                If the mode is `GLFW_STICKY_KEYS`, the value must be either `GLFW_TRUE` to
-                enable sticky keys, or `GLFW_FALSE` to disable it.  If sticky keys are
-                enabled, a key press will ensure that [glfwGetKey][#glfwGetKey(MemorySegment, int)] returns `GLFW_PRESS`
-                the next time it is called even if the key had been released before the
-                call.  This is useful when you are only interested in whether keys have been
-                pressed but not when or in which order.
-
-                If the mode is `GLFW_STICKY_MOUSE_BUTTONS`, the value must be either
-                `GLFW_TRUE` to enable sticky mouse buttons, or `GLFW_FALSE` to disable it.
-                If sticky mouse buttons are enabled, a mouse button press will ensure that
-                [glfwGetMouseButton][#glfwGetMouseButton(MemorySegment, int)] returns `GLFW_PRESS` the next time it is called even
-                if the mouse button had been released before the call.  This is useful when
-                you are only interested in whether mouse buttons have been pressed but not
-                when or in which order.
-
-                If the mode is `GLFW_LOCK_KEY_MODS`, the value must be either `GLFW_TRUE` to
-                enable lock key modifier bits, or `GLFW_FALSE` to disable them.  If enabled,
-                callbacks that receive modifier bits will also have the
-                [GLFW_MOD_CAPS_LOCK][#GLFW_MOD_CAPS_LOCK] bit set when the event was generated with Caps Lock on,
-                and the [GLFW_MOD_NUM_LOCK][#GLFW_MOD_NUM_LOCK] bit when Num Lock was on.
-
-                If the mode is `GLFW_RAW_MOUSE_MOTION`, the value must be either `GLFW_TRUE`
-                to enable raw (unscaled and unaccelerated) mouse motion when the cursor is
-                disabled, or `GLFW_FALSE` to disable it.  If raw motion is not supported,
-                attempting to set this will emit [GLFW_FEATURE_UNAVAILABLE][#GLFW_FEATURE_UNAVAILABLE].  Call
-                [glfwRawMouseMotionSupported][#glfwRawMouseMotionSupported()] to check for support.
-
-                If the mode is `GLFW_UNLIMITED_MOUSE_BUTTONS`, the value must be either
-                `GLFW_TRUE` to disable the mouse button limit when calling the mouse button
-                callback, or `GLFW_FALSE` to limit the mouse buttons sent to the callback
-                to the mouse button token values up to `GLFW_MOUSE_BUTTON_LAST`.
-
-                @param window The window whose input mode to set.
-                @param mode One of `GLFW_CURSOR`, `GLFW_STICKY_KEYS`,
-                `GLFW_STICKY_MOUSE_BUTTONS`, `GLFW_LOCK_KEY_MODS` or
-                `GLFW_RAW_MOUSE_MOTION`.
-                @param value The new value of the specified input mode.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED],
-                [GLFW_INVALID_ENUM][#GLFW_INVALID_ENUM], [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR] and
-                [GLFW_FEATURE_UNAVAILABLE][#GLFW_FEATURE_UNAVAILABLE] (see above).
-
-                @glfw.thread_safety This function must only be called from the main thread.
-
-                @see #glfwGetInputMode(MemorySegment, int) glfwGetInputMode
-            """.trimIndent()
-        )
-
+        "glfwPollEvents"(void, entrypoint = "glfwPollEvents")
+        "glfwWaitEvents"(void, entrypoint = "glfwWaitEvents")
+        "glfwWaitEventsTimeout"(void, double("timeout"), entrypoint = "glfwWaitEventsTimeout")
+        "glfwPostEmptyEvent"(void, entrypoint = "glfwPostEmptyEvent")
+        "glfwGetInputMode"(int, GLFWwindow_ptr("window"), int("mode"), entrypoint = "glfwGetInputMode")
+        "glfwSetInputMode"(void, GLFWwindow_ptr("window"), int("mode"), int("value"), entrypoint = "glfwSetInputMode")
         +"glfwRawMouseMotionSupported"(
             glfw_boolean,
             entrypoint = "glfwRawMouseMotionSupported",
-            javadoc = """
-                Returns whether raw mouse motion is supported.
-
-                This function returns whether raw mouse motion is supported on the current
-                system.  This status does not change after GLFW has been initialized so you
-                only need to check this once.  If you attempt to enable raw motion on
-                a system that does not support it, [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR] will be emitted.
-
-                Raw mouse motion is closer to the actual motion of the mouse across
-                a surface.  It is not affected by the scaling and acceleration applied to
-                the motion of the desktop cursor.  That processing is suitable for a cursor
-                while raw motion is better for controlling for example a 3D camera.  Because
-                of this, raw mouse motion is only provided when the cursor is disabled.
-
-                @return `GLFW_TRUE` if raw mouse motion is supported on the current machine,
-                or `GLFW_FALSE` otherwise.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-
-                @glfw.thread_safety This function must only be called from the main thread.
-
-                @see #glfwSetInputMode(MemorySegment, int, int) glfwSetInputMode
-            """.trimIndent(),
             addNow = false
         ).overload()
-
         +"glfwGetKeyName_"(
             const_char_ptr,
             int("key"),
             int("scancode"),
-            entrypoint = "glfwGetKeyName",
-            javadoc = """
-                Returns the layout-specific name of the specified printable key.
-
-                This function returns the name of the specified printable key, encoded as
-                UTF-8.  This is typically the character that key would produce without any
-                modifier keys, intended for displaying key bindings to the user.  For dead
-                keys, it is typically the diacritic it would add to a character.
-
-                __Do not use this function__ for text input.  You will
-                break text input for many languages even if it happens to work for yours.
-
-                If the key is `GLFW_KEY_UNKNOWN`, the scancode is used to identify the key,
-                otherwise the scancode is ignored.  If you specify a non-printable key, or
-                `GLFW_KEY_UNKNOWN` and a scancode that maps to a non-printable key, this
-                function returns `NULL` but does not emit an error.
-
-                This behavior allows you to always pass in the arguments in the
-                key callback without modification.
-
-                The printable keys are:
-                - `GLFW_KEY_APOSTROPHE`
-                - `GLFW_KEY_COMMA`
-                - `GLFW_KEY_MINUS`
-                - `GLFW_KEY_PERIOD`
-                - `GLFW_KEY_SLASH`
-                - `GLFW_KEY_SEMICOLON`
-                - `GLFW_KEY_EQUAL`
-                - `GLFW_KEY_LEFT_BRACKET`
-                - `GLFW_KEY_RIGHT_BRACKET`
-                - `GLFW_KEY_BACKSLASH`
-                - `GLFW_KEY_WORLD_1`
-                - `GLFW_KEY_WORLD_2`
-                - `GLFW_KEY_0` to `GLFW_KEY_9`
-                - `GLFW_KEY_A` to `GLFW_KEY_Z`
-                - `GLFW_KEY_KP_0` to `GLFW_KEY_KP_9`
-                - `GLFW_KEY_KP_DECIMAL`
-                - `GLFW_KEY_KP_DIVIDE`
-                - `GLFW_KEY_KP_MULTIPLY`
-                - `GLFW_KEY_KP_SUBTRACT`
-                - `GLFW_KEY_KP_ADD`
-                - `GLFW_KEY_KP_EQUAL`
-
-                Names for printable keys depend on keyboard layout, while names for
-                non-printable keys are the same across layouts but depend on the application
-                language and should be localized along with other user interface text.
-
-                @param key The key to query, or `GLFW_KEY_UNKNOWN`.
-                @param scancode The scancode of the key to query.
-                @return The UTF-8 encoded, layout-specific name of the key, or `NULL`.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED],
-                [GLFW_INVALID_VALUE][#GLFW_INVALID_VALUE], [GLFW_INVALID_ENUM][#GLFW_INVALID_ENUM] and [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-
-                @glfw.remark The contents of the returned string may change when a keyboard
-                layout change event is received.
-
-                @glfw.pointer_lifetime The returned string is allocated and freed by GLFW.  You
-                should not free it yourself.  It is valid until the library is terminated.
-
-                @glfw.thread_safety This function must only be called from the main thread.
-            """.trimIndent()
+            entrypoint = "glfwGetKeyName"
         ).overload(name = "glfwGetKeyName")
-
-        "glfwGetKeyScancode"(
-            int,
-            int("key"),
-            entrypoint = "glfwGetKeyScancode",
-            javadoc = """
-                Returns the platform-specific scancode of the specified key.
-
-                This function returns the platform-specific scancode of the specified key.
-
-                If the specified key token corresponds to a physical key not
-                supported on the current platform then this method will return `-1`.
-                Calling this function with anything other than a key token will return `-1`
-                and generate a [GLFW_INVALID_ENUM][#GLFW_INVALID_ENUM] error.
-
-                @param key Any key token.
-                @return The platform-specific scancode for the key, or `-1` if the key is
-                not supported on the current platform or an error
-                occurred.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-                [GLFW_INVALID_ENUM][#GLFW_INVALID_ENUM].
-
-                @glfw.thread_safety This function may be called from any thread.
-            """.trimIndent()
-        )
-
-        "glfwGetKey"(
-            int,
-            GLFWwindow_ptr("window"),
-            int("key"),
-            entrypoint = "glfwGetKey",
-            javadoc = """
-                Returns the last reported state of a keyboard key for the specified
-                window.
-
-                This function returns the last state reported for the specified key to the
-                specified window.  The returned state is one of `GLFW_PRESS` or
-                `GLFW_RELEASE`.  The action `GLFW_REPEAT` is only reported to the key callback.
-
-                If the [GLFW_STICKY_KEYS][#GLFW_STICKY_KEYS] input mode is enabled, this function returns
-                `GLFW_PRESS` the first time you call it for a key that was pressed, even if
-                that key has already been released.
-
-                The key functions deal with physical keys, with key tokens
-                named after their use on the standard US keyboard layout.  If you want to
-                input text, use the Unicode character callback instead.
-
-                The modifier key bit masks are not key tokens and cannot be
-                used with this function.
-
-                __Do not use this function__ to implement text input.
-
-                @param window The desired window.
-                @param key The desired keyboard key.  `GLFW_KEY_UNKNOWN` is
-                not a valid key for this function.
-                @return One of `GLFW_PRESS` or `GLFW_RELEASE`.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-                [GLFW_INVALID_ENUM][#GLFW_INVALID_ENUM].
-
-                @glfw.thread_safety This function must only be called from the main thread.
-            """.trimIndent()
-        )
-
-        "glfwGetMouseButton"(
-            int,
-            GLFWwindow_ptr("window"),
-            int("button"),
-            entrypoint = "glfwGetMouseButton",
-            javadoc = """
-                Returns the last reported state of a mouse button for the specified
-                window.
-
-                This function returns the last state reported for the specified mouse button
-                to the specified window.  The returned state is one of `GLFW_PRESS` or
-                `GLFW_RELEASE`.
-
-                If the [GLFW_STICKY_MOUSE_BUTTONS][#GLFW_STICKY_MOUSE_BUTTONS] input mode is enabled, this function
-                returns `GLFW_PRESS` the first time you call it for a mouse button that was
-                pressed, even if that mouse button has already been released.
-
-                The [GLFW_UNLIMITED_MOUSE_BUTTONS][#GLFW_UNLIMITED_MOUSE_BUTTONS] input mode does not effect the
-                limit on buttons which can be polled with this function.
-
-                @param window The desired window.
-                @param button The desired mouse button token.
-                @return One of `GLFW_PRESS` or `GLFW_RELEASE`.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-                [GLFW_INVALID_ENUM][#GLFW_INVALID_ENUM].
-
-                @glfw.thread_safety This function must only be called from the main thread.
-            """.trimIndent()
-        )
-
+        "glfwGetKeyScancode"(int, int("key"), entrypoint = "glfwGetKeyScancode")
+        "glfwGetKey"(int, GLFWwindow_ptr("window"), int("key"), entrypoint = "glfwGetKey")
+        "glfwGetMouseButton"(int, GLFWwindow_ptr("window"), int("button"), entrypoint = "glfwGetMouseButton")
         +"glfwGetCursorPos"(
             void,
             GLFWwindow_ptr("window"),
             double_ptr("xpos").ref(),
             double_ptr("ypos").ref(),
-            entrypoint = "glfwGetCursorPos",
-            javadoc = """
-                Retrieves the position of the cursor relative to the content area of
-                the window.
-
-                This function returns the position of the cursor, in screen coordinates,
-                relative to the upper-left corner of the content area of the specified
-                window.
-
-                If the cursor is disabled (with `GLFW_CURSOR_DISABLED`) then the cursor
-                position is unbounded and limited only by the minimum and maximum values of
-                a `double`.
-
-                The coordinate can be converted to their integer equivalents with the
-                `floor` function.  Casting directly to an integer type works for positive
-                coordinates, but fails for negative ones.
-
-                Any or all of the position arguments may be `NULL`.  If an error occurs, all
-                non-`NULL` position arguments will be set to zero.
-
-                @param window The desired window.
-                @param xpos Where to store the cursor x-coordinate, relative to the
-                left edge of the content area, or `NULL`.
-                @param ypos Where to store the cursor y-coordinate, relative to the to
-                top edge of the content area, or `NULL`.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-                [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-
-                @glfw.thread_safety This function must only be called from the main thread.
-
-                @see #glfwSetCursorPos(MemorySegment, double, double) glfwSetCursorPos
-            """.trimIndent()
+            entrypoint = "glfwGetCursorPos"
         ).overload()
-
         "glfwSetCursorPos"(
             void,
             GLFWwindow_ptr("window"),
             double("xpos"),
             double("ypos"),
-            entrypoint = "glfwSetCursorPos",
-            javadoc = """
-                Sets the position of the cursor, relative to the content area of the
-                window.
-
-                This function sets the position, in screen coordinates, of the cursor
-                relative to the upper-left corner of the content area of the specified
-                window.  The window must have input focus.  If the window does not have
-                input focus when this function is called, it fails silently.
-
-                __Do not use this function__ to implement things like camera controls.  GLFW
-                already provides the `GLFW_CURSOR_DISABLED` cursor mode that hides the
-                cursor, transparently re-centers it and provides unconstrained cursor
-                motion.  See [glfwSetInputMode][#glfwSetInputMode(MemorySegment, int, int)] for more information.
-
-                If the cursor mode is `GLFW_CURSOR_DISABLED` then the cursor position is
-                unconstrained and limited only by the minimum and maximum values of
-                a `double`.
-
-                @param window The desired window.
-                @param xpos The desired x-coordinate, relative to the left edge of the
-                content area.
-                @param ypos The desired y-coordinate, relative to the top edge of the
-                content area.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED],
-                [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR] and [GLFW_FEATURE_UNAVAILABLE][#GLFW_FEATURE_UNAVAILABLE] (see remarks).
-
-                @glfw.remark @wayland This function will only work when the cursor mode is
-                `GLFW_CURSOR_DISABLED`, otherwise it will emit [GLFW_FEATURE_UNAVAILABLE][#GLFW_FEATURE_UNAVAILABLE].
-
-                @glfw.thread_safety This function must only be called from the main thread.
-
-                @see #glfwGetCursorPos(MemorySegment, MemorySegment, MemorySegment) glfwGetCursorPos
-            """.trimIndent()
+            entrypoint = "glfwSetCursorPos"
         )
-
         "glfwCreateCursor"(
             GLFWcursor_ptr,
             const_GLFWimage_ptr("image"),
             int("xhot"),
             int("yhot"),
-            entrypoint = "glfwCreateCursor",
-            javadoc = """
-                Creates a custom cursor.
-
-                Creates a new custom cursor image that can be set for a window with
-                [glfwSetCursor][#glfwSetCursor(MemorySegment, MemorySegment)].  The cursor can be destroyed with [glfwDestroyCursor][#glfwDestroyCursor(MemorySegment)].
-                Any remaining cursors are destroyed by [glfwTerminate][#glfwTerminate()].
-
-                The pixels are 32-bit, little-endian, non-premultiplied RGBA, i.e. eight
-                bits per channel with the red channel first.  They are arranged canonically
-                as packed sequential rows, starting from the top-left corner.
-
-                The cursor hotspot is specified in pixels, relative to the upper-left corner
-                of the cursor image.  Like all other coordinate systems in GLFW, the X-axis
-                points to the right and the Y-axis points down.
-
-                @param image The desired cursor image.
-                @param xhot The desired x-coordinate, in pixels, of the cursor hotspot.
-                @param yhot The desired y-coordinate, in pixels, of the cursor hotspot.
-                @return The handle of the created cursor, or `NULL` if an
-                error occurred.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED],
-                [GLFW_INVALID_VALUE][#GLFW_INVALID_VALUE] and [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-
-                @glfw.pointer_lifetime The specified image data is copied before this function
-                returns.
-
-                @glfw.thread_safety This function must only be called from the main thread.
-
-                @see #glfwDestroyCursor(MemorySegment) glfwDestroyCursor
-                @see #glfwCreateStandardCursor(int) glfwCreateStandardCursor
-            """.trimIndent()
+            entrypoint = "glfwCreateCursor"
         )
-
-        "glfwCreateStandardCursor"(
-            GLFWcursor_ptr,
-            int("shape"),
-            entrypoint = "glfwCreateStandardCursor",
-            javadoc = """
-                Creates a cursor with a standard shape.
-
-                Returns a cursor with a standard shape, that can be set for a window with
-                [glfwSetCursor][#glfwSetCursor(MemorySegment, MemorySegment)].  The images for these cursors come from the system
-                cursor theme and their exact appearance will vary between platforms.
-
-                Most of these shapes are guaranteed to exist on every supported platform but
-                a few may not be present.  See the table below for details.
-
-                | Cursor shape                   | Windows | macOS | X11    | Wayland |
-                | ------------------------------ | ------- | ----- | ------ | ------- |
-                | [GLFW_ARROW_CURSOR][#GLFW_ARROW_CURSOR]         | Yes     | Yes   | Yes    | Yes |
-                | [GLFW_IBEAM_CURSOR][#GLFW_IBEAM_CURSOR]         | Yes     | Yes   | Yes    | Yes |
-                | [GLFW_CROSSHAIR_CURSOR][#GLFW_CROSSHAIR_CURSOR]     | Yes     | Yes   | Yes    | Yes |
-                | [GLFW_POINTING_HAND_CURSOR][#GLFW_POINTING_HAND_CURSOR] | Yes     | Yes   | Yes    | Yes |
-                | [GLFW_RESIZE_EW_CURSOR][#GLFW_RESIZE_EW_CURSOR]     | Yes     | Yes   | Yes    | Yes |
-                | [GLFW_RESIZE_NS_CURSOR][#GLFW_RESIZE_NS_CURSOR]     | Yes     | Yes   | Yes    | Yes |
-                | [GLFW_RESIZE_NWSE_CURSOR][#GLFW_RESIZE_NWSE_CURSOR]   | Yes     | Yes<sup>1</sup> | Maybe<sup>2</sup> | Maybe<sup>2</sup> |
-                | [GLFW_RESIZE_NESW_CURSOR][#GLFW_RESIZE_NESW_CURSOR]   | Yes     | Yes<sup>1</sup> | Maybe<sup>2</sup> | Maybe<sup>2</sup> |
-                | [GLFW_RESIZE_ALL_CURSOR][#GLFW_RESIZE_ALL_CURSOR]    | Yes     | Yes   | Yes    | Yes |
-                | [GLFW_NOT_ALLOWED_CURSOR][#GLFW_NOT_ALLOWED_CURSOR]   | Yes     | Yes   | Maybe<sup>2</sup> | Maybe<sup>2</sup> |
-
-                1. This uses a private system API and may fail in the future.
-                2. This uses a newer standard that not all cursor themes support.
-
-                If the requested shape is not available, this function emits a
-                [GLFW_CURSOR_UNAVAILABLE][#GLFW_CURSOR_UNAVAILABLE] error and returns `NULL`.
-
-                @param shape One of the standard shapes.
-                @return A new cursor ready to use or `NULL` if an
-                error occurred.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED],
-                [GLFW_INVALID_ENUM][#GLFW_INVALID_ENUM], [GLFW_CURSOR_UNAVAILABLE][#GLFW_CURSOR_UNAVAILABLE] and
-                [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-
-                @glfw.thread_safety This function must only be called from the main thread.
-
-                @see #glfwCreateCursor(MemorySegment, int, int) glfwCreateCursor
-            """.trimIndent()
-        )
-
-        "glfwDestroyCursor"(
-            void,
-            GLFWcursor_ptr("cursor"),
-            entrypoint = "glfwDestroyCursor",
-            javadoc = """
-                Destroys a cursor.
-
-                This function destroys a cursor previously created with
-                [glfwCreateCursor][#glfwCreateCursor(MemorySegment, int, int)].  Any remaining cursors will be destroyed by
-                [glfwTerminate][#glfwTerminate()].
-
-                If the specified cursor is current for any window, that window will be
-                reverted to the default cursor.  This does not affect the cursor mode.
-
-                @param cursor The cursor object to destroy.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-                [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-
-                @glfw.reentrancy This function must not be called from a callback.
-
-                @glfw.thread_safety This function must only be called from the main thread.
-
-                @see #glfwCreateCursor(MemorySegment, int, int) glfwCreateCursor
-            """.trimIndent()
-        )
-
-        "glfwSetCursor"(
-            void,
-            GLFWwindow_ptr("window"),
-            GLFWcursor_ptr("cursor"),
-            entrypoint = "glfwSetCursor",
-            javadoc = """
-                Sets the cursor for the window.
-
-                This function sets the cursor image to be used when the cursor is over the
-                content area of the specified window.  The set cursor will only be visible
-                when the cursor mode of the window is
-                `GLFW_CURSOR_NORMAL`.
-
-                On some platforms, the set cursor may not be visible unless the window also
-                has input focus.
-
-                @param window The window to set the cursor for.
-                @param cursor The cursor to set, or `NULL` to switch back to the default
-                arrow cursor.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-                [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-
-                @glfw.thread_safety This function must only be called from the main thread.
-            """.trimIndent()
-        )
+        "glfwCreateStandardCursor"(GLFWcursor_ptr, int("shape"), entrypoint = "glfwCreateStandardCursor")
+        "glfwDestroyCursor"(void, GLFWcursor_ptr("cursor"), entrypoint = "glfwDestroyCursor")
+        "glfwSetCursor"(void, GLFWwindow_ptr("window"), GLFWcursor_ptr("cursor"), entrypoint = "glfwSetCursor")
 
         //region Callback 2
-        windowCallback(
-            "glfwSetKeyCallback",
-            GLFWkeyfun,
-            javadoc = """
-                Sets the key callback.
-
-                This function sets the key callback of the specified window, which is called
-                when a key is pressed, repeated or released.
-
-                The key functions deal with physical keys, with layout independent
-                key tokens named after their values in the standard US keyboard
-                layout.  If you want to input text, use the
-                [character callback][#glfwSetCharCallback(MemorySegment, MemorySegment)] instead.
-
-                When a window loses input focus, it will generate synthetic key release
-                events for all pressed keys with associated key tokens.  You can tell these
-                events from user-generated events by the fact that the synthetic ones are
-                generated after the focus loss event has been processed, i.e. after the
-                [window focus callback][#glfwSetWindowFocusCallback(MemorySegment, MemorySegment)] has been called.
-
-                The scancode of a key is specific to that platform or sometimes even to that
-                machine.  Scancodes are intended to allow users to bind keys that don't have
-                a GLFW key token.  Such keys have `key` set to `GLFW_KEY_UNKNOWN`, their
-                state is not saved and so it cannot be queried with [glfwGetKey][#glfwGetKey(MemorySegment, int)].
-
-                Sometimes GLFW needs to generate synthetic key events, in which case the
-                scancode may be zero.
-
-                @param window The window whose callback to set.
-                @param callback The new key callback, or `NULL` to remove the currently
-                set callback.
-                @return The previously set callback, or `NULL` if no callback was set or the
-                library had not been initialized.
-
-                @glfw.callback_signature
-                For more information about the callback parameters, see the
-                [function pointer type][GLFWKeyFun].
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-
-                @glfw.thread_safety This function must only be called from the main thread.
-            """.trimIndent()
-        )
-
-        windowCallback(
-            "glfwSetCharCallback",
-            GLFWcharfun,
-            javadoc = """
-                Sets the Unicode character callback.
-
-                This function sets the character callback of the specified window, which is
-                called when a Unicode character is input.
-
-                The character callback is intended for Unicode text input.  As it deals with
-                characters, it is keyboard layout dependent, whereas the
-                [key callback][#glfwSetKeyCallback(MemorySegment, MemorySegment)] is not.  Characters do not map 1:1
-                to physical keys, as a key may produce zero, one or more characters.  If you
-                want to know whether a specific physical key was pressed or released, see
-                the key callback instead.
-
-                The character callback behaves as system text input normally does and will
-                not be called if modifier keys are held down that would prevent normal text
-                input on that platform, for example a Super (Command) key on macOS or Alt key
-                on Windows.
-
-                @param window The window whose callback to set.
-                @param callback The new callback, or `NULL` to remove the currently set
-                callback.
-                @return The previously set callback, or `NULL` if no callback was set or the
-                library had not been initialized.
-
-                @glfw.callback_signature
-                For more information about the callback parameters, see the
-                [function pointer type][GLFWCharFun].
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-
-                @glfw.thread_safety This function must only be called from the main thread.
-            """.trimIndent()
-        )
-
-        windowCallback(
-            "glfwSetMouseButtonCallback",
-            GLFWmousebuttonfun,
-            javadoc = """
-                Sets the mouse button callback.
-
-                This function sets the mouse button callback of the specified window, which
-                is called when a mouse button is pressed or released.
-
-                When a window loses input focus, it will generate synthetic mouse button
-                release events for all pressed mouse buttons with associated button tokens.
-                You can tell these events from user-generated events by the fact that the
-                synthetic ones are generated after the focus loss event has been processed,
-                i.e. after the [window focus callback][#glfwSetWindowFocusCallback(MemorySegment, MemorySegment)] has
-                been called.
-
-                The reported `button` value can be higher than `GLFW_MOUSE_BUTTON_LAST` if
-                the button does not have an associated button token and the
-                [GLFW_UNLIMITED_MOUSE_BUTTONS][#GLFW_UNLIMITED_MOUSE_BUTTONS] input mode is set.
-
-                @param window The window whose callback to set.
-                @param callback The new callback, or `NULL` to remove the currently set
-                callback.
-                @return The previously set callback, or `NULL` if no callback was set or the
-                library had not been initialized.
-
-                @glfw.callback_signature
-                For more information about the callback parameters, see the
-                [function pointer type][GLFWMouseButtonFun].
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-
-                @glfw.thread_safety This function must only be called from the main thread.
-            """.trimIndent()
-        )
-
-        windowCallback(
-            "glfwSetCursorPosCallback",
-            GLFWcursorposfun,
-            javadoc = """
-                Sets the cursor position callback.
-
-                This function sets the cursor position callback of the specified window,
-                which is called when the cursor is moved.  The callback is provided with the
-                position, in screen coordinates, relative to the upper-left corner of the
-                content area of the window.
-
-                @param window The window whose callback to set.
-                @param callback The new callback, or `NULL` to remove the currently set
-                callback.
-                @return The previously set callback, or `NULL` if no callback was set or the
-                library had not been initialized.
-
-                @glfw.callback_signature
-                For more information about the callback parameters, see the
-                [function pointer type][GLFWCursorPosFun].
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-
-                @glfw.thread_safety This function must only be called from the main thread.
-            """.trimIndent()
-        )
-
-        windowCallback(
-            "glfwSetCursorEnterCallback",
-            GLFWcursorenterfun,
-            javadoc = """
-                Sets the cursor enter/leave callback.
-
-                This function sets the cursor boundary crossing callback of the specified
-                window, which is called when the cursor enters or leaves the content area of
-                the window.
-
-                @param window The window whose callback to set.
-                @param callback The new callback, or `NULL` to remove the currently set
-                callback.
-                @return The previously set callback, or `NULL` if no callback was set or the
-                library had not been initialized.
-
-                @glfw.callback_signature
-                For more information about the callback parameters, see the
-                [function pointer type][GLFWCursorEnterFun].
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-
-                @glfw.thread_safety This function must only be called from the main thread.
-            """.trimIndent()
-        )
-
-        windowCallback(
-            "glfwSetScrollCallback",
-            GLFWscrollfun,
-            javadoc = """
-                Sets the scroll callback.
-
-                This function sets the scroll callback of the specified window, which is
-                called when a scrolling device is used, such as a mouse wheel or scrolling
-                area of a touchpad.
-
-                The scroll callback receives all scrolling input, like that from a mouse
-                wheel or a touchpad scrolling area.
-
-                @param window The window whose callback to set.
-                @param callback The new scroll callback, or `NULL` to remove the
-                currently set callback.
-                @return The previously set callback, or `NULL` if no callback was set or the
-                library had not been initialized.
-
-                @glfw.callback_signature
-                For more information about the callback parameters, see the
-                [function pointer type][GLFWScrollFun].
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-
-                @glfw.thread_safety This function must only be called from the main thread.
-            """.trimIndent()
-        )
-
-        windowCallback(
-            "glfwSetDropCallback",
-            GLFWdropfun,
-            javadoc = """
-                Sets the path drop callback.
-
-                This function sets the path drop callback of the specified window, which is
-                called when one or more dragged paths are dropped on the window.
-
-                Because the path array and its strings may have been generated specifically
-                for that event, they are not guaranteed to be valid after the callback has
-                returned.  If you wish to use them after the callback returns, you need to
-                make a deep copy.
-
-                @param window The window whose callback to set.
-                @param callback The new file drop callback, or `NULL` to remove the
-                currently set callback.
-                @return The previously set callback, or `NULL` if no callback was set or the
-                library had not been initialized.
-
-                @glfw.callback_signature
-                For more information about the callback parameters, see the
-                [function pointer type][GLFWDropFun].
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-
-                @glfw.thread_safety This function must only be called from the main thread.
-            """.trimIndent()
-        )
+        windowCallback("glfwSetKeyCallback", GLFWkeyfun)
+        windowCallback("glfwSetCharCallback", GLFWcharfun)
+        windowCallback("glfwSetMouseButtonCallback", GLFWmousebuttonfun)
+        windowCallback("glfwSetCursorPosCallback", GLFWcursorposfun)
+        windowCallback("glfwSetCursorEnterCallback", GLFWcursorenterfun)
+        windowCallback("glfwSetScrollCallback", GLFWscrollfun)
+        windowCallback("glfwSetDropCallback", GLFWdropfun)
         //endregion
 
-        +"glfwJoystickPresent"(
-            glfw_boolean,
-            int("jid"),
-            entrypoint = "glfwJoystickPresent",
-            javadoc = """
-                Returns whether the specified joystick is present.
-
-                This function returns whether the specified joystick is present.
-
-                There is no need to call this function before other functions that accept
-                a joystick ID, as they all check for presence before performing any other
-                work.
-
-                @param jid The joystick to query.
-                @return `GLFW_TRUE` if the joystick is present, or `GLFW_FALSE` otherwise.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED],
-                [GLFW_INVALID_ENUM][#GLFW_INVALID_ENUM] and [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-
-                @glfw.thread_safety This function must only be called from the main thread.
-            """.trimIndent(),
-            addNow = false
-        ).overload()
-
+        +"glfwJoystickPresent"(glfw_boolean, int("jid"), entrypoint = "glfwJoystickPresent", addNow = false).overload()
         "glfwGetJoystickAxes"(
             jfloat_array c "const float*",
             int("jid"),
             int_ptr("count").ref(),
-            entrypoint = "glfwGetJoystickAxes",
-            javadoc = """
-                Returns the values of all axes of the specified joystick.
-
-                This function returns the values of all axes of the specified joystick.
-                Each element in the array is a value between -1.0 and 1.0.
-
-                If the specified joystick is not present this function will return `NULL`
-                but will not generate an error.  This can be used instead of first calling
-                [glfwJoystickPresent][#glfwJoystickPresent(int)].
-
-                @param jid The joystick to query.
-                @param count Where to store the number of axis values in the returned
-                array.  This is set to zero if the joystick is not present or an error
-                occurred.
-                @return An array of axis values, or `NULL` if the joystick is not present or
-                an error occurred.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED],
-                [GLFW_INVALID_ENUM][#GLFW_INVALID_ENUM] and [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-
-                @glfw.pointer_lifetime The returned array is allocated and freed by GLFW.  You
-                should not free it yourself.  It is valid until the specified joystick is
-                disconnected or the library is terminated.
-
-                @glfw.thread_safety This function must only be called from the main thread.
-            """.trimIndent()
+            entrypoint = "glfwGetJoystickAxes"
         )
-
         "glfwGetJoystickButtons"(
             address c "const unsigned char*",
             int("jid"),
             int_ptr("count").ref(),
-            entrypoint = "glfwGetJoystickButtons",
-            javadoc = """
-                Returns the state of all buttons of the specified joystick.
-
-                This function returns the state of all buttons of the specified joystick.
-                Each element in the array is either `GLFW_PRESS` or `GLFW_RELEASE`.
-
-                For backward compatibility with earlier versions that did not have
-                [glfwGetJoystickHats][#glfwGetJoystickHats(int, MemorySegment)], the button array also includes all hats, each
-                represented as four buttons.  The hats are in the same order as returned by
-                __glfwGetJoystickHats__ and are in the order _up_, _right_, _down_ and
-                _left_.  To disable these extra buttons, set the
-                [GLFW_JOYSTICK_HAT_BUTTONS][#GLFW_JOYSTICK_HAT_BUTTONS] init hint before initialization.
-
-                If the specified joystick is not present this function will return `NULL`
-                but will not generate an error.  This can be used instead of first calling
-                [glfwJoystickPresent][#glfwJoystickPresent(int)].
-
-                @param jid The joystick to query.
-                @param count Where to store the number of button states in the returned
-                array.  This is set to zero if the joystick is not present or an error
-                occurred.
-                @return An array of button states, or `NULL` if the joystick is not present
-                or an error occurred.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED],
-                [GLFW_INVALID_ENUM][#GLFW_INVALID_ENUM] and [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-
-                @glfw.pointer_lifetime The returned array is allocated and freed by GLFW.  You
-                should not free it yourself.  It is valid until the specified joystick is
-                disconnected or the library is terminated.
-
-                @glfw.thread_safety This function must only be called from the main thread.
-            """.trimIndent()
+            entrypoint = "glfwGetJoystickButtons"
         )
-
         "glfwGetJoystickHats"(
             address c "const unsigned char*",
             int("jid"),
             int_ptr("count").ref(),
-            entrypoint = "glfwGetJoystickHats",
-            javadoc = """
-                Returns the state of all hats of the specified joystick.
-
-                This function returns the state of all hats of the specified joystick.
-                Each element in the array is one of the following values:
-
-                | Name                  | Value |
-                | ----                  | ----- |
-                | `GLFW_HAT_CENTERED`   | 0 |
-                | `GLFW_HAT_UP`         | 1 |
-                | `GLFW_HAT_RIGHT`      | 2 |
-                | `GLFW_HAT_DOWN`       | 4 |
-                | `GLFW_HAT_LEFT`       | 8 |
-                | `GLFW_HAT_RIGHT_UP`   | `GLFW_HAT_RIGHT` \| `GLFW_HAT_UP` |
-                | `GLFW_HAT_RIGHT_DOWN` | `GLFW_HAT_RIGHT` \| `GLFW_HAT_DOWN` |
-                | `GLFW_HAT_LEFT_UP`    | `GLFW_HAT_LEFT` \| `GLFW_HAT_UP` |
-                | `GLFW_HAT_LEFT_DOWN`  | `GLFW_HAT_LEFT` \| `GLFW_HAT_DOWN` |
-
-                The diagonal directions are bitwise combinations of the primary (up, right,
-                down and left) directions and you can test for these individually by ANDing
-                it with the corresponding direction.
-
-                ```java
-                if (hats[2] & GLFW_HAT_RIGHT)
-                {
-                    // State of hat 2 could be right-up, right or right-down
-                }
-                ```
-
-                If the specified joystick is not present this function will return `NULL`
-                but will not generate an error.  This can be used instead of first calling
-                [glfwJoystickPresent][#glfwJoystickPresent(int)].
-
-                @param jid The joystick to query.
-                @param count Where to store the number of hat states in the returned
-                array.  This is set to zero if the joystick is not present or an error
-                occurred.
-                @return An array of hat states, or `NULL` if the joystick is not present
-                or an error occurred.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED],
-                [GLFW_INVALID_ENUM][#GLFW_INVALID_ENUM] and [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-
-                @glfw.pointer_lifetime The returned array is allocated and freed by GLFW.  You
-                should not free it yourself.  It is valid until the specified joystick is
-                disconnected, this function is called again for that joystick or the library
-                is terminated.
-
-                @glfw.thread_safety This function must only be called from the main thread.
-            """.trimIndent()
+            entrypoint = "glfwGetJoystickHats"
         )
-
         +"glfwGetJoystickName_"(
             const_char_ptr,
             int("jid"),
-            entrypoint = "glfwGetJoystickName",
-            javadoc = """
-                Returns the name of the specified joystick.
-
-                This function returns the name, encoded as UTF-8, of the specified joystick.
-                The returned string is allocated and freed by GLFW.  You should not free it
-                yourself.
-
-                If the specified joystick is not present this function will return `NULL`
-                but will not generate an error.  This can be used instead of first calling
-                [glfwJoystickPresent][#glfwJoystickPresent(int)].
-
-                @param jid The joystick to query.
-                @return The UTF-8 encoded name of the joystick, or `NULL` if the joystick
-                is not present or an error occurred.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED],
-                [GLFW_INVALID_ENUM][#GLFW_INVALID_ENUM] and [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-
-                @glfw.pointer_lifetime The returned string is allocated and freed by GLFW.  You
-                should not free it yourself.  It is valid until the specified joystick is
-                disconnected or the library is terminated.
-
-                @glfw.thread_safety This function must only be called from the main thread.
-            """.trimIndent()
+            entrypoint = "glfwGetJoystickName"
         ).overload(name = "glfwGetJoystickName")
-
         +"glfwGetJoystickGUID_"(
             const_char_ptr,
             int("jid"),
-            entrypoint = "glfwGetJoystickGUID",
-            javadoc = """
-                Returns the SDL compatible GUID of the specified joystick.
-
-                This function returns the SDL compatible GUID, as a UTF-8 encoded
-                hexadecimal string, of the specified joystick.  The returned string is
-                allocated and freed by GLFW.  You should not free it yourself.
-
-                The GUID is what connects a joystick to a gamepad mapping.  A connected
-                joystick will always have a GUID even if there is no gamepad mapping
-                assigned to it.
-
-                If the specified joystick is not present this function will return `NULL`
-                but will not generate an error.  This can be used instead of first calling
-                [glfwJoystickPresent][#glfwJoystickPresent(int)].
-
-                The GUID uses the format introduced in SDL 2.0.5.  This GUID tries to
-                uniquely identify the make and model of a joystick but does not identify
-                a specific unit, e.g. all wired Xbox 360 controllers will have the same
-                GUID on that platform.  The GUID for a unit may vary between platforms
-                depending on what hardware information the platform specific APIs provide.
-
-                @param jid The joystick to query.
-                @return The UTF-8 encoded GUID of the joystick, or `NULL` if the joystick
-                is not present or an error occurred.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED],
-                [GLFW_INVALID_ENUM][#GLFW_INVALID_ENUM] and [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-
-                @glfw.pointer_lifetime The returned string is allocated and freed by GLFW.  You
-                should not free it yourself.  It is valid until the specified joystick is
-                disconnected or the library is terminated.
-
-                @glfw.thread_safety This function must only be called from the main thread.
-            """.trimIndent()
+            entrypoint = "glfwGetJoystickGUID"
         ).overload(name = "glfwGetJoystickGUID")
-
-        "glfwSetJoystickUserPointer"(
-            void,
-            int("jid"),
-            void_ptr("pointer"),
-            entrypoint = "glfwSetJoystickUserPointer",
-            javadoc = """
-                Sets the user pointer of the specified joystick.
-
-                This function sets the user-defined pointer of the specified joystick.  The
-                current value is retained until the joystick is disconnected.  The initial
-                value is `NULL`.
-
-                This function may be called from the joystick callback, even for a joystick
-                that is being disconnected.
-
-                @param jid The joystick whose pointer to set.
-                @param pointer The new value.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-
-                @glfw.thread_safety This function may be called from any thread.  Access is not
-                synchronized.
-
-                @see #glfwGetJoystickUserPointer(int) glfwGetJoystickUserPointer
-            """.trimIndent()
-        )
-
-        "glfwGetJoystickUserPointer"(
-            void_ptr,
-            int("jid"),
-            entrypoint = "glfwGetJoystickUserPointer",
-            javadoc = """
-                Returns the user pointer of the specified joystick.
-
-                This function returns the current value of the user-defined pointer of the
-                specified joystick.  The initial value is `NULL`.
-
-                This function may be called from the joystick callback, even for a joystick
-                that is being disconnected.
-
-                @param jid The joystick whose pointer to return.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-
-                @glfw.thread_safety This function may be called from any thread.  Access is not
-                synchronized.
-
-                @see #glfwSetJoystickUserPointer(int, MemorySegment) glfwSetJoystickUserPointer
-            """.trimIndent()
-        )
-
+        "glfwSetJoystickUserPointer"(void, int("jid"), void_ptr("pointer"), entrypoint = "glfwSetJoystickUserPointer")
+        "glfwGetJoystickUserPointer"(void_ptr, int("jid"), entrypoint = "glfwGetJoystickUserPointer")
         +"glfwJoystickIsGamepad"(
             glfw_boolean,
             int("jid"),
             entrypoint = "glfwJoystickIsGamepad",
-            javadoc = """
-                Returns whether the specified joystick has a gamepad mapping.
-
-                This function returns whether the specified joystick is both present and has
-                a gamepad mapping.
-
-                If the specified joystick is present but does not have a gamepad mapping
-                this function will return `GLFW_FALSE` but will not generate an error.  Call
-                [glfwJoystickPresent][#glfwJoystickPresent(int)] to check if a joystick is present regardless of
-                whether it has a mapping.
-
-                @param jid The joystick to query.
-                @return `GLFW_TRUE` if a joystick is both present and has a gamepad mapping,
-                or `GLFW_FALSE` otherwise.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-                [GLFW_INVALID_ENUM][#GLFW_INVALID_ENUM].
-
-                @glfw.thread_safety This function must only be called from the main thread.
-
-                @see #glfwGetGamepadState(int, MemorySegment) glfwGetGamepadState
-            """.trimIndent(),
             addNow = false
         ).overload()
-
         +"glfwSetJoystickCallback"(
             address c "GLFWjoystickfun",
             GLFWjoystickfun("callback"),
-            entrypoint = "glfwSetJoystickCallback",
-            javadoc = """
-                Sets the joystick configuration callback.
-
-                This function sets the joystick configuration callback, or removes the
-                currently set callback.  This is called when a joystick is connected to or
-                disconnected from the system.
-
-                For joystick connection and disconnection events to be delivered on all
-                platforms, you need to call one of the [event processing](@ref events)
-                functions.  Joystick disconnection may also be detected and the callback
-                called by joystick functions.  The function will then return whatever it
-                returns if the joystick is not present.
-
-                @param callback The new callback, or `NULL` to remove the currently set
-                callback.
-                @return The previously set callback, or `NULL` if no callback was set or the
-                library had not been initialized.
-
-                @glfw.callback_signature
-                For more information about the callback parameters, see the
-                [function pointer type][GLFWJoystickFun].
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-
-                @glfw.thread_safety This function must only be called from the main thread.
-            """.trimIndent()
+            entrypoint = "glfwSetJoystickCallback"
         ).callbackOverload("Arena.global()")
-
         +(+"glfwUpdateGamepadMappings"(
             glfw_boolean,
             (address.copy(
@@ -5362,68 +987,13 @@ fun main() {
                 layout = const_char_ptr.layout
             ))("string"),
             entrypoint = "glfwUpdateGamepadMappings",
-            javadoc = """
-                Adds the specified SDL_GameControllerDB gamepad mappings.
-
-                This function parses the specified ASCII encoded string and updates the
-                internal list with any gamepad mappings it finds.  This string may
-                contain either a single gamepad mapping or many mappings separated by
-                newlines.  The parser supports the full format of the `gamecontrollerdb.txt`
-                source file including empty lines and comments.
-
-                See gamepad_mapping for a description of the format.
-
-                If there is already a gamepad mapping for a given GUID in the internal list,
-                it will be replaced by the one passed to this function.  If the library is
-                terminated and re-initialized the internal list will revert to the built-in
-                default.
-
-                @param string The string containing the gamepad mappings.
-                @return `GLFW_TRUE` if successful, or `GLFW_FALSE` if an
-                error occurred.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-                [GLFW_INVALID_VALUE][#GLFW_INVALID_VALUE].
-
-                @glfw.thread_safety This function must only be called from the main thread.
-
-                @see #glfwJoystickIsGamepad(int) glfwJoystickIsGamepad
-                @see #glfwGetGamepadName(int) glfwGetGamepadName
-            """.trimIndent(),
             addNow = false,
         ).overload()).overload(parameters = listOf(const_char_ptr("string")))
-
         +"glfwGetGamepadName_"(
             const_char_ptr,
             int("jid"),
-            entrypoint = "glfwGetGamepadName",
-            javadoc = """
-                Returns the human-readable gamepad name for the specified joystick.
-
-                This function returns the human-readable name of the gamepad from the
-                gamepad mapping assigned to the specified joystick.
-
-                If the specified joystick is not present or does not have a gamepad mapping
-                this function will return `NULL` but will not generate an error.  Call
-                [glfwJoystickPresent][#glfwJoystickPresent(int)] to check whether it is present regardless of
-                whether it has a mapping.
-
-                @param jid The joystick to query.
-                @return The UTF-8 encoded name of the gamepad, or `NULL` if the
-                joystick is not present, does not have a mapping or an
-                error occurred.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and [GLFW_INVALID_ENUM][#GLFW_INVALID_ENUM].
-
-                @glfw.pointer_lifetime The returned string is allocated and freed by GLFW.  You
-                should not free it yourself.  It is valid until the specified joystick is
-                disconnected, the gamepad mappings are updated or the library is terminated.
-                @glfw.thread_safety This function must only be called from the main thread.
-
-                @see #glfwJoystickIsGamepad(int) glfwJoystickIsGamepad
-            """.trimIndent()
+            entrypoint = "glfwGetGamepadName"
         ).overload(name = "glfwGetGamepadName")
-
         +(+"glfwGetGamepadState"(
             glfw_boolean,
             int("jid"),
@@ -5433,346 +1003,27 @@ fun main() {
                 layout = GLFWgamepadstate_ptr.layout
             ))("state"),
             entrypoint = "glfwGetGamepadState",
-            javadoc = """
-                Retrieves the state of the specified joystick remapped as a gamepad.
-
-                This function retrieves the state of the specified joystick remapped to
-                an Xbox-like gamepad.
-
-                If the specified joystick is not present or does not have a gamepad mapping
-                this function will return `GLFW_FALSE` but will not generate an error.  Call
-                [glfwJoystickPresent][#glfwJoystickPresent(int)] to check whether it is present regardless of
-                whether it has a mapping.
-
-                The Guide button may not be available for input as it is often hooked by the
-                system or the Steam client.
-
-                Not all devices have all the buttons or axes provided by
-                [GLFWGamepadState].  Unavailable buttons and axes will always report
-                `GLFW_RELEASE` and 0.0 respectively.
-
-                @param jid The joystick to query.
-                @param state The gamepad input state of the joystick.
-                @return `GLFW_TRUE` if successful, or `GLFW_FALSE` if no joystick is
-                connected, it has no gamepad mapping or an error
-                occurred.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-                [GLFW_INVALID_ENUM][#GLFW_INVALID_ENUM].
-
-                @glfw.thread_safety This function must only be called from the main thread.
-
-                @see #glfwUpdateGamepadMappings(MemorySegment) glfwUpdateGamepadMappings
-                @see #glfwJoystickIsGamepad(int) glfwJoystickIsGamepad
-            """.trimIndent(),
             addNow = false
         ).overload()).overload(parameters = listOf(int("jid"), GLFWgamepadstate_ptr("state")))
-
         +"glfwSetClipboardString"(
             void,
             GLFWwindow_ptr("window"),
             const_char_ptr("string"),
-            entrypoint = "glfwSetClipboardString",
-            javadoc = """
-                Sets the clipboard to the specified string.
-
-                This function sets the system clipboard to the specified, UTF-8 encoded
-                string.
-
-                @param window Deprecated.  Any valid window or `NULL`.
-                @param string A UTF-8 encoded string.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-                [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-
-                @glfw.remark __Windows:__ The clipboard on Windows has a single global lock for reading and
-                writing.  GLFW tries to acquire it a few times, which is almost always enough.  If it
-                cannot acquire the lock then this function emits [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR] and returns.
-                It is safe to try this multiple times.
-
-                @glfw.pointer_lifetime The specified string is copied before this function
-                returns.
-
-                @glfw.thread_safety This function must only be called from the main thread.
-
-                @see #glfwGetClipboardString(MemorySegment) glfwGetClipboardString
-            """.trimIndent()
+            entrypoint = "glfwSetClipboardString"
         ).overload()
-
         +"glfwGetClipboardString_"(
             const_char_ptr,
             GLFWwindow_ptr("window"),
-            entrypoint = "glfwGetClipboardString",
-            javadoc = """
-                Returns the contents of the clipboard as a string.
-
-                This function returns the contents of the system clipboard, if it contains
-                or is convertible to a UTF-8 encoded string.  If the clipboard is empty or
-                if its contents cannot be converted, `NULL` is returned and a
-                [GLFW_FORMAT_UNAVAILABLE][#GLFW_FORMAT_UNAVAILABLE] error is generated.
-
-                @param window Deprecated.  Any valid window or `NULL`.
-                @return The contents of the clipboard as a UTF-8 encoded string, or `NULL`
-                if an error occurred.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED],
-                [GLFW_FORMAT_UNAVAILABLE][#GLFW_FORMAT_UNAVAILABLE] and [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-
-                @glfw.remark __Windows:__ The clipboard on Windows has a single global lock for reading and
-                writing.  GLFW tries to acquire it a few times, which is almost always enough.  If it
-                cannot acquire the lock then this function emits [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR] and returns.
-                It is safe to try this multiple times.
-
-                @glfw.pointer_lifetime The returned string is allocated and freed by GLFW.  You
-                should not free it yourself.  It is valid until the next call to
-                `glfwGetClipboardString` or [glfwSetClipboardString][#glfwSetClipboardString(MemorySegment, MemorySegment)], or until the library
-                is terminated.
-
-                @glfw.thread_safety This function must only be called from the main thread.
-
-                @see #glfwSetClipboardString(MemorySegment, MemorySegment) glfwSetClipboardString
-            """.trimIndent()
+            entrypoint = "glfwGetClipboardString"
         ).overload(name = "glfwGetClipboardString")
-
-        "glfwGetTime"(
-            double,
-            entrypoint = "glfwGetTime",
-            javadoc = """
-                Returns the GLFW time.
-
-                This function returns the current GLFW time, in seconds.  Unless the time
-                has been set using [glfwSetTime][#glfwSetTime(double)] it measures time elapsed since GLFW was
-                initialized.
-
-                This function and [glfwSetTime][#glfwSetTime(double)] are helper functions on top of
-                [glfwGetTimerFrequency][#glfwGetTimerFrequency()] and [glfwGetTimerValue][#glfwGetTimerValue()].
-
-                The resolution of the timer is system dependent, but is usually on the order
-                of a few micro- or nanoseconds.  It uses the highest-resolution monotonic
-                time source on each operating system.
-
-                @return The current time, in seconds, or zero if an
-                error occurred.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-
-                @glfw.thread_safety This function may be called from any thread.  Reading and
-                writing of the internal base time is not atomic, so it needs to be
-                externally synchronized with calls to [glfwSetTime][#glfwSetTime(double)].
-            """.trimIndent()
-        )
-
-        "glfwSetTime"(
-            void,
-            double("time"),
-            entrypoint = "glfwSetTime",
-            javadoc = """
-                Sets the GLFW time.
-
-                This function sets the current GLFW time, in seconds.  The value must be
-                a positive finite number less than or equal to 18446744073.0, which is
-                approximately 584.5 years.
-
-                This function and [glfwGetTime][#glfwGetTime()] are helper functions on top of
-                [glfwGetTimerFrequency][#glfwGetTimerFrequency()] and [glfwGetTimerValue][#glfwGetTimerValue()].
-
-                @param time The new value, in seconds.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-                [GLFW_INVALID_VALUE][#GLFW_INVALID_VALUE].
-
-                @glfw.remark The upper limit of GLFW time is calculated as
-                floor((2<sup>64</sup> - 1) / 10<sup>9</sup>) and is due to implementations
-                storing nanoseconds in 64 bits.  The limit may be increased in the future.
-
-                @glfw.thread_safety This function may be called from any thread.  Reading and
-                writing of the internal base time is not atomic, so it needs to be
-                externally synchronized with calls to [glfwGetTime][#glfwGetTime()].
-            """.trimIndent()
-        )
-
-        "glfwGetTimerValue"(
-            uint64_t,
-            entrypoint = "glfwGetTimerValue",
-            javadoc = """
-                Returns the current value of the raw timer.
-
-                This function returns the current value of the raw timer, measured in
-                1&nbsp;/&nbsp;frequency seconds.  To get the frequency, call
-                [glfwGetTimerFrequency][#glfwGetTimerFrequency()].
-
-                @return The value of the timer, or zero if an
-                error occurred.
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-                @glfw.thread_safety This function may be called from any thread.
-
-                @see #glfwGetTimerFrequency() glfwGetTimerFrequency
-            """.trimIndent()
-        )
-
-        "glfwGetTimerFrequency"(
-            uint64_t,
-            entrypoint = "glfwGetTimerFrequency",
-            javadoc = """
-                Returns the frequency, in Hz, of the raw timer.
-
-                This function returns the frequency, in Hz, of the raw timer.
-
-                @return The frequency of the timer, in Hz, or zero if an
-                error occurred.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-
-                @glfw.thread_safety This function may be called from any thread.
-
-                @see #glfwGetTimerValue() glfwGetTimerValue
-            """.trimIndent()
-        )
-
-        "glfwMakeContextCurrent"(
-            void,
-            GLFWwindow_ptr("window"),
-            entrypoint = "glfwMakeContextCurrent",
-            javadoc = """
-                Makes the context of the specified window current for the calling
-                thread.
-
-                This function makes the OpenGL or OpenGL ES context of the specified window
-                current on the calling thread.  It can also detach the current context from
-                the calling thread without making a new one current by passing in `NULL`.
-
-                A context must only be made current on a single thread at a time and each
-                thread can have only a single current context at a time.  Making a context
-                current detaches any previously current context on the calling thread.
-
-                When moving a context between threads, you must detach it (make it
-                non-current) on the old thread before making it current on the new one.
-
-                By default, making a context non-current implicitly forces a pipeline flush.
-                On machines that support `GL_KHR_context_flush_control`, you can control
-                whether a context performs this flush by setting the
-                [GLFW_CONTEXT_RELEASE_BEHAVIOR][#GLFW_CONTEXT_RELEASE_BEHAVIOR]
-                hint.
-
-                The specified window must have an OpenGL or OpenGL ES context.  Specifying
-                a window without a context will generate a [GLFW_NO_WINDOW_CONTEXT][#GLFW_NO_WINDOW_CONTEXT]
-                error.
-
-                @param window The window whose context to make current, or `NULL` to
-                detach the current context.
-
-                @glfw.remark If the previously current context was created via a different
-                context creation API than the one passed to this function, GLFW will still
-                detach the previous one from its API before making the new one current.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED],
-                [GLFW_NO_WINDOW_CONTEXT][#GLFW_NO_WINDOW_CONTEXT] and [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-
-                @glfw.thread_safety This function may be called from any thread.
-
-                @see #glfwGetCurrentContext() glfwGetCurrentContext
-            """.trimIndent()
-        )
-
-        "glfwGetCurrentContext"(
-            GLFWwindow_ptr,
-            entrypoint = "glfwGetCurrentContext",
-            javadoc = """
-                Returns the window whose context is current on the calling thread.
-
-                This function returns the window whose OpenGL or OpenGL ES context is
-                current on the calling thread.
-
-                @return The window whose context is current, or `NULL` if no window's
-                context is current.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-
-                @glfw.thread_safety This function may be called from any thread.
-
-                @see #glfwMakeContextCurrent(MemorySegment) glfwMakeContextCurrent
-            """.trimIndent()
-        )
-
-        "glfwSwapBuffers"(
-            void,
-            GLFWwindow_ptr("window"),
-            entrypoint = "glfwSwapBuffers",
-            javadoc = """
-                Swaps the front and back buffers of the specified window.
-
-                This function swaps the front and back buffers of the specified window when
-                rendering with OpenGL or OpenGL ES.  If the swap interval is greater than
-                zero, the GPU driver waits the specified number of screen updates before
-                swapping the buffers.
-
-                The specified window must have an OpenGL or OpenGL ES context.  Specifying
-                a window without a context will generate a [GLFW_NO_WINDOW_CONTEXT][#GLFW_NO_WINDOW_CONTEXT]
-                error.
-
-                This function does not apply to Vulkan.  If you are rendering with Vulkan,
-                see `vkQueuePresentKHR` instead.
-
-                @param window The window whose buffers to swap.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED],
-                [GLFW_NO_WINDOW_CONTEXT][#GLFW_NO_WINDOW_CONTEXT] and [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-
-                @glfw.remark __EGL:__ The context of the specified window must be current on the
-                calling thread.
-
-                @glfw.thread_safety This function may be called from any thread.
-
-                @see #glfwSwapInterval(int) glfwSwapInterval
-            """.trimIndent()
-        )
-
-        "glfwSwapInterval"(
-            void,
-            int("interval"),
-            entrypoint = "glfwSwapInterval",
-            javadoc = """
-                Sets the swap interval for the current context.
-
-                This function sets the swap interval for the current OpenGL or OpenGL ES
-                context, i.e. the number of screen updates to wait from the time
-                [glfwSwapBuffers][#glfwSwapBuffers(MemorySegment)] was called before swapping the buffers and returning.  This
-                is sometimes called _vertical synchronization_, _vertical retrace
-                synchronization_ or just _vsync_.
-
-                A context that supports either of the `WGL_EXT_swap_control_tear` and
-                `GLX_EXT_swap_control_tear` extensions also accepts _negative_ swap
-                intervals, which allows the driver to swap immediately even if a frame
-                arrives a little bit late.  You can check for these extensions with
-                [glfwExtensionSupported][#glfwExtensionSupported(MemorySegment)].
-
-                A context must be current on the calling thread.  Calling this function
-                without a current context will cause a [GLFW_NO_CURRENT_CONTEXT][#GLFW_NO_CURRENT_CONTEXT] error.
-
-                This function does not apply to Vulkan.  If you are rendering with Vulkan,
-                see the present mode of your swapchain instead.
-
-                @param interval The minimum number of screen updates to wait for
-                until the buffers are swapped by [glfwSwapBuffers][#glfwSwapBuffers(MemorySegment)].
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED],
-                [GLFW_NO_CURRENT_CONTEXT][#GLFW_NO_CURRENT_CONTEXT] and [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-
-                @glfw.remark This function is not called during context creation, leaving the
-                swap interval set to whatever is the default for that API.  This is done
-                because some swap interval extensions used by GLFW do not allow the swap
-                interval to be reset to zero once it has been set to a non-zero value.
-
-                Some GPU drivers do not honor the requested swap interval, either
-                because of a user setting that overrides the application's request or due to
-                bugs in the driver.
-
-                @glfw.thread_safety This function may be called from any thread.
-
-                @see #glfwSwapBuffers(MemorySegment) glfwSwapBuffers
-            """.trimIndent()
-        )
-
+        "glfwGetTime"(double, entrypoint = "glfwGetTime")
+        "glfwSetTime"(void, double("time"), entrypoint = "glfwSetTime")
+        "glfwGetTimerValue"(uint64_t, entrypoint = "glfwGetTimerValue")
+        "glfwGetTimerFrequency"(uint64_t, entrypoint = "glfwGetTimerFrequency")
+        "glfwMakeContextCurrent"(void, GLFWwindow_ptr("window"), entrypoint = "glfwMakeContextCurrent")
+        "glfwGetCurrentContext"(GLFWwindow_ptr, entrypoint = "glfwGetCurrentContext")
+        "glfwSwapBuffers"(void, GLFWwindow_ptr("window"), entrypoint = "glfwSwapBuffers")
+        "glfwSwapInterval"(void, int("interval"), entrypoint = "glfwSwapInterval")
         +(+"glfwExtensionSupported"(
             glfw_boolean,
             address.copy(
@@ -5781,150 +1032,18 @@ fun main() {
                 layout = const_char_ptr.layout
             )("extension"),
             entrypoint = "glfwExtensionSupported",
-            javadoc = """
-                Returns whether the specified extension is available.
-
-                This function returns whether the specified
-                API extension is supported by the current OpenGL or
-                OpenGL ES context.  It searches both for client API extension and context
-                creation API extensions.
-
-                A context must be current on the calling thread.  Calling this function
-                without a current context will cause a [GLFW_NO_CURRENT_CONTEXT][#GLFW_NO_CURRENT_CONTEXT] error.
-
-                As this functions retrieves and searches one or more extension strings each
-                call, it is recommended that you cache its results if it is going to be used
-                frequently.  The extension strings will not change during the lifetime of
-                a context, so there is no danger in doing this.
-
-                This function does not apply to Vulkan.  If you are using Vulkan, see
-                [glfwGetRequiredInstanceExtensions][#glfwGetRequiredInstanceExtensions(MemorySegment)], `vkEnumerateInstanceExtensionProperties`
-                and `vkEnumerateDeviceExtensionProperties` instead.
-
-                @param extension The ASCII encoded name of the extension.
-                @return `GLFW_TRUE` if the extension is available, or `GLFW_FALSE`
-                otherwise.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED],
-                [GLFW_NO_CURRENT_CONTEXT][#GLFW_NO_CURRENT_CONTEXT], [GLFW_INVALID_VALUE][#GLFW_INVALID_VALUE] and
-                [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-
-                @glfw.thread_safety This function may be called from any thread.
-
-                @see #glfwGetProcAddress(MemorySegment) glfwGetProcAddress
-            """.trimIndent(),
             addNow = false
         ).overload()).overload(parameters = listOf(const_char_ptr("extension")))
-
         +"glfwGetProcAddress"(
             address c "GLFWglproc",
             const_char_ptr("procname"),
-            entrypoint = "glfwGetProcAddress",
-            javadoc = """
-                Returns the address of the specified function for the current
-                context.
-
-                This function returns the address of the specified OpenGL or OpenGL ES
-                core or extension function, if it is supported
-                by the current context.
-
-                A context must be current on the calling thread.  Calling this function
-                without a current context will cause a [GLFW_NO_CURRENT_CONTEXT][#GLFW_NO_CURRENT_CONTEXT] error.
-
-                This function does not apply to Vulkan.  If you are rendering with Vulkan,
-                see [glfwGetInstanceProcAddress][GLFWVulkan#glfwGetInstanceProcAddress(MemorySegment, MemorySegment)], `vkGetInstanceProcAddr` and
-                `vkGetDeviceProcAddr` instead.
-
-                @param procname The ASCII encoded name of the function.
-                @return The address of the function, or `NULL` if an
-                error occurred.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED],
-                [GLFW_NO_CURRENT_CONTEXT][#GLFW_NO_CURRENT_CONTEXT] and [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-
-                @glfw.remark The address of a given function is not guaranteed to be the same
-                between contexts.
-
-                This function may return a non-`NULL` address despite the
-                associated version or extension not being available.  Always check the
-                context version or extension string first.
-
-                @glfw.pointer_lifetime The returned function pointer is valid until the context
-                is destroyed or the library is terminated.
-
-                @glfw.thread_safety This function may be called from any thread.
-
-                @see #glfwExtensionSupported(MemorySegment) glfwExtensionSupported
-            """.trimIndent()
+            entrypoint = "glfwGetProcAddress"
         ).overload()
-
-        +"glfwVulkanSupported"(
-            glfw_boolean,
-            entrypoint = "glfwVulkanSupported",
-            javadoc = """
-                Returns whether the Vulkan loader and an ICD have been found.
-
-                This function returns whether the Vulkan loader and any minimally functional
-                ICD have been found.
-
-                The availability of a Vulkan loader and even an ICD does not by itself guarantee that
-                surface creation or even instance creation is possible.  Call
-                [glfwGetRequiredInstanceExtensions][#glfwGetRequiredInstanceExtensions(MemorySegment)] to check whether the extensions necessary for Vulkan
-                surface creation are available and [glfwGetPhysicalDevicePresentationSupport][GLFWVulkan#glfwGetPhysicalDevicePresentationSupport(MemorySegment, MemorySegment, int)] to
-                check whether a queue family of a physical device supports image presentation.
-
-                @return `GLFW_TRUE` if Vulkan is minimally available, or `GLFW_FALSE`
-                otherwise.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-
-                @glfw.thread_safety This function may be called from any thread.
-            """.trimIndent(),
-            addNow = false
-        ).overload()
-
+        +"glfwVulkanSupported"(glfw_boolean, entrypoint = "glfwVulkanSupported", addNow = false).overload()
         "glfwGetRequiredInstanceExtensions"(
             address c "const char**",
             (address c "uint32_t*")("count").ref(),
-            entrypoint = "glfwGetRequiredInstanceExtensions",
-            javadoc = """
-                Returns the Vulkan instance extensions required by GLFW.
-
-                This function returns an array of names of Vulkan instance extensions required
-                by GLFW for creating Vulkan surfaces for GLFW windows.  If successful, the
-                list will always contain `VK_KHR_surface`, so if you don't require any
-                additional extensions you can pass this list directly to the
-                `VkInstanceCreateInfo` struct.
-
-                If Vulkan is not available on the machine, this function returns `NULL` and
-                generates a [GLFW_API_UNAVAILABLE][#GLFW_API_UNAVAILABLE] error.  Call [glfwVulkanSupported][#glfwVulkanSupported()]
-                to check whether Vulkan is at least minimally available.
-
-                If Vulkan is available but no set of extensions allowing window surface
-                creation was found, this function returns `NULL`.  You may still use Vulkan
-                for off-screen rendering and compute work.
-
-                @param count Where to store the number of extensions in the returned
-                array.  This is set to zero if an error occurred.
-                @return An array of ASCII encoded extension names, or `NULL` if an
-                error occurred.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-                [GLFW_API_UNAVAILABLE][#GLFW_API_UNAVAILABLE].
-
-                @glfw.remark Additional extensions may be required by future versions of GLFW.
-                You should check if any extensions you wish to enable are already in the
-                returned array, as it is an error to specify an extension more than once in
-                the `VkInstanceCreateInfo` struct.
-
-                @glfw.pointer_lifetime The returned array is allocated and freed by GLFW.  You
-                should not free it yourself.  It is guaranteed to be valid only until the
-                library is terminated.
-
-                @glfw.thread_safety This function may be called from any thread.
-
-                @see GLFWVulkan#glfwCreateWindowSurface(MemorySegment, MemorySegment, MemorySegment, MemorySegment) glfwCreateWindowSurface
-            """.trimIndent()
+            entrypoint = "glfwGetRequiredInstanceExtensions"
         )
 
         //endregion
@@ -5940,195 +1059,29 @@ fun main() {
         "glfwInitVulkanLoader"(
             void,
             (address c "PFN_vkGetInstanceProcAddr")("loader"),
-            entrypoint = "glfwInitVulkanLoader",
-            javadoc = """
-                Sets the desired Vulkan `vkGetInstanceProcAddr` function.
-
-                This function sets the `vkGetInstanceProcAddr` function that GLFW will use for all
-                Vulkan related entry point queries.
-
-                This feature is mostly useful on macOS, if your copy of the Vulkan loader is in
-                a location where GLFW cannot find it through dynamic loading, or if you are still
-                using the static library version of the loader.
-
-                If set to `NULL`, GLFW will try to load the Vulkan loader dynamically by its standard
-                name and get this function from there.  This is the default behavior.
-
-                The standard name of the loader is `vulkan-1.dll` on Windows, `libvulkan.so.1` on
-                Linux and other Unix-like systems and `libvulkan.1.dylib` on macOS.  If your code is
-                also loading it via these names then you probably don't need to use this function.
-
-                The function address you set is never reset by GLFW, but it only takes effect during
-                initialization.  Once GLFW has been initialized, any updates will be ignored until the
-                library is terminated and initialized again.
-
-                @param loader The address of the function to use, or `NULL`.
-
-                Loader function signature
-                ```c
-                PFN_vkVoidFunction vkGetInstanceProcAddr(VkInstance instance, const char* name)
-                ```
-                For more information about this function, see the
-                [Vulkan Registry](https://www.khronos.org/registry/vulkan/).
-
-                @glfw.errors None.
-
-                @glfw.remark This function may be called before [glfwInit][GLFW#glfwInit()].
-
-                @glfw.thread_safety This function must only be called from the main thread.
-
-                @see GLFW#glfwInit() glfwInit
-            """.trimIndent()
+            entrypoint = "glfwInitVulkanLoader"
         )
-
         +"glfwGetInstanceProcAddress"(
             address c "GLFWvkproc",
             VkInstance("instance"),
             const_char_ptr("procname"),
-            entrypoint = "glfwGetInstanceProcAddress",
-            javadoc = """
-                Returns the address of the specified Vulkan instance function.
-
-                This function returns the address of the specified Vulkan core or extension
-                function for the specified instance.  If instance is set to `NULL` it can
-                return any function exported from the Vulkan loader, including at least the
-                following functions:
-                - `vkEnumerateInstanceExtensionProperties`
-                - `vkEnumerateInstanceLayerProperties`
-                - `vkCreateInstance`
-                - `vkGetInstanceProcAddr`
-
-                If Vulkan is not available on the machine, this function returns `NULL` and
-                generates a [GLFW_API_UNAVAILABLE][GLFW#GLFW_API_UNAVAILABLE] error.  Call [glfwVulkanSupported][GLFW#glfwVulkanSupported()]
-                to check whether Vulkan is at least minimally available.
-
-                This function is equivalent to calling `vkGetInstanceProcAddr` with
-                a platform-specific query of the Vulkan loader as a fallback.
-
-                @param instance The Vulkan instance to query, or `NULL` to retrieve
-                functions related to instance creation.
-                @param procname The ASCII encoded name of the function.
-                @return The address of the function, or `NULL` if an
-                error occurred.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][GLFW#GLFW_NOT_INITIALIZED] and
-                [GLFW_API_UNAVAILABLE][GLFW#GLFW_API_UNAVAILABLE].
-
-                @glfw.pointer_lifetime The returned function pointer is valid until the library
-                is terminated.
-
-                @glfw.thread_safety This function may be called from any thread.
-            """.trimIndent()
+            entrypoint = "glfwGetInstanceProcAddress"
         ).overload()
-
         +"glfwGetPhysicalDevicePresentationSupport"(
             glfw_boolean,
             VkInstance("instance"),
             VkPhysicalDevice("device"),
             uint32_t("queuefamily"),
             entrypoint = "glfwGetPhysicalDevicePresentationSupport",
-            javadoc = """
-                Returns whether the specified queue family can present images.
-
-                This function returns whether the specified queue family of the specified
-                physical device supports presentation to the platform GLFW was built for.
-
-                If Vulkan or the required window surface creation instance extensions are
-                not available on the machine, or if the specified instance was not created
-                with the required extensions, this function returns `GLFW_FALSE` and
-                generates a [GLFW_API_UNAVAILABLE][GLFW#GLFW_API_UNAVAILABLE] error.  Call [glfwVulkanSupported][GLFW#glfwVulkanSupported()]
-                to check whether Vulkan is at least minimally available and
-                [glfwGetRequiredInstanceExtensions][GLFW#glfwGetRequiredInstanceExtensions(MemorySegment)] to check what instance extensions are
-                required.
-
-                @param instance The instance that the physical device belongs to.
-                @param device The physical device that the queue family belongs to.
-                @param queuefamily The index of the queue family to query.
-                @return `GLFW_TRUE` if the queue family supports presentation, or
-                `GLFW_FALSE` otherwise.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][GLFW#GLFW_NOT_INITIALIZED],
-                [GLFW_API_UNAVAILABLE][GLFW#GLFW_API_UNAVAILABLE] and [GLFW_PLATFORM_ERROR][GLFW#GLFW_PLATFORM_ERROR].
-
-                @glfw.remark __macOS:__ This function currently always returns `GLFW_TRUE`, as the
-                `VK_MVK_macos_surface` and `VK_EXT_metal_surface` extensions do not provide
-                a `vkGetPhysicalDevice*PresentationSupport` type function.
-
-                @glfw.thread_safety This function may be called from any thread.  For
-                synchronization details of Vulkan objects, see the Vulkan specification.
-            """.trimIndent(),
             addNow = false
         ).overload()
-
         "glfwCreateWindowSurface"(
             VkResult,
             VkInstance("instance"),
             GLFWwindow_ptr("window"),
             const_VkAllocationCallbacks_ptr("allocator"),
             VkSurfaceKHR_ptr("surface").ref(),
-            entrypoint = "glfwCreateWindowSurface",
-            javadoc = """
-                Creates a Vulkan surface for the specified window.
-
-                This function creates a Vulkan surface for the specified window.
-
-                If the Vulkan loader or at least one minimally functional ICD were not found,
-                this function returns `VK_ERROR_INITIALIZATION_FAILED` and generates a
-                [GLFW_API_UNAVAILABLE][GLFW#GLFW_API_UNAVAILABLE] error.  Call [glfwVulkanSupported][GLFW#glfwVulkanSupported()] to check whether
-                Vulkan is at least minimally available.
-
-                If the required window surface creation instance extensions are not
-                available or if the specified instance was not created with these extensions
-                enabled, this function returns `VK_ERROR_EXTENSION_NOT_PRESENT` and
-                generates a [GLFW_API_UNAVAILABLE][GLFW#GLFW_API_UNAVAILABLE] error.  Call
-                [glfwGetRequiredInstanceExtensions][GLFW#glfwGetRequiredInstanceExtensions(MemorySegment)] to check what instance extensions are
-                required.
-
-                The window surface cannot be shared with another API so the window must
-                have been created with the client api hint
-                set to `GLFW_NO_API` otherwise it generates a [GLFW_INVALID_VALUE][GLFW#GLFW_INVALID_VALUE] error
-                and returns `VK_ERROR_NATIVE_WINDOW_IN_USE_KHR`.
-
-                The window surface must be destroyed before the specified Vulkan instance.
-                It is the responsibility of the caller to destroy the window surface.  GLFW
-                does not destroy it for you.  Call `vkDestroySurfaceKHR` to destroy the
-                surface.
-
-                @param instance The Vulkan instance to create the surface in.
-                @param window The window to create the surface for.
-                @param allocator The allocator to use, or `NULL` to use the default
-                allocator.
-                @param surface Where to store the handle of the surface.  This is set
-                to `VK_NULL_HANDLE` if an error occurred.
-                @return `VK_SUCCESS` if successful, or a Vulkan error code if an
-                error occurred.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][GLFW#GLFW_NOT_INITIALIZED],
-                [GLFW_API_UNAVAILABLE][GLFW#GLFW_API_UNAVAILABLE], [GLFW_PLATFORM_ERROR][GLFW#GLFW_PLATFORM_ERROR] and [GLFW_INVALID_VALUE][GLFW#GLFW_INVALID_VALUE]
-
-                @glfw.remark If an error occurs before the creation call is made, GLFW returns
-                the Vulkan error code most appropriate for the error.  Appropriate use of
-                [glfwVulkanSupported][GLFW#glfwVulkanSupported()] and [glfwGetRequiredInstanceExtensions][GLFW#glfwGetRequiredInstanceExtensions(MemorySegment)] should
-                eliminate almost all occurrences of these errors.
-                - __macOS:__ GLFW prefers the `VK_EXT_metal_surface` extension, with the
-                    `VK_MVK_macos_surface` extension as a fallback.  The name of the selected
-                    extension, if any, is included in the array returned by
-                    [glfwGetRequiredInstanceExtensions][GLFW#glfwGetRequiredInstanceExtensions(MemorySegment)].
-
-                    This function creates and sets a `CAMetalLayer` instance for
-                    the window content view, which is required for MoltenVK to function.
-                - __X11:__ By default GLFW prefers the `VK_KHR_xcb_surface` extension,
-                    with the `VK_KHR_xlib_surface` extension as a fallback.  You can make
-                    `VK_KHR_xlib_surface` the preferred extension by setting the
-                    [GLFW_X11_XCB_VULKAN_SURFACE][GLFW#GLFW_X11_XCB_VULKAN_SURFACE] init
-                    hint.  The name of the selected extension, if any, is included in the array
-                    returned by [glfwGetRequiredInstanceExtensions][GLFW#glfwGetRequiredInstanceExtensions(MemorySegment)].
-
-                @glfw.thread_safety This function may be called from any thread.  For
-                synchronization details of Vulkan objects, see the Vulkan specification.
-
-                @see GLFW#glfwGetRequiredInstanceExtensions(MemorySegment) glfwGetRequiredInstanceExtensions
-            """.trimIndent()
+            entrypoint = "glfwCreateWindowSurface"
         )
     }
 
@@ -6140,101 +1093,20 @@ fun main() {
             const_char_ptr,
             GLFWmonitor_ptr("monitor"),
             entrypoint = "glfwGetWin32Adapter",
-            javadoc = """
-                Returns the adapter device name of the specified monitor.
-
-                @return The UTF-8 encoded adapter device name (for example `\\.\DISPLAY1`)
-                of the specified monitor, or `NULL` if an error
-                occurred.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][GLFW#GLFW_NOT_INITIALIZED] and
-                [GLFW_PLATFORM_UNAVAILABLE][GLFW#GLFW_PLATFORM_UNAVAILABLE].
-
-                @glfw.thread_safety This function may be called from any thread.  Access is not
-                synchronized.
-            """.trimIndent(),
-            optional = true,
-            defaultCode = "return MemorySegment.NULL;"
-        ).overload(name = "glfwGetWin32Adapter", defaultCode = "return null;")
-
+            optional = true
+        ).overload(name = "glfwGetWin32Adapter")
         +"glfwGetWin32Monitor_"(
             const_char_ptr,
             GLFWmonitor_ptr("monitor"),
             entrypoint = "glfwGetWin32Monitor",
-            javadoc = """
-                Returns the display device name of the specified monitor.
-
-                @return The UTF-8 encoded display device name (for example
-                `\\.\DISPLAY1\Monitor0`) of the specified monitor, or `NULL` if an
-                error occurred.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][GLFW#GLFW_NOT_INITIALIZED] and
-                [GLFW_PLATFORM_UNAVAILABLE][GLFW#GLFW_PLATFORM_UNAVAILABLE].
-
-                @glfw.thread_safety This function may be called from any thread.  Access is not
-                synchronized.
-            """.trimIndent(),
-            optional = true,
-            defaultCode = "return MemorySegment.NULL;"
-        ).overload(name = "glfwGetWin32Monitor", defaultCode = "return null;")
-
-        "glfwGetWin32Window"(
-            HWND,
-            GLFWwindow_ptr("window"),
-            entrypoint = "glfwGetWin32Window",
-            javadoc = """
-                Returns the `HWND` of the specified window.
-
-                @return The `HWND` of the specified window, or `NULL` if an
-                error occurred.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][GLFW#GLFW_NOT_INITIALIZED] and
-                [GLFW_PLATFORM_UNAVAILABLE][GLFW#GLFW_PLATFORM_UNAVAILABLE].
-                @glfw.remark The `HDC` associated with the window can be queried with the
-                [GetDC](https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getdc)
-                function.
-                ```c
-                HDC dc = GetDC(glfwGetWin32Window(window));
-                ```
-                This DC is private and does not need to be released.
-
-                @glfw.thread_safety This function may be called from any thread.  Access is not
-                synchronized.
-            """.trimIndent(),
-            optional = true,
-            defaultCode = "return MemorySegment.NULL;"
-        )
+            optional = true
+        ).overload(name = "glfwGetWin32Monitor")
+        "glfwGetWin32Window"(HWND, GLFWwindow_ptr("window"), entrypoint = "glfwGetWin32Window", optional = true)
         //endregion
 
         //region WGL
         val HGLRC = address c "HGLRC"
-        "glfwGetWGLContext"(
-            HGLRC,
-            GLFWwindow_ptr("window"),
-            entrypoint = "glfwGetWGLContext",
-            javadoc = """
-                Returns the `HGLRC` of the specified window.
-
-                @return The `HGLRC` of the specified window, or `NULL` if an
-                error occurred.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][GLFW#GLFW_NOT_INITIALIZED],
-                [GLFW_PLATFORM_UNAVAILABLE][GLFW#GLFW_PLATFORM_UNAVAILABLE] and [GLFW_NO_WINDOW_CONTEXT][GLFW#GLFW_NO_WINDOW_CONTEXT].
-
-                @glfw.remark The `HDC` associated with the window can be queried with the
-                [GetDC](https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getdc)
-                function.
-                ```c
-                HDC dc = GetDC(glfwGetWin32Window(window));
-                ```
-                This DC is private and does not need to be released.
-
-                @glfw.thread_safety This function may be called from any thread.  Access is not
-                synchronized.
-            """.trimIndent(),
-            optional = true,
-            defaultCode = "return MemorySegment.NULL;"
-        )
+        "glfwGetWGLContext"(HGLRC, GLFWwindow_ptr("window"), entrypoint = "glfwGetWGLContext", optional = true)
         //endregion
 
         //region COCOA
@@ -6245,83 +1117,14 @@ fun main() {
             CGDirectDisplayID,
             GLFWmonitor_ptr("monitor"),
             entrypoint = "glfwGetCocoaMonitor",
-            javadoc = """
-                Returns the `CGDirectDisplayID` of the specified monitor.
-
-                @return The `CGDirectDisplayID` of the specified monitor, or
-                `kCGNullDirectDisplay` if an error occurred.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][GLFW#GLFW_NOT_INITIALIZED] and
-                [GLFW_PLATFORM_UNAVAILABLE][GLFW#GLFW_PLATFORM_UNAVAILABLE].
-
-                @glfw.thread_safety This function may be called from any thread.  Access is not
-                synchronized.
-            """.trimIndent(),
-            optional = true,
-            defaultCode = "return 0;"
+            optional = true
         )
-
-        "glfwGetCocoaWindow"(
-            id,
-            GLFWwindow_ptr("window"),
-            entrypoint = "glfwGetCocoaWindow",
-            javadoc = """
-                Returns the `NSWindow` of the specified window.
-
-                @return The `NSWindow` of the specified window, or `nil` if an
-                error occurred.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][GLFW#GLFW_NOT_INITIALIZED] and
-                [GLFW_PLATFORM_UNAVAILABLE][GLFW#GLFW_PLATFORM_UNAVAILABLE].
-
-                @glfw.thread_safety This function may be called from any thread.  Access is not
-                synchronized.
-            """.trimIndent(),
-            optional = true,
-            defaultCode = "return MemorySegment.NULL;"
-        )
-
-        "glfwGetCocoaView"(
-            id,
-            GLFWwindow_ptr("window"),
-            entrypoint = "glfwGetCocoaView",
-            javadoc = """
-                Returns the `NSView` of the specified window.
-
-                @return The `NSView` of the specified window, or `nil` if an
-                error occurred.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][GLFW#GLFW_NOT_INITIALIZED] and
-                [GLFW_PLATFORM_UNAVAILABLE][GLFW#GLFW_PLATFORM_UNAVAILABLE].
-
-                @glfw.thread_safety This function may be called from any thread.  Access is not
-                synchronized.
-            """.trimIndent(),
-            optional = true,
-            defaultCode = "return MemorySegment.NULL;"
-        )
+        "glfwGetCocoaWindow"(id, GLFWwindow_ptr("window"), entrypoint = "glfwGetCocoaWindow", optional = true)
+        "glfwGetCocoaView"(id, GLFWwindow_ptr("window"), entrypoint = "glfwGetCocoaView", optional = true)
         //endregion
 
         //region NSGL
-        "glfwGetNSGLContext"(
-            id,
-            GLFWwindow_ptr("window"),
-            entrypoint = "glfwGetNSGLContext",
-            javadoc = """
-                Returns the `NSOpenGLContext` of the specified window.
-
-                @return The `NSOpenGLContext` of the specified window, or `nil` if an
-                error occurred.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][GLFW#GLFW_NOT_INITIALIZED],
-                [GLFW_PLATFORM_UNAVAILABLE][GLFW#GLFW_PLATFORM_UNAVAILABLE] and [GLFW_NO_WINDOW_CONTEXT][GLFW#GLFW_NO_WINDOW_CONTEXT].
-
-                @glfw.thread_safety This function may be called from any thread.  Access is not
-                synchronized.
-            """.trimIndent(),
-            optional = true,
-            defaultCode = "return MemorySegment.NULL;"
-        )
+        "glfwGetNSGLContext"(id, GLFWwindow_ptr("window"), entrypoint = "glfwGetNSGLContext", optional = true)
         //endregion
 
         //region X11
@@ -6330,181 +1133,29 @@ fun main() {
         val RROutput = jlong c "RROutput"
         val Window = jlong c "Window"
 
-        "glfwGetX11Display"(
-            Display_ptr,
-            entrypoint = "glfwGetX11Display",
-            javadoc = """
-                Returns the `Display` used by GLFW.
-
-                @return The `Display` used by GLFW, or `NULL` if an
-                error occurred.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][GLFW#GLFW_NOT_INITIALIZED] and
-                [GLFW_PLATFORM_UNAVAILABLE][GLFW#GLFW_PLATFORM_UNAVAILABLE].
-
-                @glfw.thread_safety This function may be called from any thread.  Access is not
-                synchronized.
-            """.trimIndent(),
-            optional = true,
-            defaultCode = "return MemorySegment.NULL;"
-        )
-
-        "glfwGetX11Adapter"(
-            RRCrtc,
-            GLFWmonitor_ptr("monitor"),
-            entrypoint = "glfwGetX11Adapter",
-            javadoc = """
-                Returns the `RRCrtc` of the specified monitor.
-
-                @return The `RRCrtc` of the specified monitor, or `None` if an
-                error occurred.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][GLFW#GLFW_NOT_INITIALIZED] and
-                [GLFW_PLATFORM_UNAVAILABLE][GLFW#GLFW_PLATFORM_UNAVAILABLE].
-
-                @glfw.thread_safety This function may be called from any thread.  Access is not
-                synchronized.
-            """.trimIndent(),
-            optional = true,
-            defaultCode = "return 0L;"
-        )
-
-        "glfwGetX11Monitor"(
-            RROutput,
-            GLFWmonitor_ptr("monitor"),
-            entrypoint = "glfwGetX11Monitor",
-            javadoc = """
-                Returns the `RROutput` of the specified monitor.
-
-                @return The `RROutput` of the specified monitor, or `None` if an
-                error occurred.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][GLFW#GLFW_NOT_INITIALIZED] and
-                [GLFW_PLATFORM_UNAVAILABLE][GLFW#GLFW_PLATFORM_UNAVAILABLE].
-
-                @glfw.thread_safety This function may be called from any thread.  Access is not
-                synchronized.
-            """.trimIndent(),
-            optional = true,
-            defaultCode = "return 0L;"
-        )
-
-        "glfwGetX11Window"(
-            RROutput,
-            GLFWwindow_ptr("window"),
-            entrypoint = "glfwGetX11Window",
-            javadoc = """
-                Returns the `Window` of the specified window.
-
-                @return The `Window` of the specified window, or `None` if an
-                error occurred.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][GLFW#GLFW_NOT_INITIALIZED] and
-                [GLFW_PLATFORM_UNAVAILABLE][GLFW#GLFW_PLATFORM_UNAVAILABLE].
-
-                @glfw.thread_safety This function may be called from any thread.  Access is not
-                synchronized.
-            """.trimIndent(),
-            optional = true,
-            defaultCode = "return 0L;"
-        )
-
+        "glfwGetX11Display"(Display_ptr, entrypoint = "glfwGetX11Display", optional = true)
+        "glfwGetX11Adapter"(RRCrtc, GLFWmonitor_ptr("monitor"), entrypoint = "glfwGetX11Adapter", optional = true)
+        "glfwGetX11Monitor"(RROutput, GLFWmonitor_ptr("monitor"), entrypoint = "glfwGetX11Monitor", optional = true)
+        "glfwGetX11Window"(RROutput, GLFWwindow_ptr("window"), entrypoint = "glfwGetX11Window", optional = true)
         +"glfwSetX11SelectionString"(
             void,
             const_char_ptr("string"),
             entrypoint = "glfwSetX11SelectionString",
-            javadoc = """
-                Sets the current primary selection to the specified string.
-
-                @param string A UTF-8 encoded string.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][GLFW#GLFW_NOT_INITIALIZED],
-                [GLFW_PLATFORM_UNAVAILABLE][GLFW#GLFW_PLATFORM_UNAVAILABLE] and [GLFW_PLATFORM_ERROR][GLFW#GLFW_PLATFORM_ERROR].
-
-                @glfw.pointer_lifetime The specified string is copied before this function
-                returns.
-
-                @glfw.thread_safety This function must only be called from the main thread.
-
-                @see #glfwGetX11SelectionString() glfwGetX11SelectionString
-                @see GLFW#glfwSetClipboardString(MemorySegment, MemorySegment) glfwSetClipboardString
-            """.trimIndent(),
             optional = true
         ).overload()
-
         +"glfwGetX11SelectionString_"(
             const_char_ptr,
             entrypoint = "glfwGetX11SelectionString",
-            javadoc = """
-                Returns the contents of the current primary selection as a string.
-
-                If the selection is empty or if its contents cannot be converted, `NULL`
-                is returned and a [GLFW_FORMAT_UNAVAILABLE][GLFW#GLFW_FORMAT_UNAVAILABLE] error is generated.
-
-                @return The contents of the selection as a UTF-8 encoded string, or `NULL`
-                if an error occurred.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][GLFW#GLFW_NOT_INITIALIZED],
-                [GLFW_PLATFORM_UNAVAILABLE][GLFW#GLFW_PLATFORM_UNAVAILABLE] and [GLFW_PLATFORM_ERROR][GLFW#GLFW_PLATFORM_ERROR].
-
-                @glfw.pointer_lifetime The returned string is allocated and freed by GLFW. You
-                should not free it yourself. It is valid until the next call to
-                `glfwGetX11SelectionString` or [glfwSetX11SelectionString][#glfwSetX11SelectionString(MemorySegment)], or until the
-                library is terminated.
-
-                @glfw.thread_safety This function must only be called from the main thread.
-
-                @see #glfwSetX11SelectionString(MemorySegment) glfwSetX11SelectionString
-                @see GLFW#glfwGetClipboardString(MemorySegment) glfwGetClipboardString
-            """.trimIndent(),
-            optional = true,
-            defaultCode = "return MemorySegment.NULL;"
-        ).overload(name = "glfwGetX11SelectionString", defaultCode = "return null;")
+            optional = true
+        ).overload(name = "glfwGetX11SelectionString")
         //endregion
 
         //region GLX
         val GLXContext = address c "GLXContext"
         val GLXWindow = jlong c "GLXWindow"
 
-        "glfwGetGLXContext"(
-            GLXContext,
-            GLFWwindow_ptr("window"),
-            entrypoint = "glfwGetGLXContext",
-            javadoc = """
-                Returns the `GLXContext` of the specified window.
-
-                @return The `GLXContext` of the specified window, or `NULL` if an
-                error occurred.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][GLFW#GLFW_NOT_INITIALIZED],
-                [GLFW_NO_WINDOW_CONTEXT][GLFW#GLFW_NO_WINDOW_CONTEXT] and [GLFW_PLATFORM_UNAVAILABLE][GLFW#GLFW_PLATFORM_UNAVAILABLE].
-
-                @glfw.thread_safety This function may be called from any thread.  Access is not
-                synchronized.
-            """.trimIndent(),
-            optional = true,
-            defaultCode = "return MemorySegment.NULL;"
-        )
-
-        "glfwGetGLXWindow"(
-            GLXWindow,
-            GLFWwindow_ptr("window"),
-            entrypoint = "glfwGetGLXWindow",
-            javadoc = """
-                Returns the `GLXWindow` of the specified window.
-
-                @return The `GLXWindow` of the specified window, or `None` if an
-                error occurred.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][GLFW#GLFW_NOT_INITIALIZED],
-                [GLFW_NO_WINDOW_CONTEXT][GLFW#GLFW_NO_WINDOW_CONTEXT] and [GLFW_PLATFORM_UNAVAILABLE][GLFW#GLFW_PLATFORM_UNAVAILABLE].
-
-                @glfw.thread_safety This function may be called from any thread.  Access is not
-                synchronized.
-            """.trimIndent(),
-            optional = true,
-            defaultCode = "return 0L;"
-        )
+        "glfwGetGLXContext"(GLXContext, GLFWwindow_ptr("window"), entrypoint = "glfwGetGLXContext", optional = true)
+        "glfwGetGLXWindow"(GLXWindow, GLFWwindow_ptr("window"), entrypoint = "glfwGetGLXWindow", optional = true)
         //endregion
 
         //region WAYLAND
@@ -6512,63 +1163,18 @@ fun main() {
         val struct_wl_output_ptr = address c "struct wl_output*"
         val struct_wl_surface_ptr = address c "struct wl_surface*"
 
-        "glfwGetWaylandDisplay"(
-            struct_wl_display_ptr,
-            entrypoint = "glfwGetWaylandDisplay",
-            javadoc = """
-                Returns the `struct wl_display*` used by GLFW.
-
-                @return The `struct wl_display*` used by GLFW, or `NULL` if an
-                error occurred.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][GLFW#GLFW_NOT_INITIALIZED] and
-                [GLFW_PLATFORM_UNAVAILABLE][GLFW#GLFW_PLATFORM_UNAVAILABLE].
-
-                @glfw.thread_safety This function may be called from any thread.  Access is not
-                synchronized.
-            """.trimIndent(),
-            optional = true,
-            defaultCode = "return MemorySegment.NULL;"
-        )
-
+        "glfwGetWaylandDisplay"(struct_wl_display_ptr, entrypoint = "glfwGetWaylandDisplay", optional = true)
         "glfwGetWaylandMonitor"(
             struct_wl_output_ptr,
             GLFWmonitor_ptr("monitor"),
             entrypoint = "glfwGetWaylandMonitor",
-            javadoc = """
-                Returns the `struct wl_output*` of the specified monitor.
-
-                @return The `struct wl_output*` of the specified monitor, or `NULL` if an
-                error occurred.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][GLFW#GLFW_NOT_INITIALIZED] and
-                [GLFW_PLATFORM_UNAVAILABLE][GLFW#GLFW_PLATFORM_UNAVAILABLE].
-
-                @glfw.thread_safety This function may be called from any thread.  Access is not
-                synchronized.
-            """.trimIndent(),
-            optional = true,
-            defaultCode = "return MemorySegment.NULL;"
+            optional = true
         )
-
         "glfwGetWaylandWindow"(
             struct_wl_surface_ptr,
             GLFWwindow_ptr("window"),
             entrypoint = "glfwGetWaylandWindow",
-            javadoc = """
-                Returns the main `struct wl_surface*` of the specified window.
-
-                @return The main `struct wl_surface*` of the specified window, or `NULL` if
-                an error occurred.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][GLFW#GLFW_NOT_INITIALIZED] and
-                [GLFW_PLATFORM_UNAVAILABLE][GLFW#GLFW_PLATFORM_UNAVAILABLE].
-
-                @glfw.thread_safety This function may be called from any thread.  Access is not
-                synchronized.
-            """.trimIndent(),
-            optional = true,
-            defaultCode = "return MemorySegment.NULL;"
+            optional = true
         )
         //endregion
 
@@ -6577,66 +1183,9 @@ fun main() {
         val EGLContext = address c "EGLContext"
         val EGLSurface = address c "EGLSurface"
 
-        "glfwGetEGLDisplay"(
-            EGLDisplay,
-            entrypoint = "glfwGetEGLDisplay",
-            javadoc = """
-                Returns the `EGLDisplay` used by GLFW.
-
-                @return The `EGLDisplay` used by GLFW, or `EGL_NO_DISPLAY` if an
-                error occurred.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][GLFW#GLFW_NOT_INITIALIZED].
-
-                @glfw.remark Because EGL is initialized on demand, this function will return
-                `EGL_NO_DISPLAY` until the first context has been created via EGL.
-
-                @glfw.thread_safety This function may be called from any thread.  Access is not
-                synchronized.
-            """.trimIndent(),
-            optional = true,
-            defaultCode = "return MemorySegment.NULL;"
-        )
-
-        "glfwGetEGLContext"(
-            EGLContext,
-            GLFWwindow_ptr("window"),
-            entrypoint = "glfwGetEGLContext",
-            javadoc = """
-                Returns the `EGLContext` of the specified window.
-
-                @return The `EGLContext` of the specified window, or `EGL_NO_CONTEXT` if an
-                error occurred.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][GLFW#GLFW_NOT_INITIALIZED] and
-                [GLFW_NO_WINDOW_CONTEXT][GLFW#GLFW_NO_WINDOW_CONTEXT].
-
-                @glfw.thread_safety This function may be called from any thread.  Access is not
-                synchronized.
-            """.trimIndent(),
-            optional = true,
-            defaultCode = "return MemorySegment.NULL;"
-        )
-
-        "glfwGetEGLSurface"(
-            EGLSurface,
-            GLFWwindow_ptr("window"),
-            entrypoint = "glfwGetEGLSurface",
-            javadoc = """
-                Returns the `EGLSurface` of the specified window.
-
-                @return The `EGLSurface` of the specified window, or `EGL_NO_SURFACE` if an
-                error occurred.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][GLFW#GLFW_NOT_INITIALIZED] and
-                [GLFW_NO_WINDOW_CONTEXT][GLFW#GLFW_NO_WINDOW_CONTEXT].
-
-                @glfw.thread_safety This function may be called from any thread.  Access is not
-                synchronized.
-            """.trimIndent(),
-            optional = true,
-            defaultCode = "return MemorySegment.NULL;"
-        )
+        "glfwGetEGLDisplay"(EGLDisplay, entrypoint = "glfwGetEGLDisplay", optional = true)
+        "glfwGetEGLContext"(EGLContext, GLFWwindow_ptr("window"), entrypoint = "glfwGetEGLContext", optional = true)
+        "glfwGetEGLSurface"(EGLSurface, GLFWwindow_ptr("window"), entrypoint = "glfwGetEGLSurface", optional = true)
         //endregion
 
         //region OSMESA
@@ -6652,30 +1201,9 @@ fun main() {
             int_ptr_osmesa("format").ref(),
             void_ptr_ptr_osmesa("buffer").ref(),
             entrypoint = "glfwGetOSMesaColorBuffer",
-            javadoc = """
-                Retrieves the color buffer associated with the specified window.
-
-                @param window The window whose color buffer to retrieve.
-                @param width Where to store the width of the color buffer, or `NULL`.
-                @param height Where to store the height of the color buffer, or `NULL`.
-                @param format Where to store the OSMesa pixel format of the color
-                buffer, or `NULL`.
-                @param buffer Where to store the address of the color buffer, or
-                `NULL`.
-                @return `GLFW_TRUE` if successful, or `GLFW_FALSE` if an
-                error occurred.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][GLFW#GLFW_NOT_INITIALIZED] and
-                [GLFW_NO_WINDOW_CONTEXT][GLFW#GLFW_NO_WINDOW_CONTEXT].
-
-                @glfw.thread_safety This function may be called from any thread.  Access is not
-                synchronized.
-            """.trimIndent(),
             addNow = false,
-            optional = true,
-            defaultCode = "return false;"
+            optional = true
         ).overload()
-
         +"glfwGetOSMesaDepthBuffer"(
             glfw_boolean,
             GLFWwindow_ptr("window"),
@@ -6684,48 +1212,14 @@ fun main() {
             int_ptr_osmesa("bytesPerValue").ref(),
             void_ptr_ptr_osmesa("buffer").ref(),
             entrypoint = "glfwGetOSMesaDepthBuffer",
-            javadoc = """
-                Retrieves the depth buffer associated with the specified window.
-
-                @param window The window whose depth buffer to retrieve.
-                @param width Where to store the width of the depth buffer, or `NULL`.
-                @param height Where to store the height of the depth buffer, or `NULL`.
-                @param bytesPerValue Where to store the number of bytes per depth
-                buffer element, or `NULL`.
-                @param buffer Where to store the address of the depth buffer, or
-                `NULL`.
-                @return `GLFW_TRUE` if successful, or `GLFW_FALSE` if an
-                error occurred.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][GLFW#GLFW_NOT_INITIALIZED] and
-                [GLFW_NO_WINDOW_CONTEXT][GLFW#GLFW_NO_WINDOW_CONTEXT].
-
-                @glfw.thread_safety This function may be called from any thread.  Access is not
-                synchronized.
-            """.trimIndent(),
             addNow = false,
-            optional = true,
-            defaultCode = "return false;"
+            optional = true
         ).overload()
-
         "glfwGetOSMesaContext"(
             OSMesaContext,
             GLFWwindow_ptr("window"),
             entrypoint = "glfwGetOSMesaContext",
-            javadoc = """
-                Returns the `OSMesaContext` of the specified window.
-
-                @return The `OSMesaContext` of the specified window, or `NULL` if an
-                error occurred.
-
-                @glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][GLFW#GLFW_NOT_INITIALIZED] and
-                [GLFW_NO_WINDOW_CONTEXT][GLFW#GLFW_NO_WINDOW_CONTEXT].
-
-                @glfw.thread_safety This function may be called from any thread.  Access is not
-                synchronized.
-            """.trimIndent(),
-            optional = true,
-            defaultCode = "return MemorySegment.NULL;"
+            optional = true
         )
         //endregion
     }
@@ -6745,14 +1239,12 @@ private fun DowncallMethod.windowCallbackOverload(): DowncallMethod =
 
 private fun StaticDowncall.windowCallback(
     name: String,
-    callbackType: CustomTypeSpec,
-    javadoc: String
+    callbackType: CustomTypeSpec
 ) {
     +name(
         address c callbackType.cType,
         GLFWwindow_ptr("window"),
         callbackType("callback"),
-        entrypoint = name,
-        javadoc = javadoc
+        entrypoint = name
     ).windowCallbackOverload()
 }

--- a/generators/nfd/src/main/kotlin/overrungl/nfd/NFDGenerator.kt
+++ b/generators/nfd/src/main/kotlin/overrungl/nfd/NFDGenerator.kt
@@ -64,12 +64,7 @@ val const_nfdpickfoldernargs_t_ptr = address c "const nfdpickfoldernargs_t*"
 
 fun main() {
     //region Structs
-    Struct(
-        nfdPackage,
-        "NFDFilterItem",
-        "nfdnfilteritem_t",
-        javadoc = "UTF-16 Filter Item on Windows, UTF-8 Filter Item on others"
-    ) {
+    Struct(nfdPackage, "NFDFilterItem", "nfdnfilteritem_t") {
         const_nfdnchar_t_ptr("name")
         const_nfdnchar_t_ptr("spec")
         doLast {
@@ -93,17 +88,7 @@ fun main() {
         }
     }
 
-    val nfdwindowhandle_t = Struct(
-        nfdPackage,
-        "NFDWindowHandle",
-        "nfdwindowhandle_t",
-        javadoc = """
-            The native window handle.
-
-            If using a platform abstraction framework (e.g. SDL2), this should be
-            obtained using the corresponding NFD glue header (e.g. nfd_sdl2.h).
-        """.trimIndent()
-    ) {
+    val nfdwindowhandle_t = Struct(nfdPackage, "NFDWindowHandle", "nfdwindowhandle_t") {
         size_t("type")
         void_ptr("handle")
     }
@@ -129,54 +114,22 @@ fun main() {
 
     StaticDowncall(nfdPackage, "NFD", "NFDInternal.lookup()") {
         int {
-            "NFD_ERROR"("0", javadoc = "Programmatic error")
-            "NFD_OKAY"("1", javadoc = "User pressed okay, or successful return")
-            "NFD_CANCEL"("2", javadoc = "User pressed cancel")
+            "NFD_ERROR"("0")
+            "NFD_OKAY"("1")
+            "NFD_CANCEL"("2")
         }
-        int(javadoc = "The native window handle type.\nWayland support will be implemented separately in the future") {
+        int {
             "NFD_WINDOW_HANDLE_TYPE_UNSET"("0")
-            "NFD_WINDOW_HANDLE_TYPE_WINDOWS"(
-                "1",
-                javadoc = "Windows: handle is HWND (the Windows API typedefs this to void*)"
-            )
-            "NFD_WINDOW_HANDLE_TYPE_COCOA"("2", javadoc = "Cocoa: handle is NSWindow*")
-            "NFD_WINDOW_HANDLE_TYPE_X11"("3", javadoc = "X11: handle is Window")
+            "NFD_WINDOW_HANDLE_TYPE_WINDOWS"("1")
+            "NFD_WINDOW_HANDLE_TYPE_COCOA"("2")
+            "NFD_WINDOW_HANDLE_TYPE_X11"("3")
         }
-        int(
-            "NFD_INTERFACE_VERSION" to "1",
-            javadoc = """
-                This is a unique identifier tagged to all the NFD_*With() function calls, for backward
-                compatibility purposes. <p>There is usually no need to use this directly, unless you want to use
-                NFD differently depending on the version you're building with.
-            """.trimIndent()
-        )
+        int("NFD_INTERFACE_VERSION" to "1")
 
         //region methods
-        "NFD_FreePath"(
-            void,
-            nfdnchar_t_ptr("filePath"),
-            entrypoint = "NFD_FreePathN",
-            javadoc = """
-                Free a file path that was returned by the dialogs.
-
-                Note: use NFD_PathSet_FreePath() to free path from pathset instead of this function.
-            """.trimIndent()
-        )
-        "NFD_Init"(
-            nfdresult_t,
-            entrypoint = "NFD_Init",
-            javadoc = """
-                Initialize NFD. Call this for every thread that might use NFD, before calling any other NFD
-                functions on that thread.
-            """.trimIndent()
-        )
-        "NFD_Quit"(
-            void,
-            entrypoint = "NFD_Quit",
-            javadoc = """
-                Call this to de-initialize NFD, if [NFD_Init][#NFD_Init()] returned NFD_OKAY.
-            """.trimIndent()
-        )
+        "NFD_FreePath"(void, nfdnchar_t_ptr("filePath"), entrypoint = "NFD_FreePathN")
+        "NFD_Init"(nfdresult_t, entrypoint = "NFD_Init")
+        "NFD_Quit"(void, entrypoint = "NFD_Quit")
 
         "NFD_OpenDialog"(
             nfdresult_t,
@@ -184,35 +137,20 @@ fun main() {
             const_nfdnfilteritem_t_ptr("filterList"),
             nfdfiltersize_t("filterCount"),
             const_nfdnchar_t_ptr("defaultPath"),
-            entrypoint = "NFD_OpenDialogN",
-            javadoc = """
-                Single file open dialog
-
-                It's the caller's responsibility to free `outPath` via NFD_FreePath() if this function returns
-                NFD_OKAY.
-                @param filterCount If zero, filterList is ignored (you can use null).
-                @param defaultPath If null, the operating system will decide.
-            """.trimIndent()
+            entrypoint = "NFD_OpenDialogN"
         )
         "NFD_OpenDialog_With_Impl"(
             nfdresult_t,
             nfdversion_t("version"),
             nfdnchar_t_ptr_ptr("outPath"),
             const_nfdopendialognargs_t_ptr("args"),
-            entrypoint = "NFD_OpenDialogN_With_Impl",
-            javadoc = "This function is a library implementation detail.  Please use NFD_OpenDialog_With() instead."
+            entrypoint = "NFD_OpenDialogN_With_Impl"
         )
         "NFD_OpenDialog_With"(
             nfdresult_t,
             nfdnchar_t_ptr_ptr("outPath"),
             const_nfdopendialognargs_t_ptr("args"),
             entrypoint = null,
-            javadoc = """
-                Single file open dialog, with additional parameters.
-
-                It is the caller's responsibility to free `outPath` via NFD_FreePath() if this function
-                returns NFD_OKAY.  See documentation of [NFDOpenDialogArgs] for details.
-            """.trimIndent(),
             code = "return NFD_OpenDialog_With_Impl(NFD_INTERFACE_VERSION, outPath, args);"
         )
         "NFD_OpenDialogMultiple"(
@@ -221,38 +159,20 @@ fun main() {
             const_nfdnfilteritem_t_ptr("filterList"),
             nfdfiltersize_t("filterCount"),
             const_nfdnchar_t_ptr("defaultPath"),
-            entrypoint = "NFD_OpenDialogMultipleN",
-            javadoc = """
-                Multiple file open dialog
-
-                It is the caller's responsibility to free `outPaths` via NFD_PathSet_Free() if this function
-                returns NFD_OKAY.
-                @param filterCount If zero, filterList is ignored (you can use null).
-                @param defaultPath If null, the operating system will decide.
-            """.trimIndent()
+            entrypoint = "NFD_OpenDialogMultipleN"
         )
         "NFD_OpenDialogMultiple_With_Impl"(
             nfdresult_t,
             nfdversion_t("version"),
             const_nfdpathset_t_ptr_ptr("outPaths"),
             const_nfdopendialognargs_t_ptr("args"),
-            entrypoint = "NFD_OpenDialogMultipleN_With_Impl",
-            javadoc = """
-                This function is a library implementation detail.  Please use NFD_OpenDialogMultiple_With()
-                instead.
-            """.trimIndent()
+            entrypoint = "NFD_OpenDialogMultipleN_With_Impl"
         )
         "NFD_OpenDialogMultiple_With"(
             nfdresult_t,
             const_nfdpathset_t_ptr_ptr("outPaths"),
             const_nfdopendialognargs_t_ptr("args"),
             entrypoint = null,
-            javadoc = """
-                Multiple file open dialog, with additional parameters.
-
-                It is the caller's responsibility to free `outPaths` via NFD_PathSet_Free() if this function
-                returns NFD_OKAY.  See documentation of [NFDOpenDialogArgs] for details.
-            """.trimIndent(),
             code = "return NFD_OpenDialogMultiple_With_Impl(NFD_INTERFACE_VERSION, outPaths, args);"
         )
 
@@ -263,35 +183,20 @@ fun main() {
             nfdfiltersize_t("filterCount"),
             const_nfdnchar_t_ptr("defaultPath"),
             const_nfdnchar_t_ptr("defaultName"),
-            entrypoint = "NFD_SaveDialogN",
-            javadoc = """
-                Save dialog
-
-                It is the caller's responsibility to free `outPath` via NFD_FreePath() if this function returns
-                NFD_OKAY.
-                @param filterCount If zero, filterList is ignored (you can use null).
-                @param defaultPath If null, the operating system will decide.
-            """.trimIndent()
+            entrypoint = "NFD_SaveDialogN"
         )
         "NFD_SaveDialog_With_Impl"(
             nfdresult_t,
             nfdversion_t("version"),
             nfdnchar_t_ptr_ptr("outPath"),
             const_nfdsavedialognargs_t_ptr("args"),
-            entrypoint = "NFD_SaveDialogN_With_Impl",
-            javadoc = "This function is a library implementation detail.  Please use NFD_SaveDialog_With() instead."
+            entrypoint = "NFD_SaveDialogN_With_Impl"
         )
         "NFD_SaveDialog_With"(
             nfdresult_t,
             nfdnchar_t_ptr_ptr("outPath"),
             const_nfdsavedialognargs_t_ptr("args"),
             entrypoint = null,
-            javadoc = """
-                Single file save dialog, with additional parameters.
-
-                It is the caller's responsibility to free `outPath` via NFD_FreePath() if this function
-                returns NFD_OKAY.  See documentation of [NFDSaveDialogArgs] for details.
-            """.trimIndent(),
             code = "return NFD_SaveDialog_With_Impl(NFD_INTERFACE_VERSION, outPath, args);"
         )
 
@@ -299,101 +204,51 @@ fun main() {
             nfdresult_t,
             nfdnchar_t_ptr_ptr("outPath"),
             const_nfdnchar_t_ptr("defaultPath"),
-            entrypoint = "NFD_PickFolderN",
-            javadoc = """
-                Select single folder dialog
-
-                It is the caller's responsibility to free `outPath` via NFD_FreePath() if this function returns
-                NFD_OKAY.
-                @param defaultPath If null, the operating system will decide.
-            """.trimIndent()
+            entrypoint = "NFD_PickFolderN"
         )
         "NFD_PickFolder_With_Impl"(
             nfdresult_t,
             nfdversion_t("version"),
             nfdnchar_t_ptr_ptr("outPath"),
             const_nfdpickfoldernargs_t_ptr("args"),
-            entrypoint = "NFD_PickFolderN_With_Impl",
-            javadoc = "This function is a library implementation detail.  Please use NFD_PickFolder_With() instead."
+            entrypoint = "NFD_PickFolderN_With_Impl"
         )
         "NFD_PickFolder_With"(
             nfdresult_t,
             nfdnchar_t_ptr_ptr("outPath"),
             const_nfdpickfoldernargs_t_ptr("args"),
             entrypoint = null,
-            javadoc = """
-                Select single folder dialog, with additional parameters.
-
-                It is the caller's responsibility to free `outPath` via NFD_FreePath() if this function
-                returns NFD_OKAY.  See documentation of [NFDPickFolderArgs] for details.
-            """.trimIndent(),
             code = "return NFD_PickFolder_With_Impl(NFD_INTERFACE_VERSION, outPath, args);"
         )
         "NFD_PickFolderMultiple"(
             nfdresult_t,
             const_nfdpathset_t_ptr_ptr("outPaths"),
             const_nfdnchar_t_ptr("defaultPath"),
-            entrypoint = "NFD_PickFolderMultipleN",
-            javadoc = """
-                Select multiple folder dialog
-
-                It is the caller's responsibility to free `outPaths` via NFD_PathSet_Free() if this function
-                NFD_OKAY.
-                @param defaultPath If null, the operating system will decide.
-            """.trimIndent()
+            entrypoint = "NFD_PickFolderMultipleN"
         )
         "NFD_PickFolderMultiple_With_Impl"(
             nfdresult_t,
             nfdversion_t("version"),
             const_nfdpathset_t_ptr_ptr("outPaths"),
             const_nfdpickfoldernargs_t_ptr("args"),
-            entrypoint = "NFD_PickFolderMultipleN_With_Impl",
-            javadoc = "This function is a library implementation detail.  Please use NFD_PickFolderMultiple_With() instead."
+            entrypoint = "NFD_PickFolderMultipleN_With_Impl"
         )
         "NFD_PickFolderMultiple_With"(
             nfdresult_t,
             const_nfdpathset_t_ptr_ptr("outPaths"),
             const_nfdpickfoldernargs_t_ptr("args"),
             entrypoint = null,
-            javadoc = """
-                Select multiple folder dialog, with additional parameters.
-
-                It is the caller's responsibility to free `outPaths` via NFD_PathSet_Free() if this function
-                returns NFD_OKAY.  See documentation of [NFDPickFolderArgs] for details.
-            """.trimIndent(),
             code = "return NFD_PickFolderMultiple_With_Impl(NFD_INTERFACE_VERSION, outPaths, args);"
         )
 
-        +"NFD_GetError_"(
-            const_char_ptr,
-            entrypoint = "NFD_GetError",
-            javadoc = """
-                Get the last error
-
-                This is set when a function returns NFD_ERROR.
-                The memory is owned by NFD and should not be freed by user code.
-                This is *always* ASCII printable characters, so it can be interpreted as UTF-8 without any
-                conversion.
-                @return The last error that was set, or null if there is no error.
-            """.trimIndent()
-        ).overload("NFD_GetError")
-        "NFD_ClearError"(
-            void,
-            entrypoint = "NFD_ClearError",
-            javadoc = "Clear the error."
-        )
+        +"NFD_GetError_"(const_char_ptr, entrypoint = "NFD_GetError").overload("NFD_GetError")
+        "NFD_ClearError"(void, entrypoint = "NFD_ClearError")
 
         +"NFD_PathSet_GetCount"(
             nfdresult_t,
             const_nfdpathset_t_ptr("pathSet"),
             nfdpathsetsize_t_ptr("count").ref(),
-            entrypoint = "NFD_PathSet_GetCount",
-            javadoc = """
-                Get the number of entries stored in pathSet.
-
-                Note: some paths might be invalid (NFD_ERROR will be returned by NFD_PathSet_GetPath),
-                so we might not actually have this number of usable paths.
-            """.trimIndent()
+            entrypoint = "NFD_PathSet_GetCount"
         ).overload(
             parameters = listOf(
                 const_nfdpathset_t_ptr("pathSet"),
@@ -405,57 +260,23 @@ fun main() {
             const_nfdpathset_t_ptr("pathSet"),
             nfdpathsetsize_t("index"),
             nfdnchar_t_ptr_ptr("outPath"),
-            entrypoint = "NFD_PathSet_GetPathN",
-            javadoc = """
-                Get the native path at offset index.
-                <p>
-                It is the caller's responsibility to free `outPath` via NFD_PathSet_FreePath() if this function
-                returns NFD_OKAY.
-            """.trimIndent()
+            entrypoint = "NFD_PathSet_GetPathN"
         )
-        "NFD_PathSet_FreePath"(
-            void,
-            const_nfdnchar_t_ptr("filePath"),
-            entrypoint = "NFD_PathSet_FreePathN",
-            javadoc = "Free the path gotten by NFD_PathSet_GetPath()."
-        )
+        "NFD_PathSet_FreePath"(void, const_nfdnchar_t_ptr("filePath"), entrypoint = "NFD_PathSet_FreePathN")
         "NFD_PathSet_GetEnum"(
             nfdresult_t,
             const_nfdpathset_t_ptr("pathSet"),
             nfdpathsetenum_t_ptr("outEnumerator"),
-            entrypoint = "NFD_PathSet_GetEnum",
-            javadoc = """
-                Gets an enumerator of the path set.
-
-                It is the caller's responsibility to free `enumerator` via NFD_PathSet_FreeEnum()
-                if this function returns NFD_OKAY, and it should be freed before freeing the pathset.
-            """.trimIndent()
+            entrypoint = "NFD_PathSet_GetEnum"
         )
-        "NFD_PathSet_FreeEnum"(
-            void,
-            nfdpathsetenum_t_ptr("enumerator"),
-            entrypoint = "NFD_PathSet_FreeEnum",
-            javadoc = "Frees an enumerator of the path set."
-        )
+        "NFD_PathSet_FreeEnum"(void, nfdpathsetenum_t_ptr("enumerator"), entrypoint = "NFD_PathSet_FreeEnum")
         "NFD_PathSet_EnumNext"(
             nfdresult_t,
             nfdpathsetenum_t_ptr("enumerator"),
             nfdnchar_t_ptr_ptr("outPath"),
-            entrypoint = "NFD_PathSet_EnumNextN",
-            javadoc = """
-                Gets the next item from the path set enumerator.
-
-                If there are no more items, then *outPaths will be set to null.
-                It is the caller's responsibility to free `*outPath` via NFD_PathSet_FreePath()
-                if this function returns NFD_OKAY and `*outPath` is not null.
-            """.trimIndent()
+            entrypoint = "NFD_PathSet_EnumNextN"
         )
-        "NFD_PathSet_Free"(
-            void,
-            const_nfdpathset_t_ptr("pathSet"),
-            entrypoint = "NFD_PathSet_Free",
-            javadoc = "Free the pathSet"
-        )
+        "NFD_PathSet_Free"(void, const_nfdpathset_t_ptr("pathSet"), entrypoint = "NFD_PathSet_Free")
         //endregion
     }
 }

--- a/generators/openal/src/main/kotlin/overrungl/openal/AL.kt
+++ b/generators/openal/src/main/kotlin/overrungl/openal/AL.kt
@@ -102,7 +102,7 @@ fun AL() {
 
         ALenum("AL_DISTANCE_MODEL" to "0xD000")
 
-        ALenum("Distance model values.") {
+        ALenum {
             "AL_INVERSE_DISTANCE"("0xD001")
             "AL_INVERSE_DISTANCE_CLAMPED"("0xD002")
             "AL_LINEAR_DISTANCE"("0xD003")

--- a/generators/openal/src/main/kotlin/overrungl/openal/ALC.kt
+++ b/generators/openal/src/main/kotlin/overrungl/openal/ALC.kt
@@ -47,7 +47,7 @@ fun ALC() {
         ALCenum("ALC_DEVICE_SPECIFIER" to "0x1005")
         ALCenum("ALC_EXTENSIONS" to "0x1006")
 
-        ALCenum("ALC_EXT_CAPTURE" to "1", "Capture extension")
+        ALCenum("ALC_EXT_CAPTURE" to "1")
         ALCenum("ALC_CAPTURE_DEVICE_SPECIFIER" to "0x310")
         ALCenum("ALC_CAPTURE_DEFAULT_DEVICE_SPECIFIER" to "0x311")
         ALCenum("ALC_CAPTURE_SAMPLES" to "0x312")

--- a/generators/opengl/src/main/kotlin/overrungl/opengl/OpenGLGenerator.kt
+++ b/generators/opengl/src/main/kotlin/overrungl/opengl/OpenGLGenerator.kt
@@ -802,6 +802,9 @@ fun main() {
             appendLine(
                 """
                     /// The OpenGL binding.
+                    ///
+                    /// - [References](https://registry.khronos.org/OpenGL-Refpages/gl4/)
+                    /// - [Registry](https://github.com/KhronosGroup/OpenGL-Registry)
                     module overrungl.opengl {
                         exports overrungl.opengl;
                 """.trimIndent()

--- a/generators/opengl/src/main/kotlin/overrungl/opengl/OpenGLGenerator.kt
+++ b/generators/opengl/src/main/kotlin/overrungl/opengl/OpenGLGenerator.kt
@@ -802,9 +802,6 @@ fun main() {
             appendLine(
                 """
                     /// The OpenGL binding.
-                    ///
-                    /// - [References](https://registry.khronos.org/OpenGL-Refpages/gl4/)
-                    /// - [Registry](https://github.com/KhronosGroup/OpenGL-Registry)
                     module overrungl.opengl {
                         exports overrungl.opengl;
                 """.trimIndent()

--- a/generators/src/main/kotlin/overrungl/gen/DowncallMethod.kt
+++ b/generators/src/main/kotlin/overrungl/gen/DowncallMethod.kt
@@ -35,11 +35,9 @@ data class DowncallMethod(
     val name: String,
     val parameters: List<DowncallParameter>,
     val entrypoint: String?,
-    val javadoc: String?,
     val code: String?,
     val overload: Boolean,
     val optional: Boolean,
-    val defaultCode: String?,
 ) {
     val allocatorRequirement: AllocatorRequirement by lazy {
         parameters.map { p ->
@@ -67,14 +65,10 @@ data class DowncallMethod(
     fun overload(
         name: String = this.name,
         parameters: List<DowncallParameter> = this.parameters,
-        javadoc: String? = this.javadoc,
-        defaultCode: String? = this.defaultCode
     ): DowncallMethod = copy(
         name = name,
         parameters = parameters,
-        javadoc = javadoc,
         overload = true,
-        defaultCode = defaultCode
     )
 
     private fun <T> List<T>.insertFirst(t: T): List<T> {

--- a/generators/src/main/kotlin/overrungl/gen/Struct.kt
+++ b/generators/src/main/kotlin/overrungl/gen/Struct.kt
@@ -24,7 +24,6 @@ class Struct(
     private val packageName: String,
     private val name: String,
     private val cType: String? = null,
-    private val javadoc: String? = null,
     private val opaque: Boolean = false,
     action: Struct.() -> Unit
 ) {
@@ -65,16 +64,16 @@ class Struct(
         doLast = action
     }
 
-    operator fun CustomTypeSpec.invoke(name: String, javadoc: String? = null) {
-        members.add(ValueStructMember(this, name, javadoc))
+    operator fun CustomTypeSpec.invoke(name: String) {
+        members.add(ValueStructMember(this, name))
     }
 
-    operator fun ByValueWrapper.invoke(name: String, javadoc: String? = null) {
-        members.add(ByValueStructStructMember(this.struct, name, javadoc))
+    operator fun ByValueWrapper.invoke(name: String) {
+        members.add(ByValueStructStructMember(this.struct, name))
     }
 
-    fun fixedSize(type: CustomTypeSpec, name: String, size: Long, javadoc: String? = null) {
-        members.add(FixedSizeStructMember(type, size, name, javadoc))
+    fun fixedSize(type: CustomTypeSpec, name: String, size: Long) {
+        members.add(FixedSizeStructMember(type, size, name))
     }
 
     fun write() {
@@ -95,10 +94,6 @@ class Struct(
         )
 
         // javadoc
-        if (javadoc != null) {
-            sb.appendLine(javadoc.prependIndent("/// "))
-            sb.appendLine("///")
-        }
         sb.appendLine("/// ## Members")
         members.forEach {
             sb.appendLine("/// ### ${it.name}")
@@ -110,12 +105,6 @@ class Struct(
                         is FixedSizeStructMember -> "/// [Byte offset handle][#MH_${it.name}] - [Memory layout][#ML_${it.name}] - Getter - Setter"
                     }
                 )
-            }
-            if (it.javadoc != null) {
-                sb.appendLine("///")
-                sb.appendLine(it.javadoc!!.prependIndent("/// "))
-                sb.append("///")
-                sb.appendLine()
             }
         }
         sb.appendLine(
@@ -409,19 +398,16 @@ class Struct(
 sealed interface StructMember {
     val type: CustomTypeSpec
     val name: String
-    val javadoc: String?
 }
 
 data class ValueStructMember(
     override val type: CustomTypeSpec,
-    override val name: String,
-    override val javadoc: String?
+    override val name: String
 ) : StructMember
 
 data class ByValueStructStructMember(
     val struct: Struct,
-    override val name: String,
-    override val javadoc: String?
+    override val name: String
 ) : StructMember {
     override val type: CustomTypeSpec = struct.byValueType
 }
@@ -429,8 +415,7 @@ data class ByValueStructStructMember(
 data class FixedSizeStructMember(
     val componentType: CustomTypeSpec,
     val size: Long,
-    override val name: String,
-    override val javadoc: String?
+    override val name: String
 ) : StructMember {
     override val type: CustomTypeSpec
         get() = CustomTypeSpec(

--- a/generators/src/main/kotlin/overrungl/gen/Upcall.kt
+++ b/generators/src/main/kotlin/overrungl/gen/Upcall.kt
@@ -34,7 +34,6 @@ fun generateUpcallType(packageName: String, name: String): CustomTypeSpec {
 class Upcall(
     val packageName: String,
     val name: String,
-    val javadoc: String? = null,
     action: Upcall.() -> Unit
 ) {
     var targetMethod: UpcallMethod? = null
@@ -55,7 +54,6 @@ class Upcall(
     operator fun String.invoke(
         returnType: CustomTypeSpec,
         vararg parameters: UpcallMethodParameter,
-        javadoc: String? = null,
         code: String? = null,
         overload: String? = null
     ): UpcallMethod {
@@ -63,7 +61,6 @@ class Upcall(
             name = this,
             returnType = returnType,
             parameters = parameters.toList(),
-            javadoc = javadoc,
             code = code,
             overload = overload
         )
@@ -94,10 +91,6 @@ class Upcall(
         )
         sb.appendLine()
 
-        // javadoc
-        if (javadoc != null) {
-            sb.appendLine(javadoc.prependIndent("/// "))
-        }
         sb.appendLine("@FunctionalInterface")
         sb.appendLine("public interface $name extends Upcall {")
 
@@ -132,11 +125,7 @@ class Upcall(
 
         // interface method
         interfaceMethod?.also { m ->
-            sb.appendLine("    ///The interface target method of the upcall.")
-            if (m.javadoc != null) {
-                sb.appendLine("    ///")
-                sb.appendLine(m.javadoc.prependIndent("    ///"))
-            }
+            sb.appendLine("    /// The interface target method of the upcall.")
             sb.append(
                 "    ",
                 m.returnType.javaTypeWithC(),
@@ -151,11 +140,7 @@ class Upcall(
         }
 
         // target method
-        sb.appendLine("    ///The target method of the upcall.")
-        if (targetMethodNotNull.javadoc != null) {
-            sb.appendLine("    ///")
-            sb.appendLine(targetMethodNotNull.javadoc.prependIndent("    ///"))
-        }
+        sb.appendLine("    /// The target method of the upcall.")
         sb.append("    ")
         if (targetMethodNotNull.code != null || targetMethodNotNull.overload != null) {
             sb.append("default ")
@@ -208,12 +193,8 @@ class Upcall(
         )
 
         // invoker
-        sb.appendLine("    ///A static invoker of the target method.")
-        if (targetMethodNotNull.javadoc != null) {
-            sb.appendLine("    ///")
-            sb.appendLine(targetMethodNotNull.javadoc.prependIndent("    ///"))
-        }
-        sb.appendLine("    ///@param stub the upcall stub")
+        sb.appendLine("    /// A static invoker of the target method.")
+        sb.appendLine("    /// @param stub the upcall stub")
         sb.append("""    static ${targetMethodNotNull.returnType.carrierWithC()} invoke(MemorySegment stub""")
         targetMethodNotNull.parameters.forEach { sb.append(", ", it.type.carrierWithC(), " ", it.name) }
         sb.appendLine(") {")
@@ -333,7 +314,6 @@ data class UpcallMethod(
     val name: String,
     val returnType: CustomTypeSpec,
     val parameters: List<UpcallMethodParameter>,
-    val javadoc: String?,
     val code: String?,
     val overload: String?
 )

--- a/generators/stb/src/main/kotlin/overrungl/stb/STBEasyFont.kt
+++ b/generators/stb/src/main/kotlin/overrungl/stb/STBEasyFont.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Overrun Organization
+ * Copyright (c) 2024-2025 Overrun Organization
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -23,27 +23,8 @@ val uchar_4 = jbyte_array c "unsigned char[4]"
 
 fun STBEasyFont() {
     StaticDowncall(stbPackage, "STBEasyFont", symbolLookup = stbLookup) {
-        "stb_easy_font_get_spacing"(
-            float,
-            entrypoint = "stb_easy_font_get_spacing",
-            javadoc = "{@return `stb_easy_font_spacing_val`}"
-        )
-        "stb_easy_font_spacing"(
-            void,
-            float("spacing"),
-            entrypoint = "stb_easy_font_spacing",
-            javadoc = """
-                Use positive values to expand the space between characters,
-                and small negative values (no smaller than -1.5) to contract
-                the space between characters.
-
-                E.g. spacing = 1 adds one "pixel" of spacing between the
-                characters. spacing = -1 is reasonable but feels a bit too
-                compact to me; -0.5 is a reasonable compromise as long as
-                you're scaling the font up.
-                @param spacing value
-            """.trimIndent()
-        )
+        "stb_easy_font_get_spacing"(float, entrypoint = "stb_easy_font_get_spacing")
+        "stb_easy_font_spacing"(void, float("spacing"), entrypoint = "stb_easy_font_spacing")
         "stb_easy_font_print"(
             int,
             float("x"),
@@ -52,57 +33,17 @@ fun STBEasyFont() {
             uchar_4("color"),
             void_ptr("vertex_buffer"),
             int("vbuf_size"),
-            entrypoint = "stb_easy_font_print",
-            javadoc = """
-                Takes a string (which can contain '\n') and fills out a
-                vertex buffer with renderable data to draw the string.
-                Output data assumes increasing x is rightwards, increasing y
-                is downwards.
-
-                The vertex data is divided into quads, i.e. there are four
-                vertices in the vertex buffer for each quad.
-
-                The vertices are stored in an interleaved format:
-
-                - x:`float`
-                - y:`float`
-                - z:`float`
-                - color:`uint8[4]`
-
-                You can ignore z and color if you get them from elsewhere
-                This format was chosen in the hopes it would make it
-                easier for you to reuse existing vertex-buffer-drawing code.
-
-                If you pass in NULL for color, it becomes 255,255,255,255.
-
-                If the buffer isn't large enough, it will truncate.
-                Expect it to use an average of ~270 bytes per character.
-
-                If your API doesn't draw quads, build a reusable index
-                list that allows you to render quads as indexed triangles.
-
-                @return the number of quads.
-            """.trimIndent()
+            entrypoint = "stb_easy_font_print"
         )
-        +"stb_easy_font_width"(
-            int,
-            char_ptr("width"),
-            entrypoint = "stb_easy_font_width",
-            javadoc = """
-                Takes a string and returns the horizontal size and the
-                vertical size (which can vary if 'text' has newlines).
-                @return the horizontal size
-            """.trimIndent()
-        ).overload(parameters = listOf(string_u8("width")))
+        +"stb_easy_font_width"(int, char_ptr("width"), entrypoint = "stb_easy_font_width").overload(
+            parameters = listOf(
+                string_u8("width")
+            )
+        )
         +"stb_easy_font_height"(
             int,
             char_ptr("height"),
-            entrypoint = "stb_easy_font_height",
-            javadoc = """
-                Takes a string and returns the horizontal size and the
-                vertical size (which can vary if 'text' has newlines).
-                @return the vertical size
-            """.trimIndent()
+            entrypoint = "stb_easy_font_height"
         ).overload(parameters = listOf(string_u8("height")))
     }
 }

--- a/generators/stb/src/main/kotlin/overrungl/stb/STBImage.kt
+++ b/generators/stb/src/main/kotlin/overrungl/stb/STBImage.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Overrun Organization
+ * Copyright (c) 2024-2025 Overrun Organization
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -38,33 +38,14 @@ fun STBImage() {
     }
     val stbi_io_callbacks_const_ptr = stbi_io_callbacks.pointerType c "stbi_io_callbacks const *"
 
-    Upcall(stbPackage, "STBIIORead", javadoc = "The read callback") {
-        targetMethod = "invoke"(
-            int,
-            void_ptr("user"),
-            char_ptr("data"),
-            int("size"),
-            javadoc = """
-                fill 'data' with 'size' bytes.
-                @return number of bytes actually read
-            """.trimIndent()
-        )
+    Upcall(stbPackage, "STBIIORead") {
+        targetMethod = "invoke"(int, void_ptr("user"), char_ptr("data"), int("size"))
     }
-    Upcall(stbPackage, "STBIIOSkip", javadoc = "The skip callback") {
-        targetMethod = "invoke"(
-            void,
-            void_ptr("user"),
-            int("n"),
-            javadoc = "skip the next 'n' bytes, or 'unget' the last -n bytes if negative"
-        )
+    Upcall(stbPackage, "STBIIOSkip") {
+        targetMethod = "invoke"(void, void_ptr("user"), int("n"))
     }
-    Upcall(stbPackage, "STBIIOEof", javadoc = "The eof callback") {
-        val doc = "@return nonzero if we are at end of file/data"
-        interfaceMethod = "invoke"(
-            jboolean,
-            void_ptr("user"),
-            javadoc = doc
-        )
+    Upcall(stbPackage, "STBIIOEof") {
+        interfaceMethod = "invoke"(jboolean, void_ptr("user"))
         targetMethod = "invoke_"(
             CustomTypeSpec(
                 carrier = TypeName.INT,
@@ -88,13 +69,12 @@ fun STBImage() {
                 cType = int.cType
             ),
             void_ptr("user"),
-            javadoc = doc,
             overload = "invoke"
         )
     }
 
     StaticDowncall(stbPackage, "STBImage", symbolLookup = stbLookup) {
-        int("STBI_default" to "0", javadoc = "only used for desired_channels")
+        int("STBI_default" to "0")
         int("STBI_grey" to "1")
         int("STBI_grey_alpha" to "2")
         int("STBI_rgb" to "3")
@@ -230,19 +210,9 @@ fun STBImage() {
 
         +"stbi_failure_reason_"(
             const_char_ptr,
-            entrypoint = "stbi_failure_reason",
-            javadoc = """
-                get a VERY brief reason for failure
-
-                on most compilers (and ALL modern mainstream compilers) this is threadsafe
-            """.trimIndent()
+            entrypoint = "stbi_failure_reason"
         ).overload(name = "stbi_failure_reason")
-        "stbi_image_free"(
-            void,
-            void_ptr("retval_from_stbi_load"),
-            entrypoint = "stbi_image_free",
-            javadoc = "free the loaded image -- this is just free()"
-        )
+        "stbi_image_free"(void, void_ptr("retval_from_stbi_load"), entrypoint = "stbi_image_free")
 
         // get image dimensions & components without fully decoding
         "stbi_info_from_memory"(
@@ -292,27 +262,17 @@ fun STBImage() {
         "stbi_set_unpremultiply_on_load"(
             void,
             boolean_int("flag_true_if_should_unpremultiply"),
-            entrypoint = "stbi_set_unpremultiply_on_load",
-            javadoc = """
-                for image formats that explicitly notate that they have premultiplied alpha,
-                we just return the colors as stored in the file. set this flag to force
-                unpremultiplication. results are undefined if the unpremultiply overflow.
-            """.trimIndent()
+            entrypoint = "stbi_set_unpremultiply_on_load"
         )
         "stbi_convert_iphone_png_to_rgb"(
             void,
             boolean_int("flag_true_if_should_convert"),
-            entrypoint = "stbi_convert_iphone_png_to_rgb",
-            javadoc = """
-                indicate whether we should process iphone images back to canonical format,
-                or just pass them through "as-is"
-            """.trimIndent()
+            entrypoint = "stbi_convert_iphone_png_to_rgb"
         )
         "stbi_set_flip_vertically_on_load"(
             void,
             boolean_int("flag_true_if_should_flip"),
-            entrypoint = "stbi_set_flip_vertically_on_load",
-            javadoc = "flip the image vertically, so the first pixel in the output array is the bottom left"
+            entrypoint = "stbi_set_flip_vertically_on_load"
         )
 
         "stbi_set_unpremultiply_on_load_thread"(

--- a/generators/stb/src/main/kotlin/overrungl/stb/STBImageResize2.kt
+++ b/generators/stb/src/main/kotlin/overrungl/stb/STBImageResize2.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Overrun Organization
+ * Copyright (c) 2024-2025 Overrun Organization
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -70,7 +70,7 @@ fun STBImageResize2() {
         stbir__info_ptr("samplers")
     }
 
-    Upcall(stbPackage, "STBIRInputCallback", javadoc = "INPUT CALLBACK: this callback is used for input scanlines") {
+    Upcall(stbPackage, "STBIRInputCallback") {
         targetMethod = "invoke"(
             void_const_ptr,
             void_ptr("optional_output"),
@@ -81,7 +81,7 @@ fun STBImageResize2() {
             void_ptr("context")
         )
     }
-    Upcall(stbPackage, "STBIROutputCallback", javadoc = "OUTPUT CALLBACK: this callback is used for output scanlines") {
+    Upcall(stbPackage, "STBIROutputCallback") {
         targetMethod = "invoke"(
             void,
             void_const_ptr("output_ptr"),
@@ -90,7 +90,7 @@ fun STBImageResize2() {
             void_ptr("context")
         )
     }
-    Upcall(stbPackage, "STBIRKernelCallback", javadoc = "callbacks for user installed filters") {
+    Upcall(stbPackage, "STBIRKernelCallback") {
         targetMethod = "invoke"(
             float,
             float("x"),
@@ -98,7 +98,7 @@ fun STBImageResize2() {
             void_ptr("user_data")
         )
     }
-    Upcall(stbPackage, "STBIRSupportCallback", javadoc = "callbacks for user installed filters") {
+    Upcall(stbPackage, "STBIRSupportCallback") {
         targetMethod = "invoke"(
             float,
             float("scale"),
@@ -108,44 +108,28 @@ fun STBImageResize2() {
 
     StaticDowncall(stbPackage, "STBImageResize2", symbolLookup = stbLookup) {
         // Easy-to-use API
-        stbir_pixel_layout(
-            javadoc = """
-                stbir_pixel_layout specifies:
-                - number of channels
-                - order of channels
-                - whether color is premultiplied by alpha
-                for back compatibility, you can cast the old channel count to an stbir_pixel_layout
-            """.trimIndent()
-        ) {
+        stbir_pixel_layout {
             "STBIR_1CHANNEL"("1")
             "STBIR_2CHANNEL"("2")
-            "STBIR_RGB"("3", javadoc = "3-chan, with order specified (for channel flipping)")
-            "STBIR_BGR"("0", javadoc = "3-chan, with order specified (for channel flipping)")
+            "STBIR_RGB"("3")
+            "STBIR_BGR"("0")
             "STBIR_4CHANNEL"("5")
 
-            "STBIR_RGBA"("4", javadoc = "alpha formats, where alpha is NOT premultiplied into color channels")
+            "STBIR_RGBA"("4")
             "STBIR_BGRA"("6")
             "STBIR_ARGB"("7")
             "STBIR_ABGR"("8")
             "STBIR_RA"("9")
             "STBIR_AR"("10")
 
-            "STBIR_RGBA_PM"("11", javadoc = "alpha formats, where alpha is premultiplied into color channels")
+            "STBIR_RGBA_PM"("11")
             "STBIR_BGRA_PM"("12")
             "STBIR_ARGB_PM"("13")
             "STBIR_ABGR_PM"("14")
             "STBIR_RA_PM"("15")
             "STBIR_AR_PM"("16")
 
-            "STBIR_RGBA_NO_AW"(
-                "11",
-                javadoc = """
-                    alpha formats, where NO alpha weighting is applied at all!
-                    these are just synonyms for the _PM flags (which also do
-                    no alpha weighting). These names just make it more clear
-                    for some folks).
-                """.trimIndent()
-            )
+            "STBIR_RGBA_NO_AW"("11")
             "STBIR_BGRA_NO_AW"("12")
             "STBIR_ARGB_NO_AW"("13")
             "STBIR_ABGR_NO_AW"("14")
@@ -177,37 +161,28 @@ fun STBImageResize2() {
 
 
         // Medium-complexity API
-        stbir_edge(javadoc = "stbir_edge") {
+        stbir_edge {
             "STBIR_EDGE_CLAMP"("0")
             "STBIR_EDGE_REFLECT"("1")
-            "STBIR_EDGE_WRAP"("2", javadoc = "this edge mode is slower and uses more memory")
+            "STBIR_EDGE_WRAP"("2")
             "STBIR_EDGE_ZERO"("3")
         }
 
-        stbir_filter(javadoc = "stbir_filter") {
-            "STBIR_FILTER_DEFAULT"("0", javadoc = "use same filter type that easy-to-use API chooses")
-            "STBIR_FILTER_BOX"(
-                "1",
-                javadoc = "A trapezoid w/1-pixel wide ramps, same result as box for integer scale ratios"
-            )
-            "STBIR_FILTER_TRIANGLE"("2", javadoc = "On upsampling, produces same results as bilinear texture filtering")
-            "STBIR_FILTER_CUBICBSPLINE"(
-                "3",
-                javadoc = "The cubic b-spline (aka Mitchell-Netrevalli with B=1,C=0), gaussian-esque"
-            )
-            "STBIR_FILTER_CATMULLROM"("4", javadoc = "An interpolating cubic spline")
-            "STBIR_FILTER_MITCHELL"("5", javadoc = "Mitchell-Netrevalli filter with B=1/3, C=1/3")
-            "STBIR_FILTER_POINT_SAMPLE"("6", javadoc = "Simple point sampling")
-            "STBIR_FILTER_OTHER"("7", javadoc = "User callback specified")
+        stbir_filter {
+            "STBIR_FILTER_DEFAULT"("0")
+            "STBIR_FILTER_BOX"("1")
+            "STBIR_FILTER_TRIANGLE"("2")
+            "STBIR_FILTER_CUBICBSPLINE"("3")
+            "STBIR_FILTER_CATMULLROM"("4")
+            "STBIR_FILTER_MITCHELL"("5")
+            "STBIR_FILTER_POINT_SAMPLE"("6")
+            "STBIR_FILTER_OTHER"("7")
         }
 
-        stbir_datatype(javadoc = "stbir_datatype") {
+        stbir_datatype {
             "STBIR_TYPE_UINT8"("0")
             "STBIR_TYPE_UINT8_SRGB"("1")
-            "STBIR_TYPE_UINT8_SRGB_ALPHA"(
-                "2",
-                javadoc = "alpha channel, when present, should also be SRGB (this is very unusual)"
-            )
+            "STBIR_TYPE_UINT8_SRGB_ALPHA"("2")
             "STBIR_TYPE_UINT16"("3")
             "STBIR_TYPE_FLOAT"("4")
             "STBIR_TYPE_HALF_FLOAT"("5")
@@ -323,45 +298,18 @@ fun STBImageResize2() {
             boolean_int,
             STBIR_RESIZE_ptr("resize"),
             int("non_pma_alpha_speed_over_quality"),
-            entrypoint = "stbir_set_non_pm_alpha_speed_over_quality",
-            javadoc = """
-                when inputting AND outputting non-premultiplied alpha pixels, we use a slower but higher quality technique
-                that fills the zero alpha pixel's RGB values with something plausible.  If you don't care about areas of
-                zero alpha, you can call this function to get about a 25% speed improvement for STBIR_RGBA to STBIR_RGBA
-                types of resizes.
-            """.trimIndent()
+            entrypoint = "stbir_set_non_pm_alpha_speed_over_quality"
         )
 
-        "stbir_build_samplers"(
-            boolean_int,
-            STBIR_RESIZE_ptr("resize"),
-            entrypoint = "stbir_build_samplers",
-            javadoc = "This builds the samplers and does one allocation"
-        )
-        "stbir_free_samplers"(
-            void,
-            STBIR_RESIZE_ptr("resize"),
-            entrypoint = "stbir_free_samplers",
-            javadoc = "You MUST call this, if you call stbir_build_samplers or stbir_build_samplers_with_splits"
-        )
-        "stbir_resize_extended"(
-            boolean_int,
-            STBIR_RESIZE_ptr("resize"),
-            entrypoint = "stbir_resize_extended",
-            javadoc = "And this is the main function to perform the resize synchronously on one thread."
-        )
+        "stbir_build_samplers"(boolean_int, STBIR_RESIZE_ptr("resize"), entrypoint = "stbir_build_samplers")
+        "stbir_free_samplers"(void, STBIR_RESIZE_ptr("resize"), entrypoint = "stbir_free_samplers")
+        "stbir_resize_extended"(boolean_int, STBIR_RESIZE_ptr("resize"), entrypoint = "stbir_resize_extended")
 
         "stbir_build_samplers_with_splits"(
             boolean_int,
             STBIR_RESIZE_ptr("resize"),
             int("try_splits"),
-            entrypoint = "stbir_build_samplers_with_splits",
-            javadoc = """
-                This will build samplers for threading.
-                You can pass in the number of threads you'd like to use (try_splits).
-                It returns the number of splits (threads) that you can call it with.
-                It might be less if the image resize can't be split up that many ways.
-            """.trimIndent()
+            entrypoint = "stbir_build_samplers_with_splits"
         )
 
         "stbir_resize_extended_split"(
@@ -369,19 +317,7 @@ fun STBImageResize2() {
             STBIR_RESIZE_ptr("resize"),
             int("split_start"),
             int("split_count"),
-            entrypoint = "stbir_resize_extended_splits",
-            javadoc = """
-                This function does a split of the resizing (you call this fuction for each
-                split, on multiple threads). A split is a piece of the output resize pixel space.
-
-                Note that you MUST call stbir_build_samplers_with_splits before stbir_resize_extended_split!
-
-                Usually, you will always call stbir_resize_split with split_start as the thread_index
-                and "1" for the split_count.
-                But, if you have a weird situation where you MIGHT want 8 threads, but sometimes
-                only 4 threads, you can use 0,2,4,6 for the split_start's and use "2" for the
-                split_count each time to turn in into a 4 thread resize. (This is unusual).
-            """.trimIndent()
+            entrypoint = "stbir_resize_extended_splits"
         )
     }
 }

--- a/generators/stb/src/main/kotlin/overrungl/stb/STBPerlin.kt
+++ b/generators/stb/src/main/kotlin/overrungl/stb/STBPerlin.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Overrun Organization
+ * Copyright (c) 2024-2025 Overrun Organization
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -31,20 +31,7 @@ fun STBPerlin() {
             int("x_wrap"),
             int("y_wrap"),
             int("z_wrap"),
-            entrypoint = "stb_perlin_noise3",
-            javadoc = """
-                This function computes a random value at the coordinate (x,y,z).
-                Adjacent random values are continuous but the noise fluctuates
-                its randomness with period 1, i.e. takes on wholly unrelated values
-                at integer points. Specifically, this implements Ken Perlin's
-                revised noise function from 2002.
-
-                The "wrap" parameters can be used to create wraparound noise that
-                wraps at powers of two. The numbers MUST be powers of two. Specify
-                0 to mean "don't care". (The noise always wraps every 256 due
-                details of the implementation, even if you ask for larger or no
-                wrapping.)
-            """.trimIndent()
+            entrypoint = "stb_perlin_noise3"
         )
         "stb_perlin_noise3_seed"(
             float,
@@ -55,12 +42,7 @@ fun STBPerlin() {
             int("y_wrap"),
             int("z_wrap"),
             int("seed"),
-            entrypoint = "stb_perlin_noise3_seed",
-            javadoc = """
-                As above, but 'seed' selects from multiple different variations of the
-                noise function. The current implementation only uses the bottom 8 bits
-                 of 'seed', but possibly in the future more bits will be used.
-            """.trimIndent()
+            entrypoint = "stb_perlin_noise3_seed"
         )
         "stb_perlin_ridge_noise3"(
             float,

--- a/generators/stb/src/main/kotlin/overrungl/stb/STBRectPack.kt
+++ b/generators/stb/src/main/kotlin/overrungl/stb/STBRectPack.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Overrun Organization
+ * Copyright (c) 2024-2025 Overrun Organization
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,44 +21,21 @@ import overrungl.gen.*
 val stbrp_coord = int c "stbrp_coord"
 
 fun STBRectPack() {
-    val stbrp_rect_ptr = Struct(
-        stbPackage,
-        "STBRPRect",
-        cType = "stbrp_rect",
-        javadoc = "16 bytes, nominally"
-    ) {
-        int("id", javadoc = "reserved for your use")
-        stbrp_coord("w", javadoc = "input")
-        stbrp_coord("h", javadoc = "input")
-        stbrp_coord("x", javadoc = "output")
-        stbrp_coord("y", javadoc = "output")
-        int("was_packed", javadoc = "non-zero if valid packing")
+    val stbrp_rect_ptr = Struct(stbPackage, "STBRPRect", cType = "stbrp_rect") {
+        int("id")
+        stbrp_coord("w")
+        stbrp_coord("h")
+        stbrp_coord("x")
+        stbrp_coord("y")
+        int("was_packed")
     }.pointerType c "stbrp_rect *"
-    val stbrp_node = Struct(
-        stbPackage,
-        "STBRPNode",
-        cType = "stbrp_node",
-        javadoc = """
-            the details of the following structures don't matter to you, but they must
-            be visible so you can handle the memory allocations for them
-        """.trimIndent(),
-        opaque = true
-    ) {
+    val stbrp_node = Struct(stbPackage, "STBRPNode", cType = "stbrp_node", opaque = true) {
         stbrp_coord("x")
         stbrp_coord("y")
         (address c "stbrp_node *")("next")
     }
     val stbrp_node_ptr = stbrp_node.pointerType c "stbrp_node *"
-    val stbrp_context_ptr = Struct(
-        stbPackage,
-        "STBRPContext",
-        cType = "stbrp_context",
-        javadoc = """
-            the details of the following structures don't matter to you, but they must
-            be visible so you can handle the memory allocations for them
-        """.trimIndent(),
-        opaque = true
-    ) {
+    val stbrp_context_ptr = Struct(stbPackage, "STBRPContext", cType = "stbrp_context", opaque = true) {
         int("width")
         int("height")
         int("align")
@@ -67,19 +44,11 @@ fun STBRectPack() {
         int("num_nodes")
         stbrp_node_ptr("active_head")
         stbrp_node_ptr("free_head")
-        fixedSize(
-            stbrp_node.byValueType,
-            "extra",
-            2,
-            javadoc = "we allocate two extra nodes so optimal user-node-count is 'width' not 'width+2'"
-        )
+        fixedSize(stbrp_node.byValueType, "extra", 2)
     }.pointerType c "stbrp_context *"
 
     StaticDowncall(stbPackage, "STBRectPack", symbolLookup = stbLookup) {
-        int(
-            "STBRP__MAXVAL" to "0x7fffffff",
-            javadoc = "Mostly for internal use, but this is the maximum supported coordinate value."
-        )
+        int("STBRP__MAXVAL" to "0x7fffffff")
         int("STBRP_HEURISTIC_Skyline_default" to "0")
         int("STBRP_HEURISTIC_Skyline_BL_sortHeight" to "STBRP_HEURISTIC_Skyline_default")
         int("STBRP_HEURISTIC_Skyline_BF_sortHeight" to "1")
@@ -89,32 +58,7 @@ fun STBRectPack() {
             stbrp_context_ptr("context"),
             stbrp_rect_ptr("rects"),
             int("num_rects"),
-            entrypoint = "stbrp_pack_rects",
-            javadoc = """
-                Assign packed locations to rectangles. The rectangles are of type
-                'stbrp_rect' defined below, stored in the array 'rects', and there
-                are 'num_rects' many of them.
-
-                Rectangles which are successfully packed have the 'was_packed' flag
-                set to a non-zero value and 'x' and 'y' store the minimum location
-                on each axis (i.e. bottom-left in cartesian coordinates, top-left
-                if you imagine y increasing downwards). Rectangles which do not fit
-                have the 'was_packed' flag set to 0.
-
-                You should not try to access the 'rects' array from another thread
-                while this function is running, as the function temporarily reorders
-                the array while it executes.
-
-                To pack into another rectangle, you need to call stbrp_init_target
-                again. To continue packing into the same rectangle, you can call
-                this function again. Calling this multiple times with multiple rect
-                arrays will probably produce worse packing results than calling it
-                a single time with the full rectangle array, but the option is
-                available.
-
-                @return 1 if all of the rectangles were successfully
-                        packed and 0 otherwise.
-            """.trimIndent()
+            entrypoint = "stbrp_pack_rects"
         ).overload()
 
         +"stbrp_init_target"(
@@ -124,52 +68,21 @@ fun STBRectPack() {
             int("height"),
             stbrp_node_ptr("nodes"),
             int("num_nodes"),
-            entrypoint = "stbrp_init_target",
-            javadoc = """
-                Initialize a rectangle packer to:
-                pack a rectangle that is 'width' by 'height' in dimensions
-                using temporary storage provided by the array 'nodes', which is 'num_nodes' long
-
-                You must call this function every time you start packing into a new target.
-
-                There is no "shutdown" function. The 'nodes' memory must stay valid for
-                the following stbrp_pack_rects() call (or calls), but can be freed after
-                the call (or calls) finish.
-
-                Note: to guarantee best results, either:
-                1. make sure 'num_nodes' >= 'width' or
-                2. call stbrp_allow_out_of_mem() defined below with 'allow_out_of_mem = 1'
-
-                If you don't do either of the above things, widths will be quantized to multiples
-                of small integers to guarantee the algorithm doesn't run out of temporary storage.
-
-                If you do #2, then the non-quantized algorithm will be used, but the algorithm
-                may run out of temporary storage and be unable to pack some rectangles.
-            """.trimIndent()
+            entrypoint = "stbrp_init_target"
         ).overload()
 
         +"stbrp_setup_allow_out_of_mem"(
             void,
             stbrp_context_ptr("context"),
             boolean_int("allow_out_of_mem"),
-            entrypoint = "stbrp_setup_allow_out_of_mem",
-            javadoc = """
-                Optionally call this function after init but before doing any packing to
-                change the handling of the out-of-temp-memory scenario, described above.
-                If you call init again, this will be reset to the default (false).
-            """.trimIndent()
+            entrypoint = "stbrp_setup_allow_out_of_mem"
         ).overload()
 
         +"stbrp_setup_heuristic"(
             void,
             stbrp_context_ptr("context"),
             int("heuristic"),
-            entrypoint = "stbrp_setup_heuristic",
-            javadoc = """
-                Optionally select which packing heuristic the library should use. Different
-                heuristics will produce better/worse results for different data sets.
-                If you call init again, this will be reset to the default.
-            """.trimIndent()
+            entrypoint = "stbrp_setup_heuristic"
         ).overload()
     }
 }

--- a/generators/stb/src/main/kotlin/overrungl/stb/STBTruetype.kt
+++ b/generators/stb/src/main/kotlin/overrungl/stb/STBTruetype.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Overrun Organization
+ * Copyright (c) 2024-2025 Overrun Organization
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -32,18 +32,17 @@ val stbrp_rect_ptr = CustomTypeSpec(
 fun STBTruetype() {
     //region Structs
     val stbtt__buf =
-        Struct(stbPackage, "STBTT__buf", cType = "stbtt__buf", javadoc = "private structure", opaque = true) {
+        Struct(stbPackage, "STBTT__buf", cType = "stbtt__buf", opaque = true) {
             uchar_ptr("data")
             int("cursor")
             int("size")
         }
 
     val stbtt_bakedchar_ptr = Struct(stbPackage, "STBTTBakedChar", cType = "stbtt_bakedchar") {
-        val xy01 = "coordinates of bbox in bitmap"
-        ushort("x0", javadoc = xy01)
-        ushort("y0", javadoc = xy01)
-        ushort("x1", javadoc = xy01)
-        ushort("y1", javadoc = xy01)
+        ushort("x0")
+        ushort("y0")
+        ushort("x1")
+        ushort("y1")
         float("xoff")
         float("yoff")
         float("xadvance")
@@ -51,24 +50,21 @@ fun STBTruetype() {
     val const_stbtt_bakedchar_ptr = stbtt_bakedchar_ptr c "const stbtt_bakedchar *"
 
     val stbtt_aligned_quad_ptr = Struct(stbPackage, "STBTTAlignedQuad", cType = "stbtt_aligned_quad") {
-        val tl = "top-left"
-        val br = "bottom-right"
-        float("x0", javadoc = tl)
-        float("y0", javadoc = tl)
-        float("s0", javadoc = tl)
-        float("t0", javadoc = tl)
-        float("x1", javadoc = br)
-        float("y1", javadoc = br)
-        float("s1", javadoc = br)
-        float("t1", javadoc = br)
+        float("x0")
+        float("y0")
+        float("s0")
+        float("t0")
+        float("x1")
+        float("y1")
+        float("s1")
+        float("t1")
     }.pointerType c "stbtt_aligned_quad *"
 
     val stbtt_packedchar_ptr = Struct(stbPackage, "STBTTPackedChar", cType = "stbtt_packedchar") {
-        val doc = "coordinates of bbox in bitmap"
-        ushort("x0", javadoc = doc)
-        ushort("y0", javadoc = doc)
-        ushort("x1", javadoc = doc)
-        ushort("y1", javadoc = doc)
+        ushort("x0")
+        ushort("y0")
+        ushort("x1")
+        ushort("y1")
         float("xoff")
         float("yoff")
         float("xadvance")
@@ -79,56 +75,42 @@ fun STBTruetype() {
 
     val stbtt_pack_context_ptr = address c "stbtt_pack_context *"
 
-    val stbtt_fontinfo_ptr = Struct(
-        stbPackage,
-        "STBTTFontInfo",
-        cType = "stbtt_fontinfo",
-        javadoc = """
-            The following structure is defined publicly so you can declare one on
-            the stack or as a global or etc, but you should treat it as opaque.
-        """.trimIndent(),
-        opaque = true
-    ) {
+    val stbtt_fontinfo_ptr = Struct(stbPackage, "STBTTFontInfo", cType = "stbtt_fontinfo", opaque = true) {
         void_ptr("userdata")
-        uchar_ptr("data", javadoc = "pointer to .ttf file")
-        int("fontstart", javadoc = "offset of start of font")
-        int("numGlyphs", javadoc = "number of glyphs, needed for range checking")
-        val doc1 = "table locations as offset from start of .ttf"
-        int("loca", javadoc = doc1)
-        int("head", javadoc = doc1)
-        int("glyf", javadoc = doc1)
-        int("hhea", javadoc = doc1)
-        int("hmtx", javadoc = doc1)
-        int("kern", javadoc = doc1)
-        int("gpos", javadoc = doc1)
-        int("svg", javadoc = doc1)
-        int("index_map", javadoc = "a cmap mapping for our chosen character encoding")
-        int("indexToLocFormat", javadoc = "format needed to map from glyph index to glyph")
-        stbtt__buf.byValue("cff", javadoc = "cff font data")
-        stbtt__buf.byValue("charstrings", javadoc = "the charstring index")
-        stbtt__buf.byValue("gsubrs", javadoc = "global charstring subroutines index")
-        stbtt__buf.byValue("subrs", javadoc = "private charstring subroutines index")
-        stbtt__buf.byValue("fontdicts", javadoc = "array of font dicts")
-        stbtt__buf.byValue("fdselect", javadoc = "map from glyph to fontdict")
+        uchar_ptr("data")
+        int("fontstart")
+        int("numGlyphs")
+        int("loca")
+        int("head")
+        int("glyf")
+        int("hhea")
+        int("hmtx")
+        int("kern")
+        int("gpos")
+        int("svg")
+        int("index_map")
+        int("indexToLocFormat")
+        stbtt__buf.byValue("cff")
+        stbtt__buf.byValue("charstrings")
+        stbtt__buf.byValue("gsubrs")
+        stbtt__buf.byValue("subrs")
+        stbtt__buf.byValue("fontdicts")
+        stbtt__buf.byValue("fdselect")
     }.pointerType c "stbtt_fontinfo *"
     val const_stbtt_fontinfo_ptr = stbtt_fontinfo_ptr c "const stbtt_fontinfo *"
 
     val stbtt_pack_range_ptr = Struct(stbPackage, "STBTTPackRange", cType = "stbtt_pack_range") {
         float("font_size")
-        int(
-            "first_unicode_codepoint_in_range",
-            javadoc = "if non-zero, then the chars are continuous, and this is the first codepoint"
-        )
-        int_ptr("array_of_unicode_codepoints", javadoc = "if non-zero, then this is an array of unicode codepoints")
+        int("first_unicode_codepoint_in_range")
+        int_ptr("array_of_unicode_codepoints")
         int("num_chars")
-        stbtt_packedchar_ptr("chardata_for_range", javadoc = "output")
-        val doc = "don't set these, they're used internally"
-        uchar("h_oversample", javadoc = doc)
-        uchar("v_oversample", javadoc = doc)
+        stbtt_packedchar_ptr("chardata_for_range")
+        uchar("h_oversample")
+        uchar("v_oversample")
     }.pointerType c "stbtt_pack_range *"
 
     val stbtt_kerningentry_ptr = Struct(stbPackage, "STBTTKerningEntry", cType = "stbtt_kerningentry") {
-        int("glyph1", javadoc = "use stbtt_FindGlyphIndex")
+        int("glyph1")
         int("glyph2")
         int("advance")
     }.pointerType c "stbtt_kerningentry*"
@@ -145,13 +127,7 @@ fun STBTruetype() {
         uchar("padding")
     }.pointerType c "stbtt_vertex *"
 
-    val stbtt__bitmap_ptr = Struct(
-        stbPackage,
-        "STBTT__bitmap",
-        cType = "stbtt__bitmap",
-        javadoc = "`@TODO: don't expose this structure`",
-        opaque = true
-    ) {
+    val stbtt__bitmap_ptr = Struct(stbPackage, "STBTT__bitmap", cType = "stbtt__bitmap", opaque = true) {
         int("w")
         int("h")
         int("stride")
@@ -168,13 +144,7 @@ fun STBTruetype() {
             uchar_ptr("pixels"), int("pw"), int("ph"),
             int("first_char"), int("num_chars"),
             stbtt_bakedchar_ptr("chardata"),
-            entrypoint = "stbtt_BakeFontBitmap",
-            javadoc = """
-                if return is positive, the first unused row of the bitmap
-                if return is negative, returns the negative of the number of characters that fit
-                if return is 0, no characters fit and no rows were used
-                This uses a very crappy packing.
-            """.trimIndent()
+            entrypoint = "stbtt_BakeFontBitmap"
         ).overload()
         +"stbtt_GetBakedQuad"(
             void,
@@ -183,18 +153,7 @@ fun STBTruetype() {
             float_ptr("xpos").ref(), float_ptr("ypos").ref(),
             stbtt_aligned_quad_ptr("q"),
             boolean_int("opengl_fillrule"),
-            entrypoint = "stbtt_GetBakedQuad",
-            javadoc = """
-                Call GetBakedQuad with char_index = 'character - first_char', and it
-                creates the quad you need to draw and advances the current position.
-
-                The coordinate system used assumes y increases downwards.
-
-                Characters will extend both above and below the current position;
-                see discussion of "BASELINE" above.
-
-                It's inefficient; you might want to c&p it and optimize it.
-            """.trimIndent()
+            entrypoint = "stbtt_GetBakedQuad"
         ).overload()
         +"stbtt_GetScaledFontVMetrics"(
             void,
@@ -204,8 +163,7 @@ fun STBTruetype() {
             float_ptr("ascent").ref(),
             float_ptr("descent").ref(),
             float_ptr("lineGap").ref(),
-            entrypoint = "stbtt_GetScaledFontVMetrics",
-            javadoc = "Query the font vertical metrics without having to create a font first."
+            entrypoint = "stbtt_GetScaledFontVMetrics"
         ).overload()
 
 
@@ -219,25 +177,9 @@ fun STBTruetype() {
             int("stride_in_bytes"),
             int("padding"),
             void_ptr("alloc_context"),
-            entrypoint = "stbtt_PackBegin",
-            javadoc = """
-                Initializes a packing context stored in the passed-in stbtt_pack_context.
-                Future calls using this context will pack characters into the bitmap passed
-                in here: a 1-channel bitmap that is width * height. stride_in_bytes is
-                the distance from one row to the next (or 0 to mean they are packed tightly
-                together). "padding" is the amount of padding to leave between each
-                character (normally you want '1' for bitmaps you'll use as textures with
-                bilinear filtering).
-
-                Returns `false` on failure, `true` on success.
-            """.trimIndent()
+            entrypoint = "stbtt_PackBegin"
         )
-        "stbtt_PackEnd"(
-            void,
-            stbtt_pack_context_ptr("spc"),
-            entrypoint = "stbtt_PackEnd",
-            javadoc = "Cleans up the packing context and frees all memory."
-        )
+        "stbtt_PackEnd"(void, stbtt_pack_context_ptr("spc"), entrypoint = "stbtt_PackEnd")
         "stbtt_PackFontRange"(
             boolean_int,
             stbtt_pack_context_ptr("spc"),
@@ -247,23 +189,7 @@ fun STBTruetype() {
             int("first_unicode_char_in_range"),
             int("num_chars_in_range"),
             stbtt_packedchar_ptr("chardata_for_range"),
-            entrypoint = "stbtt_PackFontRange",
-            javadoc = """
-                Creates character bitmaps from the font_index'th font found in fontdata (use
-                font_index=0 if you don't know what that is). It creates num_chars_in_range
-                bitmaps for characters with unicode values starting at first_unicode_char_in_range
-                and increasing. Data for how to render them is stored in chardata_for_range;
-                pass these to stbtt_GetPackedQuad to get back renderable quads.
-
-                font_size is the full height of the character from ascender to descender,
-                as computed by stbtt_ScaleForPixelHeight. To use a point size as computed
-                by stbtt_ScaleForMappingEmToPixels, wrap the point size in STBTT_POINT_SIZE()
-                and pass that result as 'font_size':
-                ```
-                ...,                  20 , ... // font max minus min y is 20 pixels tall
-                ..., STBTT_POINT_SIZE(20), ... // 'M' is 20 pixels tall
-                ```
-            """.trimIndent()
+            entrypoint = "stbtt_PackFontRange"
         )
         +"stbtt_PackFontRanges"(
             boolean_int,
@@ -272,48 +198,20 @@ fun STBTruetype() {
             int("font_index"),
             stbtt_pack_range_ptr("ranges"),
             int("num_ranges"),
-            entrypoint = "stbtt_PackFontRanges",
-            javadoc = """
-                Creates character bitmaps from multiple ranges of characters stored in
-                ranges. This will usually create a better-packed bitmap than multiple
-                calls to stbtt_PackFontRange. Note that you can call this multiple
-                times within a single PackBegin/PackEnd.
-            """.trimIndent()
+            entrypoint = "stbtt_PackFontRanges"
         ).overload()
         "stbtt_PackSetOversampling"(
             void,
             stbtt_pack_context_ptr("spc"),
             uint("h_oversample"),
             uint("v_oversample"),
-            entrypoint = "stbtt_PackSetOversampling",
-            javadoc = """
-                Oversampling a font increases the quality by allowing higher-quality subpixel
-                positioning, and is especially valuable at smaller text sizes.
-
-                This function sets the amount of oversampling for all following calls to
-                stbtt_PackFontRange(s) or stbtt_PackFontRangesGatherRects for a given
-                pack context. The default (no oversampling) is achieved by h_oversample=1
-                and v_oversample=1. The total number of pixels required is
-                h_oversample*v_oversample larger than the default; for example, 2x2
-                oversampling requires 4x the storage of 1x1. For best results, render
-                oversampled textures with bilinear filtering. Look at the readme in
-                stb/tests/oversample for information about oversampled fonts
-
-                To use with PackFontRangesGather etc., you must set it before calls
-                call to PackFontRangesGatherRects.
-            """.trimIndent()
+            entrypoint = "stbtt_PackSetOversampling"
         )
         "stbtt_PackSetSkipMissingCodepoints"(
             void,
             stbtt_pack_context_ptr("spc"),
             boolean_int("skip"),
-            entrypoint = "stbtt_PackSetSkipMissingCodepoints",
-            javadoc = """
-                If skip != 0, this tells stb_truetype to skip any codepoints for which
-                there is no corresponding glyph. If skip=0, which is the default, then
-                codepoints without a glyph recived the font's "missing character" glyph,
-                typically an empty box by convention.
-            """.trimIndent()
+            entrypoint = "stbtt_PackSetSkipMissingCodepoints"
         )
         +"stbtt_GetPackedQuad"(
             void,
@@ -322,18 +220,7 @@ fun STBTruetype() {
             float_ptr("xpos").ref(), float_ptr("ypos").ref(),
             stbtt_aligned_quad_ptr("q"),
             boolean_int("align_to_integer"),
-            entrypoint = "stbtt_GetPackedQuad",
-            javadoc = """
-                Calling these functions in sequence is roughly equivalent to calling
-                stbtt_PackFontRanges(). If you more control over the packing of multiple
-                fonts, or if you want to pack custom data into a font texture, take a look
-                at the source to of stbtt_PackFontRanges() and create a custom version
-                using these functions, e.g. call GatherRects multiple times,
-                building up a single array of rects, then call PackRects once,
-                then call RenderIntoRects repeatedly. This may result in a
-                better packing than calling PackFontRanges multiple times
-                (or it may not).
-            """.trimIndent()
+            entrypoint = "stbtt_GetPackedQuad"
         ).overload()
         "stbtt_PackFontRangesGatherRects"(
             int,
@@ -363,45 +250,19 @@ fun STBTruetype() {
 
 
         // FONT LOADING
-        "stbtt_GetNumberOfFonts"(
-            int,
-            const_uchar_ptr("data"),
-            entrypoint = "stbtt_GetNumberOfFonts",
-            javadoc = """
-                This function will determine the number of fonts in a font file.  TrueType
-                collection (.ttc) files may contain multiple fonts, while TrueType font
-                (.ttf) files only contain one font. The number of fonts can be used for
-                indexing with the previous function where the index is between zero and one
-                less than the total fonts. If an error occurs, -1 is returned.
-            """.trimIndent()
-        )
+        "stbtt_GetNumberOfFonts"(int, const_uchar_ptr("data"), entrypoint = "stbtt_GetNumberOfFonts")
         "stbtt_GetFontOffsetForIndex"(
             int,
             const_uchar_ptr("data"),
             int("index"),
-            entrypoint = "stbtt_GetFontOffsetForIndex",
-            javadoc = """
-                Each .ttf/.ttc file may have more than one font. Each font has a sequential
-                index number starting from 0. Call this function to get the font offset for
-                a given index; it returns -1 if the index is out of range. A regular .ttf
-                file will only define one font and it always be at offset 0, so it will
-                return '0' for index 0, and -1 for all other indices.
-            """.trimIndent()
+            entrypoint = "stbtt_GetFontOffsetForIndex"
         )
         "stbtt_InitFont"(
             boolean_int,
             stbtt_fontinfo_ptr("info"),
             const_uchar_ptr("data"),
             int("offset"),
-            entrypoint = "stbtt_InitFont",
-            javadoc = """
-                Given an offset into the file that defines a font, this function builds
-                the necessary cached info for the rest of the system. You must allocate
-                the stbtt_fontinfo yourself, and stbtt_InitFont will fill it out. You don't
-                need to do anything special to free it, because the contents are pure
-                value data with no additional data structures.
-                @return 0 on failure.
-            """.trimIndent()
+            entrypoint = "stbtt_InitFont"
         )
 
 
@@ -410,14 +271,7 @@ fun STBTruetype() {
             int,
             const_stbtt_fontinfo_ptr("info"),
             int("unicode_codepoint"),
-            entrypoint = "stbtt_FindGlyphIndex",
-            javadoc = """
-                If you're going to perform multiple operations on the same character
-                and you want a speed-up, call this function with the character you're
-                going to process, then use glyph-based functions instead of the
-                codepoint-based functions.
-                @return 0 if the character codepoint is not defined in the font.
-            """.trimIndent()
+            entrypoint = "stbtt_FindGlyphIndex"
         )
 
 
@@ -426,28 +280,13 @@ fun STBTruetype() {
             float,
             const_stbtt_fontinfo_ptr("info"),
             float("pixels"),
-            entrypoint = "stbtt_ScaleForPixelHeight",
-            javadoc = """
-                computes a scale factor to produce a font whose "height" is 'pixels' tall.
-                Height is measured as the distance from the highest ascender to the lowest
-                descender; in other words, it's equivalent to calling stbtt_GetFontVMetrics
-                and computing:
-                ```
-                scale = pixels / (ascent - descent)
-                ```
-                so if you prefer to measure height by the ascent only, use a similar calculation.
-            """.trimIndent()
+            entrypoint = "stbtt_ScaleForPixelHeight"
         )
         "stbtt_ScaleForMappingEmToPixels"(
             float,
             const_stbtt_fontinfo_ptr("info"),
             float("pixels"),
-            entrypoint = "stbtt_ScaleForMappingEmToPixels",
-            javadoc = """
-                computes a scale factor to produce a font whose EM size is mapped to
-                'pixels' tall. This is probably what traditional APIs compute, but
-                I'm not positive.
-            """.trimIndent()
+            entrypoint = "stbtt_ScaleForMappingEmToPixels"
         )
         +"stbtt_GetFontVMetrics"(
             void,
@@ -455,16 +294,7 @@ fun STBTruetype() {
             int_ptr("ascent").ref(),
             int_ptr("descent").ref(),
             int_ptr("lineGap").ref(),
-            entrypoint = "stbtt_GetFontVMetrics",
-            javadoc = """
-                these are expressed in unscaled coordinates, so you must multiply by
-                the scale factor for a given size
-
-                @param ascent the coordinate above the baseline the font extends
-                @param descent the coordinate below the baseline the font extends (i.e. it is typically negative)
-                @param lineGap the spacing between one row's descent and the next row's ascent...
-                so you should advance the vertical position by "*ascent - *descent + *lineGap"
-            """.trimIndent()
+            entrypoint = "stbtt_GetFontVMetrics"
         ).overload()
         +"stbtt_GetFontVMetricsOS2"(
             boolean_int,
@@ -472,13 +302,7 @@ fun STBTruetype() {
             int_ptr("typoAscent").ref(),
             int_ptr("typoDescent").ref(),
             int_ptr("typoLineGap").ref(),
-            entrypoint = "stbtt_GetFontVMetricsOS2",
-            javadoc = """
-                analogous to GetFontVMetrics, but returns the "typographic" values from the OS/2
-                table (specific to MS/Windows TTF files).
-
-                @return 1 on success (table present), 0 on failure.
-            """.trimIndent()
+            entrypoint = "stbtt_GetFontVMetricsOS2"
         ).overload()
         +"stbtt_GetFontBoundingBox"(
             void,
@@ -487,8 +311,7 @@ fun STBTruetype() {
             int_ptr("y0").ref(),
             int_ptr("x1").ref(),
             int_ptr("y1").ref(),
-            entrypoint = "stbtt_GetFontBoundingBox",
-            javadoc = "the bounding box around all possible characters"
+            entrypoint = "stbtt_GetFontBoundingBox"
         ).overload()
         +"stbtt_GetCodepointHMetrics"(
             void,
@@ -496,20 +319,14 @@ fun STBTruetype() {
             int("codepoint"),
             int_ptr("advanceWidth").ref(),
             int_ptr("leftSideBearing").ref(),
-            entrypoint = "stbtt_GetCodepointHMetrics",
-            javadoc = """
-                these are expressed in unscaled coordinates
-                @param advanceWidth the offset from the current horizontal position to the next horizontal position
-                @param leftSideBearing the offset from the current horizontal position to the left edge of the character
-            """.trimIndent()
+            entrypoint = "stbtt_GetCodepointHMetrics"
         ).overload()
         "stbtt_GetCodepointKernAdvance"(
             int,
             const_stbtt_fontinfo_ptr("info"),
             int("ch1"),
             int("ch2"),
-            entrypoint = "stbtt_GetCodepointKernAdvance",
-            javadoc = "an additional amount to add to the 'advance' value between ch1 and ch2"
+            entrypoint = "stbtt_GetCodepointKernAdvance"
         )
         +"stbtt_GetCodepointBox"(
             int,
@@ -519,8 +336,7 @@ fun STBTruetype() {
             int_ptr("y0").ref(),
             int_ptr("x1").ref(),
             int_ptr("y1").ref(),
-            entrypoint = "stbtt_GetCodepointBox",
-            javadoc = "Gets the bounding box of the visible part of the glyph, in unscaled coordinates"
+            entrypoint = "stbtt_GetCodepointBox"
         ).overload()
         +"stbtt_GetGlyphHMetrics"(
             void,
@@ -528,8 +344,7 @@ fun STBTruetype() {
             int("glyph_index"),
             int_ptr("advanceWidth").ref(),
             int_ptr("leftSideBearing").ref(),
-            entrypoint = "stbtt_GetGlyphHMetrics",
-            javadoc = "as above, but takes one or more glyph indices for greater efficiency"
+            entrypoint = "stbtt_GetGlyphHMetrics"
         ).overload()
         "stbtt_GetGlyphKernAdvance"(
             int,
@@ -554,12 +369,7 @@ fun STBTruetype() {
             const_stbtt_fontinfo_ptr("info"),
             stbtt_kerningentry_ptr("table"),
             int("table_length"),
-            entrypoint = "stbtt_GetKerningTable",
-            javadoc = """
-                Retrieves a complete list of all of the kerning pairs provided by the font
-                stbtt_GetKerningTable never writes more than table_length entries and returns how many entries it did write.
-                The table will be sorted by (a.glyph1 == b.glyph1)?(a.glyph2 < b.glyph2):(a.glyph1 < b.glyph1)
-            """.trimIndent()
+            entrypoint = "stbtt_GetKerningTable"
         )
 
 
@@ -571,47 +381,27 @@ fun STBTruetype() {
             "STBTT_vcubic"("4")
         }
 
-        "stbtt_IsGlyphEmpty"(
-            boolean_int,
-            const_stbtt_fontinfo_ptr("info"),
-            int("glyph_index"),
-            entrypoint = "stbtt_IsGlyphEmpty",
-            javadoc = "@return `true` if nothing is drawn for this glyph"
-        )
+        "stbtt_IsGlyphEmpty"(boolean_int, const_stbtt_fontinfo_ptr("info"), int("glyph_index"), entrypoint = "stbtt_IsGlyphEmpty")
         val stbtt_vertex_ptr_ptr = address c "stbtt_vertex **"
-        val doc_GetShape = """
-            {@return # of vertices and fills *vertices with the pointer to them}
-            these are expressed in "unscaled" coordinates
-
-            The shape is a series of contours. Each one starts with
-            a STBTT_moveto, then consists of a series of mixed
-            STBTT_lineto and STBTT_curveto segments. A lineto
-            draws a line from previous endpoint to its x,y; a curveto
-            draws a quadratic bezier from previous endpoint to
-            its x,y, using cx,cy as the bezier control point.
-        """.trimIndent()
         "stbtt_GetCodepointShape"(
             int,
             const_stbtt_fontinfo_ptr("info"),
             int("unicode_codepoint"),
             stbtt_vertex_ptr_ptr("vertices"),
-            entrypoint = "stbtt_GetCodepointShape",
-            javadoc = doc_GetShape
+            entrypoint = "stbtt_GetCodepointShape"
         )
         "stbtt_GetGlyphShape"(
             int,
             const_stbtt_fontinfo_ptr("info"),
             int("glyph_index"),
             stbtt_vertex_ptr_ptr("vertices"),
-            entrypoint = "stbtt_GetGlyphShape",
-            javadoc = doc_GetShape
+            entrypoint = "stbtt_GetGlyphShape"
         )
         +"stbtt_FreeShape"(
             void,
             const_stbtt_fontinfo_ptr("info"),
             stbtt_vertex_ptr("vertices"),
-            entrypoint = "stbtt_FreeShape",
-            javadoc = "frees the data allocated above"
+            entrypoint = "stbtt_FreeShape"
         ).overload()
         "stbtt_FindSVGDoc"(
             uchar_ptr,
@@ -619,25 +409,19 @@ fun STBTruetype() {
             int("gl"),
             entrypoint = "stbtt_FindSVGDoc"
         )
-        val doc_GetSVG = """
-            fills svg with the character's SVG data.
-            @return data size or 0 if SVG not found.
-        """.trimIndent()
         "stbtt_GetCodepointSVG"(
             int,
             const_stbtt_fontinfo_ptr("info"),
             int("unicode_codepoint"),
             const_char_ptr_ptr("svg"),
-            entrypoint = "stbtt_GetCodepointSVG",
-            javadoc = doc_GetSVG
+            entrypoint = "stbtt_GetCodepointSVG"
         )
         "stbtt_GetGlyphSVG"(
             int,
             const_stbtt_fontinfo_ptr("info"),
             int("gl"),
             const_char_ptr_ptr("svg"),
-            entrypoint = "stbtt_GetGlyphSVG",
-            javadoc = doc_GetSVG
+            entrypoint = "stbtt_GetGlyphSVG"
         )
 
 
@@ -646,8 +430,7 @@ fun STBTruetype() {
             void,
             uchar_ptr("bitmap"),
             void_ptr("userdata"),
-            entrypoint = "stbtt_FreeBitmap",
-            javadoc = "frees the bitmap allocated below"
+            entrypoint = "stbtt_FreeBitmap"
         )
         +"stbtt_GetCodepointBitmap"(
             uchar_ptr,
@@ -659,16 +442,7 @@ fun STBTruetype() {
             int_ptr("height").ref(),
             int_ptr("xoff").ref(),
             int_ptr("yoff").ref(),
-            entrypoint = "stbtt_GetCodepointBitmap",
-            javadoc = """
-                allocates a large-enough single-channel 8bpp bitmap and renders the
-                specified character/glyph at the specified scale into it, with
-                antialiasing. 0 is no coverage (transparent), 255 is fully covered (opaque).
-                *width & *height are filled out with the width & height of the bitmap,
-                which is stored left-to-right, top-to-bottom.
-
-                xoff/yoff are the offset it pixel space from the glyph origin to the top-left of the bitmap
-            """.trimIndent()
+            entrypoint = "stbtt_GetCodepointBitmap"
         ).overload()
         +"stbtt_GetCodepointBitmapSubpixel"(
             uchar_ptr,
@@ -682,11 +456,7 @@ fun STBTruetype() {
             int_ptr("height").ref(),
             int_ptr("xoff").ref(),
             int_ptr("yoff").ref(),
-            entrypoint = "stbtt_GetCodepointBitmapSubpixel",
-            javadoc = """
-                the same as stbtt_GetCodepointBitmap, but you can specify a subpixel
-                shift for the character
-            """.trimIndent()
+            entrypoint = "stbtt_GetCodepointBitmapSubpixel"
         ).overload()
         "stbtt_MakeCodepointBitmap"(
             void,
@@ -698,13 +468,7 @@ fun STBTruetype() {
             float("scale_x"),
             float("scale_y"),
             int("codepoint"),
-            entrypoint = "stbtt_MakeCodepointBitmap",
-            javadoc = """
-                the same as stbtt_GetCodepointBitmap, but you pass in storage for the bitmap
-                in the form of 'output', with row spacing of 'out_stride' bytes. the bitmap
-                is clipped to out_w/out_h bytes. Call stbtt_GetCodepointBitmapBox to get the
-                width and height and positioning info for it first.
-            """.trimIndent()
+            entrypoint = "stbtt_MakeCodepointBitmap"
         )
         "stbtt_MakeCodepointBitmapSubpixel"(
             void,
@@ -718,11 +482,7 @@ fun STBTruetype() {
             float("shift_x"),
             float("shift_y"),
             int("codepoint"),
-            entrypoint = "stbtt_MakeCodepointBitmapSubpixel",
-            javadoc = """
-                same as stbtt_MakeCodepointBitmap, but you can specify a subpixel
-                shift for the character
-            """.trimIndent()
+            entrypoint = "stbtt_MakeCodepointBitmapSubpixel"
         )
         +"stbtt_MakeCodepointBitmapSubpixelPrefilter"(
             void,
@@ -740,11 +500,7 @@ fun STBTruetype() {
             float_ptr("sub_x").ref(),
             float_ptr("sub_y").ref(),
             int("codepoint"),
-            entrypoint = "stbtt_MakeCodepointBitmapSubpixelPrefilter",
-            javadoc = """
-                same as stbtt_MakeCodepointBitmapSubpixel, but prefiltering
-                is performed (see stbtt_PackSetOversampling)
-            """.trimIndent()
+            entrypoint = "stbtt_MakeCodepointBitmapSubpixelPrefilter"
         ).overload()
         +"stbtt_GetCodepointBitmapBox"(
             void,
@@ -756,14 +512,7 @@ fun STBTruetype() {
             int_ptr("iy0").ref(),
             int_ptr("ix1").ref(),
             int_ptr("iy1").ref(),
-            entrypoint = "stbtt_GetCodepointBitmapBox",
-            javadoc = """
-                get the bbox of the bitmap centered around the glyph origin; so the
-                bitmap width is ix1-ix0, height is iy1-iy0, and location to place
-                the bitmap top left is (leftSideBearing*scale,iy0).
-                (Note that the bitmap uses y-increases-down, but the shape uses
-                y-increases-up, so CodepointBitmapBox and CodepointBox are inverted.)
-            """.trimIndent()
+            entrypoint = "stbtt_GetCodepointBitmapBox"
         ).overload()
         +"stbtt_GetCodepointBitmapBoxSubpixel"(
             void,
@@ -777,11 +526,7 @@ fun STBTruetype() {
             int_ptr("iy0").ref(),
             int_ptr("ix1").ref(),
             int_ptr("iy1").ref(),
-            entrypoint = "stbtt_GetCodepointBitmapBoxSubpixel",
-            javadoc = """
-                same as stbtt_GetCodepointBitmapBox, but you can specify a subpixel
-                shift for the character
-            """.trimIndent()
+            entrypoint = "stbtt_GetCodepointBitmapBoxSubpixel"
         ).overload()
         +"stbtt_GetGlyphBitmap"(
             uchar_ptr,
@@ -793,11 +538,7 @@ fun STBTruetype() {
             int_ptr("height").ref(),
             int_ptr("xoff").ref(),
             int_ptr("yoff").ref(),
-            entrypoint = "stbtt_GetGlyphBitmap",
-            javadoc = """
-                the following functions are equivalent to the above functions, but operate
-                on glyph indices instead of Unicode codepoints (for efficiency)
-            """.trimIndent()
+            entrypoint = "stbtt_GetGlyphBitmap"
         ).overload()
         +"stbtt_GetGlyphBitmapSubpixel"(
             uchar_ptr,
@@ -894,22 +635,7 @@ fun STBTruetype() {
             int("x_off"), int("y_off"),
             boolean_int("invert"),
             void_ptr("userdata"),
-            entrypoint = "stbtt_Rasterize",
-            javadoc = """
-                rasterize a shape with quadratic beziers into a bitmap
-                @param result 1-channel bitmap to draw into
-                @param flatness_in_pixels allowable error of curve in pixels
-                @param vertices array of vertices defining shape
-                @param num_verts number of vertices in above array
-                @param scale_x scale applied to input vertices
-                @param scale_y scale applied to input vertices
-                @param shift_x translation applied to input vertices
-                @param shift_y translation applied to input vertices
-                @param x_off another translation applied to input
-                @param y_off another translation applied to input
-                @param invert if non-zero, vertically flip shape
-                @param userdata context for to STBTT_MALLOC
-            """.trimIndent()
+            entrypoint = "stbtt_Rasterize"
         ).overload()
 
         // Signed Distance Function (or Field) rendering
@@ -917,8 +643,7 @@ fun STBTruetype() {
             void,
             uchar_ptr("bitmap"),
             void_ptr("userdata"),
-            entrypoint = "stbtt_FreeSDF",
-            javadoc = "frees the SDF bitmap allocated below"
+            entrypoint = "stbtt_FreeSDF"
         )
         +"stbtt_GetGlyphSDF"(
             uchar_ptr,
@@ -932,58 +657,7 @@ fun STBTruetype() {
             int_ptr("height").ref(),
             int_ptr("xoff").ref(),
             int_ptr("yoff").ref(),
-            entrypoint = "stbtt_GetGlyphSDF",
-            javadoc = """
-                These functions compute a discretized SDF field for a single character, suitable for storing
-                in a single-channel texture, sampling with bilinear filtering, and testing against
-                larger than some threshold to produce scalable fonts.
-
-                pixel_dist_scale & onedge_value are a scale & bias that allows you to make
-                optimal use of the limited 0..255 for your application, trading off precision
-                and special effects. SDF values outside the range 0..255 are clamped to 0..255.
-
-                The function computes the SDF analytically at each SDF pixel, not by e.g.
-                building a higher-res bitmap and approximating it. In theory the quality
-                should be as high as possible for an SDF of this size & representation, but
-                unclear if this is true in practice (perhaps building a higher-res bitmap
-                and computing from that can allow drop-out prevention).
-
-                The algorithm has not been optimized at all, so expect it to be slow
-                if computing lots of characters or very large sizes.
-
-                #### Example
-                - scale = stbtt_ScaleForPixelHeight(22)
-                - padding = 5
-                - onedge_value = 180
-                - pixel_dist_scale = 180/5.0 = 36.0
-
-                This will create an SDF bitmap in which the character is about 22 pixels
-                high but the whole bitmap is about 22+5+5=32 pixels high. To produce a filled
-                shape, sample the SDF at each pixel and fill the pixel if the SDF value
-                is greater than or equal to 180/255. (You'll actually want to antialias,
-                which is beyond the scope of this example.) Additionally, you can compute
-                offset outlines (e.g. to stroke the character border inside & outside,
-                or only outside). For example, to fill outside the character up to 3 SDF
-                pixels, you would compare against (180-36.0*3)/255 = 72/255. The above
-                choice of variables maps a range from 5 pixels outside the shape to
-                2 pixels inside the shape to 0..255; this is intended primarily for apply
-                outside effects only (the interior range is needed to allow proper
-                antialiasing of the font at *smaller* sizes)
-
-                @param info             the font
-                @param scale            controls the size of the resulting SDF bitmap, same as it would be creating a regular bitmap
-                @param glyph            the character to generate the SDF for
-                @param padding          extra "pixels" around the character which are filled with the distance to the character (not 0),
-                                        which allows effects like bit outlines
-                @param onedge_value     value 0-255 to test the SDF against to reconstruct the character (i.e. the isocontour of the character)
-                @param pixel_dist_scale what value the SDF should increase by when moving one SDF "pixel" away from the edge (on the 0..255 scale)
-                                        if positive, > onedge_value is inside; if negative, < onedge_value is inside
-                @param width            output width of the SDF bitmap (including padding)
-                @param height           output height of the SDF bitmap (including padding)
-                @param xoff             output origin of the character
-                @param yoff             output origin of the character
-                @return a 2D array of bytes 0..255, width*height in size
-            """.trimIndent()
+            entrypoint = "stbtt_GetGlyphSDF"
         ).overload()
         +"stbtt_GetCodepointSDF"(
             uchar_ptr,
@@ -997,8 +671,7 @@ fun STBTruetype() {
             int_ptr("height").ref(),
             int_ptr("xoff").ref(),
             int_ptr("yoff").ref(),
-            entrypoint = "stbtt_GetCodepointSDF",
-            javadoc = "See stbtt_GetGlyphSDF"
+            entrypoint = "stbtt_GetCodepointSDF"
         ).overload()
 
 
@@ -1007,20 +680,14 @@ fun STBTruetype() {
             const_uchar_ptr("fontdata"),
             const_char_ptr("name"),
             int("flags"),
-            entrypoint = "stbtt_FindMatchingFont",
-            javadoc = """
-                returns the offset (not index) of the font that matches, or -1 if none
-                if you use STBTT_MACSTYLE_DONTCARE, use a font name like "Arial Bold".
-                if you use any other flag, use a font name like "Arial"; this checks
-                the 'macStyle' header field; i don't know if fonts set this consistently
-            """.trimIndent()
+            entrypoint = "stbtt_FindMatchingFont"
         ).overload()
         int {
             "STBTT_MACSTYLE_DONTCARE"("0")
             "STBTT_MACSTYLE_BOLD"("1")
             "STBTT_MACSTYLE_ITALIC"("2")
             "STBTT_MACSTYLE_UNDERSCORE"("4")
-            "STBTT_MACSTYLE_NONE"("8", javadoc = "<= not same as 0, this makes us check the bitfield is 0")
+            "STBTT_MACSTYLE_NONE"("8")
         }
         "stbtt_CompareUTF8toUTF16_bigendian"(
             boolean_int,
@@ -1028,11 +695,7 @@ fun STBTruetype() {
             int("len1"),
             const_char_ptr("s2"),
             int("len2"),
-            entrypoint = "stbtt_CompareUTF8toUTF16_bigendian",
-            javadoc = """
-                returns 1/0 whether the first string interpreted as utf8 is identical to
-                the second string interpreted as big-endian utf16... useful for strings from next func
-            """.trimIndent()
+            entrypoint = "stbtt_CompareUTF8toUTF16_bigendian"
         )
         "stbtt_GetFontNameString"(
             const_char_ptr,
@@ -1042,15 +705,7 @@ fun STBTruetype() {
             int("encodingID"),
             int("languageID"),
             int("nameID"),
-            entrypoint = "stbtt_GetFontNameString",
-            javadoc = """
-                returns the string (which may be big-endian double byte, e.g. for unicode)
-                and puts the length in bytes in *length.
-
-                some of the values for the IDs are below; for more see the truetype spec:
-                - <https://developer.apple.com/textfonts/TTRefMan/RM06/Chap6name.html>
-                - <https://www.microsoft.com/typography/otspec/name.htm>
-            """.trimIndent()
+            entrypoint = "stbtt_GetFontNameString"
         )
 
         int("STBTT_PLATFORM_ID_UNICODE" to "0")

--- a/generators/stb/src/main/kotlin/overrungl/stb/STBVorbis.kt
+++ b/generators/stb/src/main/kotlin/overrungl/stb/STBVorbis.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Overrun Organization
+ * Copyright (c) 2024-2025 Overrun Organization
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -49,50 +49,18 @@ fun STBVorbis() {
             stb_vorbis_info,
             allocator("allocator"),
             stb_vorbis_ptr("f"),
-            entrypoint = "stb_vorbis_get_info",
-            javadoc = "get general information about the file"
+            entrypoint = "stb_vorbis_get_info"
         ).overload(name = "stb_vorbis_get_info")
         +"stb_vorbis_get_comment_"(
             stb_vorbis_comment,
             allocator("allocator"),
             stb_vorbis_ptr("f"),
-            entrypoint = "stb_vorbis_get_comment",
-            javadoc = "get ogg comments"
+            entrypoint = "stb_vorbis_get_comment"
         ).overload(name = "stb_vorbis_get_comment")
-        "stb_vorbis_get_error"(
-            int,
-            stb_vorbis_ptr("f"),
-            entrypoint = "stb_vorbis_get_error",
-            javadoc = "get the last error detected (clears it, too)"
-        )
-        "stb_vorbis_close"(
-            void,
-            stb_vorbis_ptr("f"),
-            entrypoint = "stb_vorbis_close",
-            javadoc = "close an ogg vorbis file and free all memory in use"
-        )
-        "stb_vorbis_get_sample_offset"(
-            int,
-            stb_vorbis_ptr("f"),
-            entrypoint = "stb_vorbis_get_sample_offset",
-            javadoc = """
-                this function returns the offset (in samples) from the beginning of the
-                file that will be returned by the next decode, if it is known, or -1
-                otherwise. after a flush_pushdata() call, this may take a while before
-                it becomes valid again.
-
-                NOT WORKING YET after a seek with PULLDATA API
-            """.trimIndent()
-        )
-        "stb_vorbis_get_file_offset"(
-            uint,
-            stb_vorbis_ptr("f"),
-            entrypoint = "stb_vorbis_get_file_offset",
-            javadoc = """
-                @return the current seek point within the file, or offset from the beginning
-                of the memory buffer. In pushdata mode it returns 0.
-            """.trimIndent()
-        )
+        "stb_vorbis_get_error"(int, stb_vorbis_ptr("f"), entrypoint = "stb_vorbis_get_error")
+        "stb_vorbis_close"(void, stb_vorbis_ptr("f"), entrypoint = "stb_vorbis_close")
+        "stb_vorbis_get_sample_offset"(int, stb_vorbis_ptr("f"), entrypoint = "stb_vorbis_get_sample_offset")
+        "stb_vorbis_get_file_offset"(uint, stb_vorbis_ptr("f"), entrypoint = "stb_vorbis_get_file_offset")
 
 
         // PUSHDATA API
@@ -102,20 +70,7 @@ fun STBVorbis() {
             int_ptr("datablock_memory_consumed_in_bytes").ref(),
             int_ptr("error").ref(),
             const_stb_vorbis_alloc_ptr("alloc_buffer"),
-            entrypoint = "stb_vorbis_open_pushdata",
-            javadoc = """
-                create a vorbis decoder by passing in the initial data block containing
-                the ogg&vorbis headers (you don't need to do parse them, just provide
-                the first N bytes of the file--you're told if it's not enough, see below)
-
-                on success, returns an stb_vorbis *, does not set error, returns the amount of
-                data parsed/consumed on this call in *datablock_memory_consumed_in_bytes;
-
-                on failure, returns NULL on error and sets *error, does not change *datablock_memory_consumed
-
-                if returns NULL and *error is VORBIS_need_more_data, then the input block was
-                incomplete and you need to pass in a larger block from the start of the file
-            """.trimIndent()
+            entrypoint = "stb_vorbis_open_pushdata"
         ).overload()
         "stb_vorbis_decode_frame_pushdata"(
             int,
@@ -124,76 +79,19 @@ fun STBVorbis() {
             int_ptr("channels").ref(),
             float_ptr_ptr_ptr("output").ref(),
             int_ptr("samples").ref(),
-            entrypoint = "stb_vorbis_decode_frame_pushdata",
-            javadoc = """
-                decode a frame of audio sample data if possible from the passed-in data block
-
-                possible cases:
-                - 0 bytes used, 0 samples output (need more data)
-                - N bytes used, 0 samples output (resynching the stream, keep going)
-                - N bytes used, M samples output (one frame of data)
-
-                note that after opening a file, you will ALWAYS get one N-bytes,0-sample
-                frame, because Vorbis always "discards" the first frame.
-
-                Note that on resynch, stb_vorbis will rarely consume all of the buffer,
-                instead only datablock_length_in_bytes-3 or less. This is because it wants
-                to avoid missing parts of a page header if they cross a datablock boundary,
-                without writing state-machiney code to record a partial detection.
-
-                The number of channels returned are stored in *channels (which can be
-                NULL--it is always the same as the number of channels reported by
-                get_info). *output will contain an array of float* buffers, one per
-                channel. In other words, (*output)[0][0] contains the first sample from
-                the first channel, and (*output)[1][0] contains the first sample from
-                the second channel.
-
-                *output points into stb_vorbis's internal output buffer storage; these
-                buffers are owned by stb_vorbis and application code should not free
-                them or modify their contents. They are transient and will be overwritten
-                once you ask for more data to get decoded, so be sure to grab any data
-                you need before then.
-
-                @param channels place to write number of float * buffers
-                @param output   place to write float ** array of float * buffers
-                @param samples  place to write number of output samples
-                @return number of bytes we used from datablock
-            """.trimIndent()
+            entrypoint = "stb_vorbis_decode_frame_pushdata"
         )
-        "stb_vorbis_flush_pushdata"(
-            void,
-            stb_vorbis_ptr("f"),
-            entrypoint = "stb_vorbis_flush_pushdata",
-            javadoc = """
-                inform stb_vorbis that your next datablock will not be contiguous with
-                previous ones (e.g. you've seeked in the data); future attempts to decode
-                frames will cause stb_vorbis to resynchronize (as noted above), and
-                once it sees a valid Ogg page (typically 4-8KB, as large as 64KB), it
-                will begin decoding the _next_ frame.
-
-                if you want to seek using pushdata, you need to seek in your file, then
-                call stb_vorbis_flush_pushdata(), then start calling decoding, then once
-                decoding is returning you data, call stb_vorbis_get_sample_offset, and
-                if you don't like the result, seek your file again and repeat.
-            """.trimIndent()
-        )
+        "stb_vorbis_flush_pushdata"(void, stb_vorbis_ptr("f"), entrypoint = "stb_vorbis_flush_pushdata")
 
 
         // PULLING INPUT API
-        val doc_decode = """
-            decode an entire file and output the data interleaved into a malloc()ed
-            buffer stored in *output. The return value is the number of samples
-            decoded, or -1 if the file could not be opened or was not an ogg vorbis file.
-            When you're done with it, just free() the pointer returned in *output.
-        """.trimIndent()
         "stb_vorbis_decode_filename"(
             int,
             const_char_ptr("filename"),
             int_ptr("channels").ref(),
             int_ptr("sample_rate").ref(),
             short_ptr_ptr("output").ref(),
-            entrypoint = "stb_vorbis_decode_filename",
-            javadoc = doc_decode
+            entrypoint = "stb_vorbis_decode_filename"
         )
         "stb_vorbis_decode_memory"(
             int,
@@ -202,8 +100,7 @@ fun STBVorbis() {
             int_ptr("channels").ref(),
             int_ptr("sample_rate").ref(),
             short_ptr_ptr("output").ref(),
-            entrypoint = "stb_vorbis_decode_memory",
-            javadoc = doc_decode
+            entrypoint = "stb_vorbis_decode_memory"
         )
         +"stb_vorbis_open_memory"(
             stb_vorbis_ptr,
@@ -211,102 +108,56 @@ fun STBVorbis() {
             int("len"),
             int_ptr("error").ref(),
             const_stb_vorbis_alloc_ptr("alloc_buffer"),
-            entrypoint = "stb_vorbis_open_memory",
-            javadoc = """
-                create an ogg vorbis decoder from an ogg vorbis stream in memory (note
-                this must be the entire stream!). on failure, returns NULL and sets *error
-            """.trimIndent()
+            entrypoint = "stb_vorbis_open_memory"
         ).overload()
         +"stb_vorbis_open_filename"(
             stb_vorbis_ptr,
             const_char_ptr("filename"),
             int_ptr("error").ref(),
             const_stb_vorbis_alloc_ptr("alloc_buffer"),
-            entrypoint = "stb_vorbis_open_filename",
-            javadoc = """
-                create an ogg vorbis decoder from a filename via fopen(). on failure,
-                returns NULL and sets *error (possibly to VORBIS_file_open_failure).
-            """.trimIndent()
+            entrypoint = "stb_vorbis_open_filename"
         ).overload()
-        val doc_seek = """
-            these functions seek in the Vorbis file to (approximately) 'sample_number'.
-            after calling seek_frame(), the next call to get_frame_*() will include
-            the specified sample. after calling stb_vorbis_seek(), the next call to
-            stb_vorbis_get_samples_* will start with the specified sample. If you
-            do not need to seek to EXACTLY the target sample when using get_samples_*,
-            you can also use seek_frame().
-        """.trimIndent()
         "stb_vorbis_seek_frame"(
             int,
             stb_vorbis_ptr("f"),
             uint("sample_number"),
-            entrypoint = "stb_vorbis_seek_frame",
-            javadoc = doc_seek
+            entrypoint = "stb_vorbis_seek_frame"
         )
         "stb_vorbis_seek"(
             int,
             stb_vorbis_ptr("f"),
             uint("sample_number"),
-            entrypoint = "stb_vorbis_seek",
-            javadoc = doc_seek
+            entrypoint = "stb_vorbis_seek"
         )
         "stb_vorbis_seek_start"(
             int,
             stb_vorbis_ptr("f"),
-            entrypoint = "stb_vorbis_seek_start",
-            javadoc = "this function is equivalent to stb_vorbis_seek(f,0)"
+            entrypoint = "stb_vorbis_seek_start"
         )
-        val doc_stream_len = "these functions return the total length of the vorbis stream"
         "stb_vorbis_stream_length_in_samples"(
             uint,
             stb_vorbis_ptr("f"),
-            entrypoint = "stb_vorbis_stream_length_in_samples",
-            javadoc = doc_stream_len
+            entrypoint = "stb_vorbis_stream_length_in_samples"
         )
         "stb_vorbis_stream_length_in_seconds"(
             float,
             stb_vorbis_ptr("f"),
-            entrypoint = "stb_vorbis_stream_length_in_seconds",
-            javadoc = doc_stream_len
+            entrypoint = "stb_vorbis_stream_length_in_seconds"
         )
         "stb_vorbis_get_frame_float"(
             int,
             stb_vorbis_ptr("f"),
             int_ptr("channels").ref(),
             float_ptr_ptr_ptr("output").ref(),
-            entrypoint = "stb_vorbis_get_frame_float",
-            javadoc = """
-                decode the next frame and return the number of samples. the number of
-                channels returned are stored in *channels (which can be NULL--it is always
-                the same as the number of channels reported by get_info). *output will
-                contain an array of float* buffers, one per channel. These outputs will
-                be overwritten on the next call to stb_vorbis_get_frame_*.
-
-                You generally should not intermix calls to stb_vorbis_get_frame_*()
-                and stb_vorbis_get_samples_*(), since the latter calls the former.
-            """.trimIndent()
+            entrypoint = "stb_vorbis_get_frame_float"
         )
-        val doc_get_frame_short = """
-            decode the next frame and return the number of *samples* per channel.
-            Note that for interleaved data, you pass in the number of shorts (the
-            size of your array), but the return value is the number of samples per
-            channel, not the total number of samples.
-
-            The data is coerced to the number of channels you request according to the
-            channel coercion rules (see below). You must pass in the size of your
-            buffer(s) so that stb_vorbis will not overwrite the end of the buffer.
-            The maximum buffer size needed can be gotten from get_info(); however,
-            the Vorbis I specification implies an absolute maximum of 4096 samples
-            per channel.
-        """.trimIndent()
         "stb_vorbis_get_frame_short_interleaved"(
             int,
             stb_vorbis_ptr("f"),
             int("num_c"),
             short_ptr("buffer").ref(),
             int("num_shorts"),
-            entrypoint = "stb_vorbis_get_frame_short_interleaved",
-            javadoc = doc_get_frame_short
+            entrypoint = "stb_vorbis_get_frame_short_interleaved"
         )
         "stb_vorbis_get_frame_short"(
             int,
@@ -314,23 +165,15 @@ fun STBVorbis() {
             int("num_c"),
             short_ptr_ptr("buffer").ref(),
             int("num_samples"),
-            entrypoint = "stb_vorbis_get_frame_short",
-            javadoc = doc_get_frame_short
+            entrypoint = "stb_vorbis_get_frame_short"
         )
-        val doc_get_samples_float = """
-            gets num_samples samples, not necessarily on a frame boundary--this requires
-            buffering so you have to supply the buffers. DOES NOT APPLY THE COERCION RULES.
-            @return the number of samples stored per channel; it may be less than requested
-            at the end of the file. If there are no more samples in the file, returns 0.
-        """.trimIndent()
         "stb_vorbis_get_samples_float_interleaved"(
             int,
             stb_vorbis_ptr("f"),
             int("channels"),
             float_ptr("buffer").ref(),
             int("num_floats"),
-            entrypoint = "stb_vorbis_get_samples_float_interleaved",
-            javadoc = doc_get_samples_float
+            entrypoint = "stb_vorbis_get_samples_float_interleaved"
         )
         "stb_vorbis_get_samples_float"(
             int,
@@ -338,25 +181,15 @@ fun STBVorbis() {
             int("channels"),
             float_ptr_ptr("buffer").ref(),
             int("num_samples"),
-            entrypoint = "stb_vorbis_get_samples_float",
-            javadoc = doc_get_samples_float
+            entrypoint = "stb_vorbis_get_samples_float"
         )
-        val doc_get_samples_short = """
-            gets num_samples samples, not necessarily on a frame boundary--this requires
-            buffering so you have to supply the buffers. Applies the coercion rules above
-            to produce 'channels' channels.
-            @return the number of samples stored per channel;
-            it may be less than requested at the end of the file. If there are no more
-            samples in the file, returns 0.
-        """.trimIndent()
         "stb_vorbis_get_samples_short_interleaved"(
             int,
             stb_vorbis_ptr("f"),
             int("channels"),
             short_ptr("buffer").ref(),
             int("num_shorts"),
-            entrypoint = "stb_vorbis_get_samples_short_interleaved",
-            javadoc = doc_get_samples_short
+            entrypoint = "stb_vorbis_get_samples_short_interleaved"
         )
         "stb_vorbis_get_samples_short"(
             int,
@@ -364,46 +197,36 @@ fun STBVorbis() {
             int("channels"),
             short_ptr_ptr("buffer").ref(),
             int("num_samples"),
-            entrypoint = "stb_vorbis_get_samples_short",
-            javadoc = doc_get_samples_short
+            entrypoint = "stb_vorbis_get_samples_short"
         )
 
-        int(
-            javadoc = """
-                STBVorbisError
-
-                from 20: decoding errors (corrupt/invalid stream) -- you probably
-                don't care about the exact details of these
-            """.trimIndent()
-        ) {
+        int {
             "VORBIS__no_error"("0")
 
-            "VORBIS_need_more_data"("1", javadoc = "not a real error")
+            "VORBIS_need_more_data"("1")
 
-            "VORBIS_invalid_api_mixing"("2", javadoc = "can't mix API modes")
-            "VORBIS_outofmem"("3", javadoc = "not enough memory")
-            "VORBIS_feature_not_supported"("4", javadoc = "uses floor 0")
-            "VORBIS_too_many_channels"("5", javadoc = "STB_VORBIS_MAX_CHANNELS is too small")
-            "VORBIS_file_open_failure"("6", javadoc = "fopen() failed")
-            "VORBIS_seek_without_length"("7", javadoc = "can't seek in unknown-length file")
+            "VORBIS_invalid_api_mixing"("2")
+            "VORBIS_outofmem"("3")
+            "VORBIS_feature_not_supported"("4")
+            "VORBIS_too_many_channels"("5")
+            "VORBIS_file_open_failure"("6")
+            "VORBIS_seek_without_length"("7")
 
-            "VORBIS_unexpected_eof"("10", javadoc = "file is truncated?")
-            "VORBIS_seek_invalid"("11", javadoc = "seek past EOF")
+            "VORBIS_unexpected_eof"("10")
+            "VORBIS_seek_invalid"("11")
 
-            val doc_vorbis_err = "vorbis errors"
-            "VORBIS_invalid_setup"("20", javadoc = doc_vorbis_err)
-            "VORBIS_invalid_stream"("21", javadoc = doc_vorbis_err)
+            "VORBIS_invalid_setup"("20")
+            "VORBIS_invalid_stream"("21")
 
-            val doc_ogg_err = "ogg errors"
-            "VORBIS_missing_capture_pattern"("30", javadoc = doc_ogg_err)
-            "VORBIS_invalid_stream_structure_version"("31", javadoc = doc_ogg_err)
-            "VORBIS_continued_packet_flag_invalid"("32", javadoc = doc_ogg_err)
-            "VORBIS_incorrect_stream_serial_number"("33", javadoc = doc_ogg_err)
-            "VORBIS_invalid_first_page"("34", javadoc = doc_ogg_err)
-            "VORBIS_bad_packet_type"("35", javadoc = doc_ogg_err)
-            "VORBIS_cant_find_last_page"("36", javadoc = doc_ogg_err)
-            "VORBIS_seek_failed"("37", javadoc = doc_ogg_err)
-            "VORBIS_ogg_skeleton_not_supported"("38", javadoc = doc_ogg_err)
+            "VORBIS_missing_capture_pattern"("30")
+            "VORBIS_invalid_stream_structure_version"("31")
+            "VORBIS_continued_packet_flag_invalid"("32")
+            "VORBIS_incorrect_stream_serial_number"("33")
+            "VORBIS_invalid_first_page"("34")
+            "VORBIS_bad_packet_type"("35")
+            "VORBIS_cant_find_last_page"("36")
+            "VORBIS_seek_failed"("37")
+            "VORBIS_ogg_skeleton_not_supported"("38")
         }
     }
 }

--- a/modules/overrungl.core/src/main/java/module-info.java
+++ b/modules/overrungl.core/src/main/java/module-info.java
@@ -16,8 +16,6 @@
 
 /// The core module of OverrunGL.
 ///
-/// - [Source](https://github.com/Over-Run/overrungl)
-///
 /// @author squid233
 /// @since 0.1.0
 module overrungl.core {

--- a/modules/overrungl.core/src/main/java/module-info.java
+++ b/modules/overrungl.core/src/main/java/module-info.java
@@ -14,12 +14,12 @@
  * copies or substantial portions of the Software.
  */
 
-/**
- * The core module of OverrunGL.
- *
- * @author squid233
- * @since 0.1.0
- */
+/// The core module of OverrunGL.
+///
+/// - [Source](https://github.com/Over-Run/overrungl)
+///
+/// @author squid233
+/// @since 0.1.0
 module overrungl.core {
     exports overrungl;
     exports overrungl.annotation;
@@ -31,8 +31,7 @@ module overrungl.core {
         overrungl.nfd,
         overrungl.openal,
         overrungl.opengl,
-        overrungl.stb,
-        overrungl.vulkan;
+        overrungl.stb;
 
     requires transitive io.github.overrun.platform;
     requires static org.jetbrains.annotations;

--- a/modules/overrungl.glfw/src/main/java/module-info.java
+++ b/modules/overrungl.glfw/src/main/java/module-info.java
@@ -14,12 +14,14 @@
  * copies or substantial portions of the Software.
  */
 
-/**
- * The GLFW binding.
- *
- * @author squid233
- * @since 0.1.0
- */
+/// The GLFW binding.
+///
+/// - [Website](https://www.glfw.org/)
+/// - [Documentation](https://www.glfw.org/docs/latest/)
+/// - [Source](https://github.com/glfw/glfw)
+///
+/// @author squid233
+/// @since 0.1.0
 module overrungl.glfw {
     exports overrungl.glfw;
 

--- a/modules/overrungl.glfw/src/main/java/overrungl/glfw/GLFW.java
+++ b/modules/overrungl.glfw/src/main/java/overrungl/glfw/GLFW.java
@@ -31,482 +31,9 @@ import java.lang.invoke.MethodHandle;
 
 import static java.lang.foreign.ValueLayout.*;
 
-/// The header of the GLFW 3 API.
+/// The GLFW binding.
 ///
-/// This is the header file of the GLFW 3 API.  It defines all its types and
-/// declares all its functions.
-///
-/// For more information about how to use this file, see build_include.
-///
-/// ## (context) Context reference
-/// Functions and types related to OpenGL and OpenGL ES contexts.
-///
-/// This is the reference documentation for OpenGL and OpenGL ES context related
-/// functions.  For more task-oriented information, see the context_guide.
-///
-/// ## (vulkan) Vulkan support reference
-/// Functions and types related to Vulkan.
-///
-/// This is the reference documentation for Vulkan related functions and types.
-/// For more task-oriented information, see the vulkan_guide.
-///
-/// ## (init) Initialization, version and error reference
-/// Functions and types related to initialization and error handling.
-///
-/// This is the reference documentation for initialization and termination of
-/// the library, version management and error handling.  For more task-oriented
-/// information, see the intro_guide.
-///
-/// ## (input) Input reference
-/// Functions and types related to input handling.
-///
-/// This is the reference documentation for input related functions and types.
-/// For more task-oriented information, see the input_guide.
-///
-/// ## (monitor) Monitor reference
-/// Functions and types related to monitors.
-///
-/// This is the reference documentation for monitor related functions and types.
-/// For more task-oriented information, see the monitor_guide.
-///
-/// ## (window) Window reference
-/// Functions and types related to windows.
-///
-/// This is the reference documentation for window related functions and types,
-/// including creation, deletion and event polling.  For more task-oriented
-/// information, see the window_guide.
-///
-/// ## (keys) Keyboard key tokens
-/// Keyboard key tokens.
-///
-/// See key input for how these are used.
-///
-/// These key codes are inspired by the _USB HID Usage Tables v1.12_ (p. 53-60),
-/// but re-arranged to map to 7-bit ASCII for printable keys (function keys are
-/// put in the 256+ range).
-///
-/// The naming of the key codes follow these rules:
-///  - The US keyboard layout is used
-///  - Names of printable alphanumeric characters are used (e.g. "A", "R",
-///    "3", etc.)
-///  - For non-alphanumeric characters, Unicode:ish names are used (e.g.
-///    "COMMA", "LEFT_SQUARE_BRACKET", etc.). Note that some names do not
-///    correspond to the Unicode standard (usually for brevity)
-///  - Keys that lack a clear US mapping are named "WORLD_x"
-///  - For non-printable keys, custom names are used (e.g. "F4",
-///    "BACKSPACE", etc.)
-///
-/// ## Window creation hints
-///
-/// ### Window related hints
-///
-/// __GLFW_RESIZABLE__ specifies whether the windowed mode window will be resizable
-/// _by the user_.  The window will still be resizable using the
-/// [glfwSetWindowSize][#glfwSetWindowSize(MemorySegment, int, int)] function.  Possible values are `GLFW_TRUE` and `GLFW_FALSE`.
-/// This hint is ignored for full screen and undecorated windows.
-///
-/// __GLFW_VISIBLE__ specifies whether the windowed mode window will be initially
-/// visible.  Possible values are `GLFW_TRUE` and `GLFW_FALSE`.  This hint is
-/// ignored for full screen windows.
-///
-/// __GLFW_DECORATED__ specifies whether the windowed mode window will have window
-/// decorations such as a border, a close widget, etc.  An undecorated window will
-/// not be resizable by the user but will still allow the user to generate close
-/// events on some platforms.  Possible values are `GLFW_TRUE` and `GLFW_FALSE`.
-/// This hint is ignored for full screen windows.
-///
-/// __GLFW_FOCUSED__ specifies whether the windowed mode window will be given input
-/// focus when created.  Possible values are `GLFW_TRUE` and `GLFW_FALSE`.  This
-/// hint is ignored for full screen and initially hidden windows.
-///
-/// __GLFW_AUTO_ICONIFY__ specifies whether the full screen window will
-/// automatically iconify and restore the previous video mode on input focus loss.
-/// Possible values are `GLFW_TRUE` and `GLFW_FALSE`.  This hint is ignored for
-/// windowed mode windows.
-///
-/// __GLFW_FLOATING__ specifies whether the windowed mode window will be floating
-/// above other regular windows, also called topmost or always-on-top.  This is
-/// intended primarily for debugging purposes and cannot be used to implement proper
-/// full screen windows.  Possible values are `GLFW_TRUE` and `GLFW_FALSE`.  This
-/// hint is ignored for full screen windows.
-///
-/// __GLFW_MAXIMIZED__ specifies whether the windowed mode window will be maximized
-/// when created.  Possible values are `GLFW_TRUE` and `GLFW_FALSE`.  This hint is
-/// ignored for full screen windows.
-///
-/// __GLFW_CENTER_CURSOR__ specifies whether the cursor should be centered over
-/// newly created full screen windows.  Possible values are `GLFW_TRUE` and
-/// `GLFW_FALSE`.  This hint is ignored for windowed mode windows.
-///
-/// __GLFW_TRANSPARENT_FRAMEBUFFER__ specifies whether the window framebuffer will
-/// be transparent.  If enabled and supported by the system, the window framebuffer
-/// alpha channel will be used to combine the framebuffer with the background.  This
-/// does not affect window decorations.  Possible values are `GLFW_TRUE` and
-/// `GLFW_FALSE`.
-///
-/// __GLFW_FOCUS_ON_SHOW__ specifies whether the window will be given input
-/// focus when [glfwShowWindow][#glfwShowWindow(MemorySegment)] is called. Possible values are `GLFW_TRUE` and
-/// `GLFW_FALSE`.
-///
-/// __GLFW_SCALE_TO_MONITOR__ specified whether the window content area should be
-/// resized based on content scale changes.  This can be
-/// because of a global user settings change or because the window was moved to
-/// a monitor with different scale settings.
-///
-/// This hint only has an effect on platforms where screen coordinates and pixels
-/// always map 1:1, such as Windows and X11.  On platforms like macOS the resolution
-/// of the framebuffer can change independently of the window size.
-///
-/// __GLFW_SCALE_FRAMEBUFFER__ specifies whether the framebuffer should be resized
-/// based on content scale changes.  This can be
-/// because of a global user settings change or because the window was moved to
-/// a monitor with different scale settings.
-///
-/// This hint only has an effect on platforms where screen coordinates can be scaled
-/// relative to pixel coordinates, such as macOS and Wayland.  On platforms like
-/// Windows and X11 the framebuffer and window content area sizes always map 1:1.
-///
-/// This is the new name, introduced in GLFW 3.4.  The older
-/// `GLFW_COCOA_RETINA_FRAMEBUFFER` name is also available for compatibility.  Both
-/// names modify the same hint value.
-///
-/// __GLFW_MOUSE_PASSTHROUGH__ specifies whether the window is transparent to mouse
-/// input, letting any mouse events pass through to whatever window is behind it.
-/// This is only supported for undecorated windows.  Decorated windows with this
-/// enabled will behave differently between platforms.  Possible values are
-/// `GLFW_TRUE` and `GLFW_FALSE`.
-///
-/// __GLFW_POSITION_X__ and __GLFW_POSITION_Y__ specify the desired initial position
-/// of the window.  The window manager may modify or ignore these coordinates.  If
-/// either or both of these hints are set to `GLFW_ANY_POSITION` then the window
-/// manager will position the window where it thinks the user will prefer it.
-/// Possible values are any valid screen coordinates and `GLFW_ANY_POSITION`.
-///
-/// ### Framebuffer related hints
-///
-/// __GLFW_RED_BITS__, __GLFW_GREEN_BITS__, __GLFW_BLUE_BITS__, __GLFW_ALPHA_BITS__,
-/// __GLFW_DEPTH_BITS__ and __GLFW_STENCIL_BITS__ specify the desired bit depths of
-/// the various components of the default framebuffer.  A value of `GLFW_DONT_CARE`
-/// means the application has no preference.
-///
-/// __GLFW_ACCUM_RED_BITS__, __GLFW_ACCUM_GREEN_BITS__, __GLFW_ACCUM_BLUE_BITS__ and
-/// __GLFW_ACCUM_ALPHA_BITS__ specify the desired bit depths of the various
-/// components of the accumulation buffer.  A value of `GLFW_DONT_CARE` means the
-/// application has no preference.
-///
-/// Accumulation buffers are a legacy OpenGL feature and should not be used in new
-/// code.
-///
-/// __GLFW_AUX_BUFFERS__ specifies the desired number of auxiliary buffers.  A value
-/// of `GLFW_DONT_CARE` means the application has no preference.
-///
-/// Auxiliary buffers are a legacy OpenGL feature and should not be used in new
-/// code.
-///
-/// __GLFW_STEREO__ specifies whether to use OpenGL stereoscopic rendering.
-/// Possible values are `GLFW_TRUE` and `GLFW_FALSE`.  This is a hard constraint.
-///
-/// __GLFW_SAMPLES__ specifies the desired number of samples to use for
-/// multisampling.  Zero disables multisampling.  A value of `GLFW_DONT_CARE` means
-/// the application has no preference.
-///
-/// __GLFW_SRGB_CAPABLE__ specifies whether the framebuffer should be sRGB capable.
-/// Possible values are `GLFW_TRUE` and `GLFW_FALSE`.
-///
-/// > __Note__
-/// >
-/// > __OpenGL:__ If enabled and supported by the system, the
-/// > `GL_FRAMEBUFFER_SRGB` enable will control sRGB rendering.  By default, sRGB
-/// > rendering will be disabled.
-/// >
-/// > __OpenGL ES:__ If enabled and supported by the system, the context will
-/// > always have sRGB rendering enabled.
-///
-/// __GLFW_DOUBLEBUFFER__ specifies whether the framebuffer should be double
-/// buffered.  You nearly always want to use double buffering.  This is a hard
-/// constraint.  Possible values are `GLFW_TRUE` and `GLFW_FALSE`.
-///
-/// ### Monitor related hints
-///
-/// __GLFW_REFRESH_RATE__ specifies the desired refresh rate for full screen
-/// windows.  A value of `GLFW_DONT_CARE` means the highest available refresh rate
-/// will be used.  This hint is ignored for windowed mode windows.
-///
-/// ### Context related hints
-///
-/// __GLFW_CLIENT_API__ specifies which client API to create the context for.
-/// Possible values are `GLFW_OPENGL_API`, `GLFW_OPENGL_ES_API` and `GLFW_NO_API`.
-/// This is a hard constraint.
-///
-/// __GLFW_CONTEXT_CREATION_API__ specifies which context creation API to use to
-/// create the context.  Possible values are `GLFW_NATIVE_CONTEXT_API`,
-/// `GLFW_EGL_CONTEXT_API` and `GLFW_OSMESA_CONTEXT_API`.  This is a hard
-/// constraint.  If no client API is requested, this hint is ignored.
-///
-/// An extension loader library that assumes it knows
-/// which API was used to create the current context may fail if you change this
-/// hint.  This can be resolved by having it load functions via
-/// [glfwGetProcAddress][#glfwGetProcAddress(MemorySegment)].
-///
-/// > __Note__
-/// >
-/// > __Wayland:__ The EGL API _is_ the native context creation API, so this hint
-/// > will have no effect.
-/// >
-/// > __X11:__ On some Linux systems, creating contexts via both the native and EGL
-/// > APIs in a single process will cause the application to segfault.  Stick to one
-/// > API or the other on Linux for now.
-/// >
-/// > __OSMesa:__ As its name implies, an OpenGL context created with OSMesa
-/// > does not update the window contents when its buffers are swapped.  Use OpenGL
-/// > functions or the OSMesa native access functions [glfwGetOSMesaColorBuffer][GLFWNative#glfwGetOSMesaColorBuffer(MemorySegment, MemorySegment, MemorySegment, MemorySegment, MemorySegment)]
-/// > and [glfwGetOSMesaDepthBuffer][GLFWNative#glfwGetOSMesaDepthBuffer(MemorySegment, MemorySegment, MemorySegment, MemorySegment, MemorySegment)] to retrieve the framebuffer contents.
-///
-/// __GLFW_CONTEXT_VERSION_MAJOR__ and __GLFW_CONTEXT_VERSION_MINOR__ specify the
-/// client API version that the created context must be compatible with.  The exact
-/// behavior of these hints depend on the requested client API.
-///
-/// While there is no way to ask the driver for a context of the highest supported
-/// version, GLFW will attempt to provide this when you ask for a version 1.0
-/// context, which is the default for these hints.
-///
-/// Do not confuse these hints with [GLFW_VERSION_MAJOR][#GLFW_VERSION_MAJOR] and
-/// [GLFW_VERSION_MINOR][#GLFW_VERSION_MINOR], which provide the API version of the GLFW header.
-///
-/// > __Note__
-/// >
-/// > __OpenGL:__ These hints are not hard constraints, but creation will fail
-/// > if the OpenGL version of the created context is less than the one requested.  It
-/// > is therefore perfectly safe to use the default of version 1.0 for legacy code
-/// > and you will still get backwards-compatible contexts of version 3.0 and above
-/// > when available.
-/// >
-/// > __OpenGL ES:__ These hints are not hard constraints, but creation will
-/// > fail if the OpenGL ES version of the created context is less than the one
-/// > requested.  Additionally, OpenGL ES 1.x cannot be returned if 2.0 or later was
-/// > requested, and vice versa.  This is because OpenGL ES 3.x is backward compatible
-/// > with 2.0, but OpenGL ES 2.0 is not backward compatible with 1.x.
-/// >
-/// > __macOS:__ The OS only supports core profile contexts for OpenGL versions 3.2
-/// > and later.  Before creating an OpenGL context of version 3.2 or later you must
-/// > set the [GLFW_OPENGL_PROFILE](@ref GLFW_OPENGL_PROFILE_hint) hint accordingly.
-/// > OpenGL 3.0 and 3.1 contexts are not supported at all on macOS.
-///
-/// __GLFW_OPENGL_FORWARD_COMPAT__ specifies whether the OpenGL context should be
-/// forward-compatible, i.e. one where all functionality deprecated in the requested
-/// version of OpenGL is removed.  This must only be used if the requested OpenGL
-/// version is 3.0 or above.  If OpenGL ES is requested, this hint is ignored.
-///
-/// Forward-compatibility is described in detail in the
-/// [OpenGL Reference Manual](https://www.opengl.org/registry/).
-///
-/// __GLFW_CONTEXT_DEBUG__ specifies whether the context should be created in debug
-/// mode, which may provide additional error and diagnostic reporting functionality.
-/// Possible values are `GLFW_TRUE` and `GLFW_FALSE`.
-///
-/// Debug contexts for OpenGL and OpenGL ES are described in detail by the
-/// [GL_KHR_debug](https://www.khronos.org/registry/OpenGL/extensions/KHR/KHR_debug.txt) extension.
-///
-/// > __Note__
-/// >
-/// > `GLFW_CONTEXT_DEBUG` is the new name introduced in GLFW 3.4.  The older
-/// > `GLFW_OPENGL_DEBUG_CONTEXT` name is also available for compatibility.
-///
-/// __GLFW_OPENGL_PROFILE__ specifies which OpenGL profile to create the context
-/// for.  Possible values are one of `GLFW_OPENGL_CORE_PROFILE` or
-/// `GLFW_OPENGL_COMPAT_PROFILE`, or `GLFW_OPENGL_ANY_PROFILE` to not request
-/// a specific profile.  If requesting an OpenGL version below 3.2,
-/// `GLFW_OPENGL_ANY_PROFILE` must be used.  If OpenGL ES is requested, this hint
-/// is ignored.
-///
-/// OpenGL profiles are described in detail in the
-/// [OpenGL Reference Manual](https://www.opengl.org/registry/).
-///
-/// __GLFW_CONTEXT_ROBUSTNESS__ specifies the robustness strategy to be used by the
-/// context.  This can be one of `GLFW_NO_RESET_NOTIFICATION` or
-/// `GLFW_LOSE_CONTEXT_ON_RESET`, or `GLFW_NO_ROBUSTNESS` to not request
-/// a robustness strategy.
-///
-/// __GLFW_CONTEXT_RELEASE_BEHAVIOR__ specifies the release behavior to be
-/// used by the context.  Possible values are one of `GLFW_ANY_RELEASE_BEHAVIOR`,
-/// `GLFW_RELEASE_BEHAVIOR_FLUSH` or `GLFW_RELEASE_BEHAVIOR_NONE`.  If the
-/// behavior is `GLFW_ANY_RELEASE_BEHAVIOR`, the default behavior of the context
-/// creation API will be used.  If the behavior is `GLFW_RELEASE_BEHAVIOR_FLUSH`,
-/// the pipeline will be flushed whenever the context is released from being the
-/// current one.  If the behavior is `GLFW_RELEASE_BEHAVIOR_NONE`, the pipeline will
-/// not be flushed on release.
-///
-/// Context release behaviors are described in detail by the
-/// [GL_KHR_context_flush_control](https://www.opengl.org/registry/specs/KHR/context_flush_control.txt) extension.
-///
-/// __GLFW_CONTEXT_NO_ERROR__ specifies whether errors should be generated by the
-/// context.  Possible values are `GLFW_TRUE` and `GLFW_FALSE`.  If enabled,
-/// situations that would have generated errors instead cause undefined behavior.
-///
-/// The no error mode for OpenGL and OpenGL ES is described in detail by the
-/// [GL_KHR_no_error](https://www.opengl.org/registry/specs/KHR/no_error.txt) extension.
-///
-/// ### Win32 specific hints
-///
-/// __GLFW_WIN32_KEYBOARD_MENU__ specifies whether to allow access to the window
-/// menu via the Alt+Space and Alt-and-then-Space keyboard shortcuts.  This is
-/// ignored on other platforms.
-///
-/// __GLFW_WIN32_SHOWDEFAULT__ specifies whether to show the window the way
-/// specified in the program's `STARTUPINFO` when it is shown for the first time.
-/// This is the same information as the `Run` option in the shortcut properties
-/// window.  If this information was not specified when the program was started,
-/// GLFW behaves as if this hint was set to `GLFW_FALSE`.  Possible values are
-/// `GLFW_TRUE` and `GLFW_FALSE`.  This is ignored on other platforms.
-///
-/// ### macOS specific hints
-///
-/// __GLFW_COCOA_FRAME_NAME__ specifies the UTF-8 encoded name to use for autosaving
-/// the window frame, or if empty disables frame autosaving for the window.  This is
-/// ignored on other platforms.  This is set with [glfwWindowHintString][#glfwWindowHintString(int, MemorySegment)].
-///
-/// __GLFW_COCOA_GRAPHICS_SWITCHING__ specifies whether to in Automatic Graphics
-/// Switching, i.e. to allow the system to choose the integrated GPU for the OpenGL
-/// context and move it between GPUs if necessary or whether to force it to always
-/// run on the discrete GPU.  This only affects systems with both integrated and
-/// discrete GPUs.  Possible values are `GLFW_TRUE` and `GLFW_FALSE`.  This is
-/// ignored on other platforms.
-///
-/// Simpler programs and tools may want to enable this to save power, while games
-/// and other applications performing advanced rendering will want to leave it
-/// disabled.
-///
-/// A bundled application that wishes to participate in Automatic Graphics Switching
-/// should also declare this in its `Info.plist` by setting the
-/// `NSSupportsAutomaticGraphicsSwitching` key to `true`.
-///
-/// ### Wayland specific window hints
-///
-/// __GLFW_WAYLAND_APP_ID__ specifies the Wayland app_id for a window, used
-/// by window managers to identify types of windows. This is set with
-/// [glfwWindowHintString][#glfwWindowHintString(int, MemorySegment)].
-///
-/// ### X11 specific window hints
-///
-/// __GLFW_X11_CLASS_NAME__ and __GLFW_X11_INSTANCE_NAME__ specifies the desired
-/// ASCII encoded class and instance parts of the ICCCM `WM_CLASS` window property.  Both
-/// hints need to be set to something other than an empty string for them to take effect.
-/// These are set with [glfwWindowHintString][#glfwWindowHintString(int, MemorySegment)].
-///
-/// ## Window attributes
-///
-/// ### Window related attributes
-///
-/// __GLFW_FOCUSED__ indicates whether the specified window has input focus.  See
-/// [Window input focus](https://www.glfw.org/docs/latest/window_guide.html#window_focus) for details.
-///
-/// __GLFW_ICONIFIED__ indicates whether the specified window is iconified.
-/// See [Window iconification](https://www.glfw.org/docs/latest/window_guide.html#window_iconify) for details.
-///
-/// __GLFW_MAXIMIZED__ indicates whether the specified window is maximized.  See
-/// [Window maximization](https://www.glfw.org/docs/latest/window_guide.html#window_maximize) for details.
-///
-/// __GLFW_HOVERED__ indicates whether the cursor is currently directly over the
-/// content area of the window, with no other windows between.  See
-/// [Cursor enter/leave events](https://www.glfw.org/docs/latest/input_guide.html#cursor_enter) for details.
-///
-/// __GLFW_VISIBLE__ indicates whether the specified window is visible.  See
-/// [Window visibility](https://www.glfw.org/docs/latest/window_guide.html#window_hide) for details.
-///
-/// __GLFW_RESIZABLE__ indicates whether the specified window is resizable _by the
-/// user_.  This can be set before creation with the
-/// [GLFW_RESIZABLE][#GLFW_RESIZABLE] window hint or after with
-/// [glfwSetWindowAttrib][#glfwSetWindowAttrib(MemorySegment, int, int)].
-///
-/// __GLFW_DECORATED__ indicates whether the specified window has decorations such
-/// as a border, a close widget, etc.  This can be set before creation with the
-/// [GLFW_DECORATED][#GLFW_DECORATED] window hint or after with
-/// [glfwSetWindowAttrib][#glfwSetWindowAttrib(MemorySegment, int, int)].
-///
-/// __GLFW_AUTO_ICONIFY__ indicates whether the specified full screen window is
-/// iconified on focus loss, a close widget, etc.  This can be set before creation
-/// with the [GLFW_AUTO_ICONIFY][#GLFW_AUTO_ICONIFY] window hint or after
-/// with [glfwSetWindowAttrib][#glfwSetWindowAttrib(MemorySegment, int, int)].
-///
-/// __GLFW_FLOATING__ indicates whether the specified window is floating, also
-/// called topmost or always-on-top.  This can be set before creation with the
-/// [GLFW_FLOATING][#GLFW_FLOATING] window hint or after with
-/// [glfwSetWindowAttrib][#glfwSetWindowAttrib(MemorySegment, int, int)].
-///
-/// __GLFW_TRANSPARENT_FRAMEBUFFER__ indicates whether the specified window has
-/// a transparent framebuffer, i.e. the window contents is composited with the
-/// background using the window framebuffer alpha channel.  See
-/// [Window transparency](https://www.glfw.org/docs/latest/window_guide.html#window_transparency) for details.
-///
-/// __GLFW_FOCUS_ON_SHOW__ specifies whether the window will be given input
-/// focus when [glfwShowWindow][#glfwShowWindow(MemorySegment)] is called. This can be set before creation
-/// with the [GLFW_FOCUS_ON_SHOW][#GLFW_FOCUS_ON_SHOW] window hint or
-/// after with [glfwSetWindowAttrib][#glfwSetWindowAttrib(MemorySegment, int, int)].
-///
-/// __GLFW_MOUSE_PASSTHROUGH__ specifies whether the window is transparent to mouse
-/// input, letting any mouse events pass through to whatever window is behind it.
-/// This can be set before creation with the
-/// [GLFW_MOUSE_PASSTHROUGH][#GLFW_MOUSE_PASSTHROUGH] window hint or after
-/// with [glfwSetWindowAttrib][#glfwSetWindowAttrib(MemorySegment, int, int)].  This is only supported for undecorated windows.
-/// Decorated windows with this enabled will behave differently between platforms.
-///
-/// ### Context related attributes
-///
-/// __GLFW_CLIENT_API__ indicates the client API provided by the window's context;
-/// either `GLFW_OPENGL_API`, `GLFW_OPENGL_ES_API` or `GLFW_NO_API`.
-///
-/// __GLFW_CONTEXT_CREATION_API__ indicates the context creation API used to create
-/// the window's context; either `GLFW_NATIVE_CONTEXT_API`, `GLFW_EGL_CONTEXT_API`
-/// or `GLFW_OSMESA_CONTEXT_API`.
-///
-/// __GLFW_CONTEXT_VERSION_MAJOR__, __GLFW_CONTEXT_VERSION_MINOR__ and
-/// __GLFW_CONTEXT_REVISION__ indicate the client API version of the window's
-/// context.
-///
-/// > __Note__
-/// >
-/// > Do not confuse these attributes with `GLFW_VERSION_MAJOR`,
-/// > `GLFW_VERSION_MINOR` and `GLFW_VERSION_REVISION` which provide the API version
-/// > of the GLFW header.
-///
-/// __GLFW_OPENGL_FORWARD_COMPAT__ is `GLFW_TRUE` if the window's context is an
-/// OpenGL forward-compatible one, or `GLFW_FALSE` otherwise.
-///
-/// __GLFW_CONTEXT_DEBUG__ is `GLFW_TRUE` if the window's context is in debug
-/// mode, or `GLFW_FALSE` otherwise.
-///
-/// This is the new name, introduced in GLFW 3.4.  The older
-/// `GLFW_OPENGL_DEBUG_CONTEXT` name is also available for compatibility.
-///
-/// __GLFW_OPENGL_PROFILE__ indicates the OpenGL profile used by the context.  This
-/// is `GLFW_OPENGL_CORE_PROFILE` or `GLFW_OPENGL_COMPAT_PROFILE` if the context
-/// uses a known profile, or `GLFW_OPENGL_ANY_PROFILE` if the OpenGL profile is
-/// unknown or the context is an OpenGL ES context.  Note that the returned profile
-/// may not match the profile bits of the context flags, as GLFW will try other
-/// means of detecting the profile when no bits are set.
-///
-/// __GLFW_CONTEXT_RELEASE_BEHAVIOR__ indicates the release used by the context.
-/// Possible values are one of `GLFW_ANY_RELEASE_BEHAVIOR`,
-/// `GLFW_RELEASE_BEHAVIOR_FLUSH` or `GLFW_RELEASE_BEHAVIOR_NONE`.  If the
-/// behavior is `GLFW_ANY_RELEASE_BEHAVIOR`, the default behavior of the context
-/// creation API will be used.  If the behavior is `GLFW_RELEASE_BEHAVIOR_FLUSH`,
-/// the pipeline will be flushed whenever the context is released from being the
-/// current one.  If the behavior is `GLFW_RELEASE_BEHAVIOR_NONE`, the pipeline will
-/// not be flushed on release.
-///
-/// __GLFW_CONTEXT_NO_ERROR__ indicates whether errors are generated by the context.
-/// Possible values are `GLFW_TRUE` and `GLFW_FALSE`.  If enabled, situations that
-/// would have generated errors instead cause undefined behavior.
-///
-/// __GLFW_CONTEXT_ROBUSTNESS__ indicates the robustness strategy used by the
-/// context.  This is `GLFW_LOSE_CONTEXT_ON_RESET` or `GLFW_NO_RESET_NOTIFICATION`
-/// if the window's context supports robustness, or `GLFW_NO_ROBUSTNESS` otherwise.
-///
-/// ### Framebuffer related attributes
-///
-/// __GLFW_DOUBLEBUFFER__ indicates whether the specified window is double-buffered
-/// when rendering with OpenGL or OpenGL ES.  This can be set before creation with
-/// the [GLFW_DOUBLEBUFFER][#GLFW_DOUBLEBUFFER] window hint.
+/// See the [online documentation](https://www.glfw.org/docs/latest/).
 ///
 /// @author squid233
 /// @since 0.1.0
@@ -514,48 +41,16 @@ public final class GLFW {
     //region ---[BEGIN GENERATOR BEGIN]---
     //@formatter:off
     //region Fields
-    ///GLFW version macros
-    ///#### Documentation of fields
-    ///##### GLFW_VERSION_MAJOR
-    ///The major version number of the GLFW header.  This is incremented when the
-    ///API is changed in non-compatible ways.
-    ///##### GLFW_VERSION_MINOR
-    ///The minor version number of the GLFW header.  This is incremented when
-    ///features are added to the API but it remains backward-compatible.
-    ///##### GLFW_VERSION_REVISION
-    ///The revision number of the GLFW header.  This is incremented when a bug fix
-    ///release is made that does not contain any API changes.
     public static final int
         GLFW_VERSION_MAJOR = 3,
         GLFW_VERSION_MINOR = 5,
         GLFW_VERSION_REVISION = 0;
-    ///One.
-    ///
-    ///This is only semantic sugar for the number 1.  You can instead use `1` or
-    ///`true` or `_True` or `GL_TRUE` or `VK_TRUE` or anything else that is equal
-    ///to one.
     public static final int GLFW_TRUE = 1;
-    ///Zero.
-    ///
-    ///This is only semantic sugar for the number 0.  You can instead use `0` or
-    ///`false` or `_False` or `GL_FALSE` or `VK_FALSE` or anything else that is
-    ///equal to zero.
     public static final int GLFW_FALSE = 0;
-    ///Key and button actions
-    ///#### Documentation of fields
-    ///##### GLFW_RELEASE
-    ///The key or mouse button was released.
-    ///##### GLFW_PRESS
-    ///The key or mouse button was pressed.
-    ///##### GLFW_REPEAT
-    ///The key was held down until it repeated.
     public static final int
         GLFW_RELEASE = 0,
         GLFW_PRESS = 1,
         GLFW_REPEAT = 2;
-    ///Joystick hat states.
-    ///
-    ///See joystick hat input for how these are used.
     public static final int
         GLFW_HAT_CENTERED = 0,
         GLFW_HAT_UP = 1,
@@ -567,34 +62,6 @@ public final class GLFW {
         GLFW_HAT_LEFT_UP = (GLFW_HAT_LEFT | GLFW_HAT_UP),
         GLFW_HAT_LEFT_DOWN = (GLFW_HAT_LEFT | GLFW_HAT_DOWN);
     public static final int GLFW_KEY_UNKNOWN = -1;
-    ///Printable keys
-    ///#### Documentation of fields
-    ///##### GLFW_KEY_APOSTROPHE
-    ///`'`
-    ///##### GLFW_KEY_COMMA
-    ///`,`
-    ///##### GLFW_KEY_MINUS
-    ///`-`
-    ///##### GLFW_KEY_PERIOD
-    ///`.`
-    ///##### GLFW_KEY_SLASH
-    ///`/`
-    ///##### GLFW_KEY_SEMICOLON
-    ///`;`
-    ///##### GLFW_KEY_EQUAL
-    ///`=`
-    ///##### GLFW_KEY_LEFT_BRACKET
-    ///`[`
-    ///##### GLFW_KEY_BACKSLASH
-    ///`\\`
-    ///##### GLFW_KEY_RIGHT_BRACKET
-    ///`]`
-    ///##### GLFW_KEY_GRAVE_ACCENT
-    ///<code>`</code>
-    ///##### GLFW_KEY_WORLD_1
-    ///non-US #1
-    ///##### GLFW_KEY_WORLD_2
-    ///non-US #2
     public static final int
         GLFW_KEY_SPACE = 32,
         GLFW_KEY_APOSTROPHE = 39,
@@ -646,7 +113,6 @@ public final class GLFW {
         GLFW_KEY_GRAVE_ACCENT = 96,
         GLFW_KEY_WORLD_1 = 161,
         GLFW_KEY_WORLD_2 = 162;
-    ///Function keys
     public static final int
         GLFW_KEY_ESCAPE = 256,
         GLFW_KEY_ENTER = 257,
@@ -719,28 +185,6 @@ public final class GLFW {
         GLFW_KEY_RIGHT_SUPER = 347,
         GLFW_KEY_MENU = 348;
     public static final int GLFW_KEY_LAST = GLFW_KEY_MENU;
-    ///Modifier key flags.
-    ///
-    ///See key input for how these are used.
-    ///#### Documentation of fields
-    ///##### GLFW_MOD_SHIFT
-    ///If this bit is set one or more Shift keys were held down.
-    ///##### GLFW_MOD_CONTROL
-    ///If this bit is set one or more Control keys were held down.
-    ///##### GLFW_MOD_ALT
-    ///If this bit is set one or more Alt keys were held down.
-    ///##### GLFW_MOD_SUPER
-    ///If this bit is set one or more Super keys were held down.
-    ///##### GLFW_MOD_CAPS_LOCK
-    ///If this bit is set the Caps Lock key is enabled.
-    ///
-    ///If this bit is set the Caps Lock key is enabled and the
-    ///[GLFW_LOCK_KEY_MODS][#GLFW_LOCK_KEY_MODS] input mode is set.
-    ///##### GLFW_MOD_NUM_LOCK
-    ///If this bit is set the Num Lock key is enabled.
-    ///
-    ///If this bit is set the Num Lock key is enabled and the
-    ///[GLFW_LOCK_KEY_MODS][#GLFW_LOCK_KEY_MODS] input mode is set.
     public static final int
         GLFW_MOD_SHIFT = 0x0001,
         GLFW_MOD_CONTROL = 0x0002,
@@ -748,9 +192,6 @@ public final class GLFW {
         GLFW_MOD_SUPER = 0x0008,
         GLFW_MOD_CAPS_LOCK = 0x0010,
         GLFW_MOD_NUM_LOCK = 0x0020;
-    ///Mouse button IDs.
-    ///
-    ///See mouse button input for how these are used.
     public static final int
         GLFW_MOUSE_BUTTON_1 = 0,
         GLFW_MOUSE_BUTTON_2 = 1,
@@ -764,9 +205,6 @@ public final class GLFW {
         GLFW_MOUSE_BUTTON_LEFT = GLFW_MOUSE_BUTTON_1,
         GLFW_MOUSE_BUTTON_RIGHT = GLFW_MOUSE_BUTTON_2,
         GLFW_MOUSE_BUTTON_MIDDLE = GLFW_MOUSE_BUTTON_3;
-    ///Joystick IDs.
-    ///
-    ///See joystick input for how these are used.
     public static final int
         GLFW_JOYSTICK_1 = 0,
         GLFW_JOYSTICK_2 = 1,
@@ -785,9 +223,6 @@ public final class GLFW {
         GLFW_JOYSTICK_15 = 14,
         GLFW_JOYSTICK_16 = 15,
         GLFW_JOYSTICK_LAST = GLFW_JOYSTICK_16;
-    ///Gamepad buttons.
-    ///
-    ///See gamepad for how these are used.
     public static final int
         GLFW_GAMEPAD_BUTTON_A = 0,
         GLFW_GAMEPAD_BUTTON_B = 1,
@@ -809,9 +244,6 @@ public final class GLFW {
         GLFW_GAMEPAD_BUTTON_CIRCLE = GLFW_GAMEPAD_BUTTON_B,
         GLFW_GAMEPAD_BUTTON_SQUARE = GLFW_GAMEPAD_BUTTON_X,
         GLFW_GAMEPAD_BUTTON_TRIANGLE = GLFW_GAMEPAD_BUTTON_Y;
-    ///Gamepad axes.
-    ///
-    ///See gamepad for how these are used.
     public static final int
         GLFW_GAMEPAD_AXIS_LEFT_X = 0,
         GLFW_GAMEPAD_AXIS_LEFT_Y = 1,
@@ -820,175 +252,6 @@ public final class GLFW {
         GLFW_GAMEPAD_AXIS_LEFT_TRIGGER = 4,
         GLFW_GAMEPAD_AXIS_RIGHT_TRIGGER = 5,
         GLFW_GAMEPAD_AXIS_LAST = GLFW_GAMEPAD_AXIS_RIGHT_TRIGGER;
-    ///Error codes.
-    ///
-    ///See error handling for how these are used.
-    ///#### Documentation of fields
-    ///##### GLFW_NO_ERROR
-    ///No error has occurred.
-    ///
-    ///###### Analysis
-    ///Yay.
-    ///##### GLFW_NOT_INITIALIZED
-    ///GLFW has not been initialized.
-    ///
-    ///This occurs if a GLFW function was called that must not be called unless the
-    ///library is initialized.
-    ///
-    ///###### Analysis
-    ///Application programmer error.  Initialize GLFW before calling any
-    ///function that requires initialization.
-    ///##### GLFW_NO_CURRENT_CONTEXT
-    ///No context is current for this thread.
-    ///
-    ///This occurs if a GLFW function was called that needs and operates on the
-    ///current OpenGL or OpenGL ES context but no context is current on the calling
-    ///thread.  One such function is [glfwSwapInterval][#glfwSwapInterval(int)].
-    ///
-    ///###### Analysis
-    ///Application programmer error.  Ensure a context is current before
-    ///calling functions that require a current context.
-    ///##### GLFW_INVALID_ENUM
-    ///One of the arguments to the function was an invalid enum value.
-    ///
-    ///One of the arguments to the function was an invalid enum value, for example
-    ///requesting [GLFW_RED_BITS][#GLFW_RED_BITS] with [glfwGetWindowAttrib][#glfwGetWindowAttrib(MemorySegment, int)].
-    ///
-    ///###### Analysis
-    ///Application programmer error.  Fix the offending call.
-    ///##### GLFW_INVALID_VALUE
-    ///One of the arguments to the function was an invalid value.
-    ///
-    ///One of the arguments to the function was an invalid value, for example
-    ///requesting a non-existent OpenGL or OpenGL ES version like 2.7.
-    ///
-    ///Requesting a valid but unavailable OpenGL or OpenGL ES version will instead
-    ///result in a [GLFW_VERSION_UNAVAILABLE][#GLFW_VERSION_UNAVAILABLE] error.
-    ///
-    ///###### Analysis
-    ///Application programmer error.  Fix the offending call.
-    ///##### GLFW_OUT_OF_MEMORY
-    ///A memory allocation failed.
-    ///
-    ///###### Analysis
-    ///A bug in GLFW or the underlying operating system.  Report the bug
-    ///to our [issue tracker](https://github.com/glfw/glfw/issues).
-    ///##### GLFW_API_UNAVAILABLE
-    ///GLFW could not find support for the requested API on the system.
-    ///
-    ///###### Analysis
-    ///The installed graphics driver does not support the requested
-    ///API, or does not support it via the chosen context creation API.
-    ///Below are a few examples.
-    ///
-    ///Some pre-installed Windows graphics drivers do not support OpenGL.  AMD only
-    ///supports OpenGL ES via EGL, while Nvidia and Intel only support it via
-    ///a WGL or GLX extension.  macOS does not provide OpenGL ES at all.  The Mesa
-    ///EGL, OpenGL and OpenGL ES libraries do not interface with the Nvidia binary
-    ///driver.  Older graphics drivers do not support Vulkan.
-    ///##### GLFW_VERSION_UNAVAILABLE
-    ///The requested OpenGL or OpenGL ES version is not available.
-    ///
-    ///The requested OpenGL or OpenGL ES version (including any requested context
-    ///or framebuffer hints) is not available on this machine.
-    ///
-    ///###### Analysis
-    ///The machine does not support your requirements.  If your
-    ///application is sufficiently flexible, downgrade your requirements and try
-    ///again.  Otherwise, inform the user that their machine does not match your
-    ///requirements.
-    ///##### GLFW_PLATFORM_ERROR
-    ///A platform-specific error occurred that does not match any of the more
-    ///specific categories.
-    ///
-    ///###### Analysis
-    ///A bug or configuration error in GLFW, the underlying operating
-    ///system or its drivers, or a lack of required resources.  Report the issue to
-    ///our [issue tracker](https://github.com/glfw/glfw/issues).
-    ///##### GLFW_FORMAT_UNAVAILABLE
-    ///The requested format is not supported or available.
-    ///
-    ///If emitted during window creation, the requested pixel format is not
-    ///supported.
-    ///
-    ///If emitted when querying the clipboard, the contents of the clipboard could
-    ///not be converted to the requested format.
-    ///
-    ///###### Analysis
-    ///If emitted during window creation, one or more
-    ///hard constraints did not match any of the
-    ///available pixel formats.  If your application is sufficiently flexible,
-    ///downgrade your requirements and try again.  Otherwise, inform the user that
-    ///their machine does not match your requirements.
-    ///
-    ///If emitted when querying the clipboard, ignore the error or report it to
-    ///the user, as appropriate.
-    ///##### GLFW_NO_WINDOW_CONTEXT
-    ///The specified window does not have an OpenGL or OpenGL ES context.
-    ///
-    ///A window that does not have an OpenGL or OpenGL ES context was passed to
-    ///a function that requires it to have one.
-    ///
-    ///###### Analysis
-    ///Application programmer error.  Fix the offending call.
-    ///##### GLFW_CURSOR_UNAVAILABLE
-    ///The specified cursor shape is not available.
-    ///
-    ///The specified standard cursor shape is not available, either because the
-    ///current platform cursor theme does not provide it or because it is not
-    ///available on the platform.
-    ///
-    ///###### Analysis
-    ///Platform or system settings limitation.  Pick another
-    ///standard cursor shape or create a
-    ///custom cursor.
-    ///##### GLFW_FEATURE_UNAVAILABLE
-    ///The requested feature is not provided by the platform.
-    ///
-    ///The requested feature is not provided by the platform, so GLFW is unable to
-    ///implement it.  The documentation for each function notes if it could emit
-    ///this error.
-    ///
-    ///###### Analysis
-    ///Platform or platform version limitation.  The error can be ignored
-    ///unless the feature is critical to the application.
-    ///
-    ///A function call that emits this error has no effect other than the error and
-    ///updating any existing out parameters.
-    ///##### GLFW_FEATURE_UNIMPLEMENTED
-    ///The requested feature is not implemented for the platform.
-    ///
-    ///The requested feature has not yet been implemented in GLFW for this platform.
-    ///
-    ///###### Analysis
-    ///An incomplete implementation of GLFW for this platform, hopefully
-    ///fixed in a future release.  The error can be ignored unless the feature is
-    ///critical to the application.
-    ///
-    ///A function call that emits this error has no effect other than the error and
-    ///updating any existing out parameters.
-    ///##### GLFW_PLATFORM_UNAVAILABLE
-    ///Platform unavailable or no matching platform was found.
-    ///
-    ///If emitted during initialization, no matching platform was found.  If the
-    ///[GLFW_PLATFORM][#GLFW_PLATFORM] init hint was set to `GLFW_ANY_PLATFORM`, GLFW could not detect any of
-    ///the platforms supported by this library binary, except for the Null platform.  If the
-    ///init hint was set to a specific platform, it is either not supported by this library
-    ///binary or GLFW was not able to detect it.
-    ///
-    ///If emitted by a native access function, GLFW was initialized for a different platform
-    ///than the function is for.
-    ///
-    ///###### Analysis
-    ///Failure to detect any platform usually only happens on non-macOS Unix
-    ///systems, either when no window system is running or the program was run from
-    ///a terminal that does not have the necessary environment variables.  Fall back to
-    ///a different platform if possible or notify the user that no usable platform was
-    ///detected.
-    ///
-    ///Failure to detect a specific platform may have the same cause as above or be because
-    ///support for that platform was not compiled in.  Call [glfwPlatformSupported][#glfwPlatformSupported(int)] to
-    ///check whether a specific platform is supported by a library binary.
     public static final int
         GLFW_NO_ERROR = 0,
         GLFW_NOT_INITIALIZED = 0x00010001,
@@ -1005,119 +268,58 @@ public final class GLFW {
         GLFW_FEATURE_UNAVAILABLE = 0x0001000C,
         GLFW_FEATURE_UNIMPLEMENTED = 0x0001000D,
         GLFW_PLATFORM_UNAVAILABLE = 0x0001000E;
-    ///Input focus window hint and attribute
     public static final int GLFW_FOCUSED = 0x00020001;
-    ///Window iconification window attribute
     public static final int GLFW_ICONIFIED = 0x00020002;
-    ///Window resize-ability window hint and attribute
     public static final int GLFW_RESIZABLE = 0x00020003;
-    ///Window visibility window hint and attribute
     public static final int GLFW_VISIBLE = 0x00020004;
-    ///Window decoration window hint and attribute
     public static final int GLFW_DECORATED = 0x00020005;
-    ///Window auto-iconification window hint and attribute
     public static final int GLFW_AUTO_ICONIFY = 0x00020006;
-    ///Window decoration window hint and attribute
     public static final int GLFW_FLOATING = 0x00020007;
-    ///Window maximization window hint and attribute
     public static final int GLFW_MAXIMIZED = 0x00020008;
-    ///Cursor centering window hint
     public static final int GLFW_CENTER_CURSOR = 0x00020009;
-    ///Window framebuffer transparency hint and attribute
     public static final int GLFW_TRANSPARENT_FRAMEBUFFER = 0x0002000A;
-    ///Mouse cursor hover window attribute.
     public static final int GLFW_HOVERED = 0x0002000B;
-    ///Input focus on calling show window hint and attribute
     public static final int GLFW_FOCUS_ON_SHOW = 0x0002000C;
-    ///Mouse input transparency window hint and attribute
     public static final int GLFW_MOUSE_PASSTHROUGH = 0x0002000D;
-    ///Initial position x-coordinate window hint.
     public static final int GLFW_POSITION_X = 0x0002000E;
-    ///Initial position y-coordinate window hint.
     public static final int GLFW_POSITION_Y = 0x0002000F;
-    ///Framebuffer bit depth hint.
     public static final int GLFW_RED_BITS = 0x00021001;
-    ///Framebuffer bit depth hint.
     public static final int GLFW_GREEN_BITS = 0x00021002;
-    ///Framebuffer bit depth hint.
     public static final int GLFW_BLUE_BITS = 0x00021003;
-    ///Framebuffer bit depth hint.
     public static final int GLFW_ALPHA_BITS = 0x00021004;
-    ///Framebuffer bit depth hint.
     public static final int GLFW_DEPTH_BITS = 0x00021005;
-    ///Framebuffer bit depth hint.
     public static final int GLFW_STENCIL_BITS = 0x00021006;
-    ///Framebuffer bit depth hint.
     public static final int GLFW_ACCUM_RED_BITS = 0x00021007;
-    ///Framebuffer bit depth hint.
     public static final int GLFW_ACCUM_GREEN_BITS = 0x00021008;
-    ///Framebuffer bit depth hint.
     public static final int GLFW_ACCUM_BLUE_BITS = 0x00021009;
-    ///Framebuffer bit depth hint.
     public static final int GLFW_ACCUM_ALPHA_BITS = 0x0002100A;
-    ///Framebuffer auxiliary buffer hint.
     public static final int GLFW_AUX_BUFFERS = 0x0002100B;
-    ///OpenGL stereoscopic rendering hint.
     public static final int GLFW_STEREO = 0x0002100C;
-    ///Framebuffer MSAA samples hint.
     public static final int GLFW_SAMPLES = 0x0002100D;
-    ///Framebuffer sRGB hint.
     public static final int GLFW_SRGB_CAPABLE = 0x0002100E;
-    ///Monitor refresh rate hint.
     public static final int GLFW_REFRESH_RATE = 0x0002100F;
-    ///Framebuffer double buffering hint and attribute.
     public static final int GLFW_DOUBLEBUFFER = 0x00021010;
-    ///Context client API hint and attribute.
     public static final int GLFW_CLIENT_API = 0x00022001;
-    ///Context client API major version hint and attribute.
     public static final int GLFW_CONTEXT_VERSION_MAJOR = 0x00022002;
-    ///Context client API minor version hint and attribute.
     public static final int GLFW_CONTEXT_VERSION_MINOR = 0x00022003;
-    ///Context client API revision number attribute.
     public static final int GLFW_CONTEXT_REVISION = 0x00022004;
-    ///Context robustness hint and attribute.
     public static final int GLFW_CONTEXT_ROBUSTNESS = 0x00022005;
-    ///OpenGL forward-compatibility hint and attribute.
     public static final int GLFW_OPENGL_FORWARD_COMPAT = 0x00022006;
-    ///Debug mode context hint and attribute.
     public static final int GLFW_CONTEXT_DEBUG = 0x00022007;
-    ///Legacy name for compatibility.
-    ///
-    ///This is an alias for compatibility with earlier versions.
     public static final int GLFW_OPENGL_DEBUG_CONTEXT = GLFW_CONTEXT_DEBUG;
-    ///OpenGL profile hint and attribute.
     public static final int GLFW_OPENGL_PROFILE = 0x00022008;
-    ///Context flush-on-release hint and attribute.
     public static final int GLFW_CONTEXT_RELEASE_BEHAVIOR = 0x00022009;
-    ///Context error suppression hint and attribute.
     public static final int GLFW_CONTEXT_NO_ERROR = 0x0002200A;
-    ///Context creation API hint and attribute.
     public static final int GLFW_CONTEXT_CREATION_API = 0x0002200B;
-    ///Window content area scaling window hint.
     public static final int GLFW_SCALE_TO_MONITOR = 0x0002200C;
-    ///Window framebuffer scaling window hint.
     public static final int GLFW_SCALE_FRAMEBUFFER = 0x0002200D;
-    ///Legacy name for compatibility.
-    ///
-    ///This is an alias for the
-    ///[GLFW_SCALE_FRAMEBUFFER][#GLFW_SCALE_FRAMEBUFFER] window hint for
-    ///compatibility with earlier versions.
     public static final int GLFW_COCOA_RETINA_FRAMEBUFFER = 0x00023001;
-    ///macOS specific window hint.
     public static final int GLFW_COCOA_FRAME_NAME = 0x00023002;
-    ///macOS specific window hint.
     public static final int GLFW_COCOA_GRAPHICS_SWITCHING = 0x00023003;
-    ///X11 specific window hint.
     public static final int GLFW_X11_CLASS_NAME = 0x00024001;
-    ///X11 specific window hint.
     public static final int GLFW_X11_INSTANCE_NAME = 0x00024002;
-    ///Win32 specific window hint.
     public static final int GLFW_WIN32_KEYBOARD_MENU = 0x00025001;
-    ///Win32 specific window hint.
     public static final int GLFW_WIN32_SHOWDEFAULT = 0x00025002;
-    ///Wayland specific window hint.
-    ///
-    ///Allows specification of the Wayland app_id.
     public static final int GLFW_WAYLAND_APP_ID = 0x00026001;
     public static final int
         GLFW_NO_API = 0,
@@ -1164,83 +366,6 @@ public final class GLFW {
         GLFW_WAYLAND_DISABLE_LIBDECOR = 0x00038002;
     public static final int
         GLFW_ANY_POSITION = 0x80000000;
-    ///Standard system cursor shapes.
-    ///
-    ///These are the standard cursor shapes] that can be
-    ///requested from the platform (window system).
-    ///#### Documentation of fields
-    ///##### GLFW_ARROW_CURSOR
-    ///The regular arrow cursor shape.
-    ///##### GLFW_IBEAM_CURSOR
-    ///The text input I-beam cursor shape.
-    ///##### GLFW_CROSSHAIR_CURSOR
-    ///The crosshair cursor shape.
-    ///##### GLFW_POINTING_HAND_CURSOR
-    ///The pointing hand cursor shape.
-    ///##### GLFW_RESIZE_EW_CURSOR
-    ///The horizontal resize/move arrow shape.
-    ///
-    ///The horizontal resize/move arrow shape.  This is usually a horizontal
-    ///double-headed arrow.
-    ///##### GLFW_RESIZE_NS_CURSOR
-    ///The vertical resize/move arrow shape.
-    ///
-    ///The vertical resize/move shape.  This is usually a vertical double-headed
-    ///arrow.
-    ///##### GLFW_RESIZE_NWSE_CURSOR
-    ///The top-left to bottom-right diagonal resize/move arrow shape.
-    ///
-    ///The top-left to bottom-right diagonal resize/move shape.  This is usually
-    ///a diagonal double-headed arrow.
-    ///
-    ///###### Note
-    ///- __macOS:__ This shape is provided by a private system API and may fail
-    ///    with [GLFW_CURSOR_UNAVAILABLE][#GLFW_CURSOR_UNAVAILABLE] in the future.
-    ///- __Wayland:__ This shape is provided by a newer standard not supported by
-    ///    all cursor themes.
-    ///- __X11:__ This shape is provided by a newer standard not supported by all
-    ///    cursor themes.
-    ///##### GLFW_RESIZE_NESW_CURSOR
-    ///The top-right to bottom-left diagonal resize/move arrow shape.
-    ///
-    ///The top-right to bottom-left diagonal resize/move shape.  This is usually
-    ///a diagonal double-headed arrow.
-    ///
-    ///###### Note
-    ///- __macOS:__ This shape is provided by a private system API and may fail
-    ///    with [GLFW_CURSOR_UNAVAILABLE][#GLFW_CURSOR_UNAVAILABLE] in the future.
-    ///- __Wayland:__ This shape is provided by a newer standard not supported by
-    ///    all cursor themes.
-    ///- __X11:__ This shape is provided by a newer standard not supported by all
-    ///    cursor themes.
-    ///##### GLFW_RESIZE_ALL_CURSOR
-    ///The omni-directional resize/move cursor shape.
-    ///
-    ///The omni-directional resize cursor/move shape.  This is usually either
-    ///a combined horizontal and vertical double-headed arrow or a grabbing hand.
-    ///##### GLFW_NOT_ALLOWED_CURSOR
-    ///The operation-not-allowed shape.
-    ///
-    ///The operation-not-allowed shape.  This is usually a circle with a diagonal
-    ///line through it.
-    ///
-    ///###### Note
-    ///- __Wayland:__ This shape is provided by a newer standard not supported by
-    ///    all cursor themes.
-    ///- __X11:__ This shape is provided by a newer standard not supported by all
-    ///    cursor themes.
-    ///##### GLFW_HRESIZE_CURSOR
-    ///Legacy name for compatibility.
-    ///
-    ///This is an alias for compatibility with earlier versions.
-    ///##### GLFW_VRESIZE_CURSOR
-    ///Legacy name for compatibility.
-    ///
-    ///This is an alias for compatibility with earlier versions.
-    ///##### GLFW_HAND_CURSOR
-    ///Legacy name for compatibility.
-    ///
-    ///This is an alias for compatibility with earlier versions.
     public static final int
         GLFW_ARROW_CURSOR = 0x00036001,
         GLFW_IBEAM_CURSOR = 0x00036002,
@@ -1257,23 +382,13 @@ public final class GLFW {
         GLFW_HAND_CURSOR = GLFW_POINTING_HAND_CURSOR;
     public static final int GLFW_CONNECTED = 0x00040001;
     public static final int GLFW_DISCONNECTED = 0x00040002;
-    ///Joystick hat buttons init hint.
     public static final int GLFW_JOYSTICK_HAT_BUTTONS = 0x00050001;
-    ///ANGLE rendering backend init hint.
     public static final int GLFW_ANGLE_PLATFORM_TYPE = 0x00050002;
-    ///Platform selection init hint.
     public static final int GLFW_PLATFORM = 0x00050003;
-    ///macOS specific init hint.
     public static final int GLFW_COCOA_CHDIR_RESOURCES = 0x00051001;
-    ///macOS specific init hint.
     public static final int GLFW_COCOA_MENUBAR = 0x00051002;
-    ///X11 specific init hint.
     public static final int GLFW_X11_XCB_VULKAN_SURFACE = 0x00052001;
-    ///Wayland specific init hint.
     public static final int GLFW_WAYLAND_LIBDECOR = 0x00053001;
-    ///Hint value that enables automatic platform selection.
-    ///
-    ///Hint value for [GLFW_PLATFORM][#GLFW_PLATFORM] that enables automatic platform selection.
     public static final int
         GLFW_ANY_PLATFORM = 0x00060000,
         GLFW_PLATFORM_WIN32 = 0x00060001,
@@ -1528,227 +643,42 @@ public final class GLFW {
     }
     //endregion
 
-    ///Initializes the GLFW library.
-    ///
-    ///This function initializes the GLFW library.  Before most GLFW functions can
-    ///be used, GLFW must be initialized, and before an application terminates GLFW
-    ///should be terminated in order to free any resources allocated during or
-    ///after initialization.
-    ///
-    ///If this function fails, it calls [glfwTerminate][#glfwTerminate()] before returning.  If it
-    ///succeeds, you should call [glfwTerminate][#glfwTerminate()] before the application exits.
-    ///
-    ///Additional calls to this function after successful initialization but before
-    ///termination will return `GLFW_TRUE` immediately.
-    ///
-    ///The [GLFW_PLATFORM][#GLFW_PLATFORM] init hint controls which platforms are considered during
-    ///initialization.  This also depends on which platforms the library was compiled to
-    ///support.
-    ///
-    ///@return `GLFW_TRUE` if successful, or `GLFW_FALSE` if an
-    ///error occurred.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_PLATFORM_UNAVAILABLE][#GLFW_PLATFORM_UNAVAILABLE] and
-    ///[GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-    ///
-    ///@glfw.remark
-    ///- __macOS:__ This function will change the current directory of the
-    ///    application to the `Contents/Resources` subdirectory of the application's
-    ///    bundle, if present.  This can be disabled with the
-    ///    [GLFW_COCOA_CHDIR_RESOURCES][#GLFW_COCOA_CHDIR_RESOURCES] init hint.
-    ///
-    ///    This function will create the main menu and dock icon for the
-    ///    application.  If GLFW finds a `MainMenu.nib` it is loaded and assumed to
-    ///    contain a menu bar.  Otherwise a minimal menu bar is created manually with
-    ///    common commands like Hide, Quit and About.  The About entry opens a minimal
-    ///    about dialog with information from the application's bundle.  The menu bar
-    ///    and dock icon can be disabled entirely with the [GLFW_COCOA_MENUBAR][#GLFW_COCOA_MENUBAR] init
-    ///    hint.
-    ///- __Wayland, X11:__ If the library was compiled with support for both
-    ///    Wayland and X11, and the [GLFW_PLATFORM][#GLFW_PLATFORM] init hint is set to
-    ///    `GLFW_ANY_PLATFORM`, the `XDG_SESSION_TYPE` environment variable affects
-    ///    which platform is picked.  If the environment variable is not set, or is set
-    ///    to something other than `wayland` or `x11`, the regular detection mechanism
-    ///    will be used instead.
-    ///- __X11:__ This function will set the `LC_CTYPE` category of the
-    ///    application locale according to the current environment if that category is
-    ///    still "C".  This is because the "C" locale breaks Unicode text input.
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
-    ///
-    ///@see #glfwInitHint(int, int) glfwInitHint
-    ///@see #glfwInitAllocator(MemorySegment) glfwInitAllocator
-    ///@see #glfwTerminate() glfwTerminate
     public static @CType("int") boolean glfwInit() {
         try {
             return (int) Handles.MH_glfwInit.invokeExact() != GLFW.GLFW_FALSE;
         } catch (Throwable e) { throw new RuntimeException("error in glfwInit", e); }
     }
 
-    ///Terminates the GLFW library.
-    ///
-    ///This function destroys all remaining windows and cursors, restores any
-    ///modified gamma ramps and frees any other allocated resources.  Once this
-    ///function is called, you must again call [glfwInit][#glfwInit()] successfully before
-    ///you will be able to use most GLFW functions.
-    ///
-    ///If GLFW has been successfully initialized, this function should be called
-    ///before the application exits.  If initialization fails, there is no need to
-    ///call this function, as it is called by [glfwInit][#glfwInit()] before it returns
-    ///failure.
-    ///
-    ///This function has no effect if GLFW is not initialized.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-    ///
-    ///@glfw.remark This function may be called before [glfwInit][#glfwInit()].
-    ///
-    ///@glfw.warning The contexts of any remaining windows must not be current on any
-    ///other thread when this function is called.
-    ///
-    ///@glfw.reentrancy This function must not be called from a callback.
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
-    ///
-    ///@see #glfwInit() glfwInit
     public static void glfwTerminate() {
         try {
             Handles.MH_glfwTerminate.invokeExact();
         } catch (Throwable e) { throw new RuntimeException("error in glfwTerminate", e); }
     }
 
-    ///Sets the specified init hint to the desired value.
-    ///
-    ///This function sets hints for the next initialization of GLFW.
-    ///
-    ///The values you set hints to are never reset by GLFW, but they only take
-    ///effect during initialization.  Once GLFW has been initialized, any values
-    ///you set will be ignored until the library is terminated and initialized
-    ///again.
-    ///
-    ///Some hints are platform specific.  These may be set on any platform but they
-    ///will only affect their specific platform.  Other platforms will ignore them.
-    ///Setting these hints requires no platform specific headers or functions.
-    ///
-    ///@param hint The init hint to set.
-    ///@param value The new value of the init hint.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_INVALID_ENUM][#GLFW_INVALID_ENUM] and
-    ///[GLFW_INVALID_VALUE][#GLFW_INVALID_VALUE].
-    ///
-    ///@glfw.remark This function may be called before [glfwInit][#glfwInit()].
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
-    ///
-    ///@see #glfwInit() glfwInit
     public static void glfwInitHint(@CType("int") int hint, @CType("int") int value) {
         try {
             Handles.MH_glfwInitHint.invokeExact(hint, value);
         } catch (Throwable e) { throw new RuntimeException("error in glfwInitHint", e); }
     }
 
-    ///Sets the init allocator to the desired value.
-    ///
-    ///To use the default allocator, call this function with a `NULL` argument.
-    ///
-    ///If you specify an allocator struct, every member must be a valid function
-    ///pointer.  If any member is `NULL`, this function will emit
-    ///[GLFW_INVALID_VALUE][#GLFW_INVALID_VALUE] and the init allocator will be unchanged.
-    ///
-    ///The functions in the allocator must fulfil a number of requirements.  See the
-    ///documentation for [GLFWAllocateFun], [GLFWReallocateFun] and
-    ///[GLFWDeallocateFun] for details.
-    ///
-    ///@param allocator The allocator to use at the next initialization, or
-    ///`NULL` to use the default one.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_INVALID_VALUE][#GLFW_INVALID_VALUE].
-    ///
-    ///@glfw.pointer_lifetime The specified allocator is copied before this function
-    ///returns.
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
-    ///
-    ///@see #glfwInit() glfwInit
     public static void glfwInitAllocator(@CType("const GLFWallocator*") java.lang.foreign.MemorySegment allocator) {
         try {
             Handles.MH_glfwInitAllocator.invokeExact(allocator);
         } catch (Throwable e) { throw new RuntimeException("error in glfwInitAllocator", e); }
     }
 
-    ///Sets the init allocator to the desired value.
-    ///
-    ///To use the default allocator, call this function with a `NULL` argument.
-    ///
-    ///If you specify an allocator struct, every member must be a valid function
-    ///pointer.  If any member is `NULL`, this function will emit
-    ///[GLFW_INVALID_VALUE][#GLFW_INVALID_VALUE] and the init allocator will be unchanged.
-    ///
-    ///The functions in the allocator must fulfil a number of requirements.  See the
-    ///documentation for [GLFWAllocateFun], [GLFWReallocateFun] and
-    ///[GLFWDeallocateFun] for details.
-    ///
-    ///@param allocator The allocator to use at the next initialization, or
-    ///`NULL` to use the default one.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_INVALID_VALUE][#GLFW_INVALID_VALUE].
-    ///
-    ///@glfw.pointer_lifetime The specified allocator is copied before this function
-    ///returns.
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
-    ///
-    ///@see #glfwInit() glfwInit
     public static void glfwInitAllocator(@CType("const GLFWallocator*") overrungl.glfw.GLFWAllocator allocator) {
         try {
             Handles.MH_glfwInitAllocator.invokeExact(Marshal.marshal(allocator));
         } catch (Throwable e) { throw new RuntimeException("error in glfwInitAllocator", e); }
     }
 
-    ///Retrieves the version of the GLFW library.
-    ///
-    ///This function retrieves the major, minor and revision numbers of the GLFW
-    ///library.  It is intended for when you are using GLFW as a shared library and
-    ///want to ensure that you are using the minimum required version.
-    ///
-    ///Any or all of the version arguments may be `NULL`.
-    ///
-    ///@param major Where to store the major version number, or `NULL`.
-    ///@param minor Where to store the minor version number, or `NULL`.
-    ///@param rev Where to store the revision number, or `NULL`.
-    ///
-    ///@glfw.errors None.
-    ///
-    ///@glfw.remark This function may be called before [glfwInit][#glfwInit()].
-    ///
-    ///@glfw.thread_safety This function may be called from any thread.
-    ///
-    ///@see #glfwGetVersionString() glfwGetVersionString
     public static void glfwGetVersion(@Out @CType("int*") java.lang.foreign.MemorySegment major, @Out @CType("int*") java.lang.foreign.MemorySegment minor, @Out @CType("int*") java.lang.foreign.MemorySegment rev) {
         try {
             Handles.MH_glfwGetVersion.invokeExact(major, minor, rev);
         } catch (Throwable e) { throw new RuntimeException("error in glfwGetVersion", e); }
     }
 
-    ///Retrieves the version of the GLFW library.
-    ///
-    ///This function retrieves the major, minor and revision numbers of the GLFW
-    ///library.  It is intended for when you are using GLFW as a shared library and
-    ///want to ensure that you are using the minimum required version.
-    ///
-    ///Any or all of the version arguments may be `NULL`.
-    ///
-    ///@param major Where to store the major version number, or `NULL`.
-    ///@param minor Where to store the minor version number, or `NULL`.
-    ///@param rev Where to store the revision number, or `NULL`.
-    ///
-    ///@glfw.errors None.
-    ///
-    ///@glfw.remark This function may be called before [glfwInit][#glfwInit()].
-    ///
-    ///@glfw.thread_safety This function may be called from any thread.
-    ///
-    ///@see #glfwGetVersionString() glfwGetVersionString
     public static void glfwGetVersion(@Out @CType("int*") int[] major, @Out @CType("int*") int[] minor, @Out @CType("int*") int[] rev) {
         try (var __overrungl_stack = MemoryStack.pushLocal()) {
             var __overrungl_ref_major = Marshal.marshal(__overrungl_stack, major);
@@ -1761,122 +691,24 @@ public final class GLFW {
         } catch (Throwable e) { throw new RuntimeException("error in glfwGetVersion", e); }
     }
 
-    ///Returns a string describing the compile-time configuration.
-    ///
-    ///This function returns the compile-time generated
-    ///version string of the GLFW library binary.  It describes
-    ///the version, platforms, compiler and any platform or operating system specific
-    ///compile-time options.  It should not be confused with the OpenGL or OpenGL ES version
-    ///string, queried with `glGetString`.
-    ///
-    ///__Do not use the version string__ to parse the GLFW library version.  The
-    ///[glfwGetVersion][#glfwGetVersion(MemorySegment, MemorySegment, MemorySegment)] function provides the version of the running library
-    ///binary in numerical format.
-    ///
-    ///__Do not use the version string__ to parse what platforms are supported.  The
-    ///[glfwPlatformSupported][#glfwPlatformSupported(int)] function lets you query platform support.
-    ///
-    ///@return The ASCII encoded GLFW version string.
-    ///
-    ///@glfw.errors None.
-    ///
-    ///@glfw.remark This function may be called before [glfwInit][#glfwInit()].
-    ///
-    ///@glfw.pointer_lifetime The returned string is static and compile-time generated.
-    ///
-    ///@glfw.thread_safety This function may be called from any thread.
-    ///
-    ///@see #glfwGetVersion(MemorySegment, MemorySegment, MemorySegment) glfwGetVersion
     public static @CType("const char*") java.lang.foreign.MemorySegment glfwGetVersionString_() {
         try {
             return (java.lang.foreign.MemorySegment) Handles.MH_glfwGetVersionString.invokeExact();
         } catch (Throwable e) { throw new RuntimeException("error in glfwGetVersionString", e); }
     }
 
-    ///Returns a string describing the compile-time configuration.
-    ///
-    ///This function returns the compile-time generated
-    ///version string of the GLFW library binary.  It describes
-    ///the version, platforms, compiler and any platform or operating system specific
-    ///compile-time options.  It should not be confused with the OpenGL or OpenGL ES version
-    ///string, queried with `glGetString`.
-    ///
-    ///__Do not use the version string__ to parse the GLFW library version.  The
-    ///[glfwGetVersion][#glfwGetVersion(MemorySegment, MemorySegment, MemorySegment)] function provides the version of the running library
-    ///binary in numerical format.
-    ///
-    ///__Do not use the version string__ to parse what platforms are supported.  The
-    ///[glfwPlatformSupported][#glfwPlatformSupported(int)] function lets you query platform support.
-    ///
-    ///@return The ASCII encoded GLFW version string.
-    ///
-    ///@glfw.errors None.
-    ///
-    ///@glfw.remark This function may be called before [glfwInit][#glfwInit()].
-    ///
-    ///@glfw.pointer_lifetime The returned string is static and compile-time generated.
-    ///
-    ///@glfw.thread_safety This function may be called from any thread.
-    ///
-    ///@see #glfwGetVersion(MemorySegment, MemorySegment, MemorySegment) glfwGetVersion
     public static @CType("const char*") java.lang.String glfwGetVersionString() {
         try {
             return Unmarshal.unmarshalAsString((java.lang.foreign.MemorySegment) Handles.MH_glfwGetVersionString.invokeExact());
         } catch (Throwable e) { throw new RuntimeException("error in glfwGetVersionString", e); }
     }
 
-    ///Returns and clears the last error for the calling thread.
-    ///
-    ///This function returns and clears the error code of the last
-    ///error that occurred on the calling thread, and optionally a UTF-8 encoded
-    ///human-readable description of it.  If no error has occurred since the last
-    ///call, it returns [GLFW_NO_ERROR][#GLFW_NO_ERROR] (zero) and the description pointer is
-    ///set to `NULL`.
-    ///
-    ///@param description Where to store the error description pointer, or `NULL`.
-    ///@return The last error code for the calling thread, or [GLFW_NO_ERROR][#GLFW_NO_ERROR]
-    ///(zero).
-    ///
-    ///@glfw.errors None.
-    ///
-    ///@glfw.pointer_lifetime The returned string is allocated and freed by GLFW.  You
-    ///should not free it yourself.  It is guaranteed to be valid only until the
-    ///next error occurs or the library is terminated.
-    ///
-    ///@glfw.remark This function may be called before [glfwInit][#glfwInit()].
-    ///
-    ///@glfw.thread_safety This function may be called from any thread.
-    ///
-    ///@see #glfwSetErrorCallback(MemorySegment) glfwSetErrorCallback
     public static @CType("int") int glfwGetError(@Out @CType("const char**") java.lang.foreign.MemorySegment description) {
         try {
             return (int) Handles.MH_glfwGetError.invokeExact(description);
         } catch (Throwable e) { throw new RuntimeException("error in glfwGetError", e); }
     }
 
-    ///Returns and clears the last error for the calling thread.
-    ///
-    ///This function returns and clears the error code of the last
-    ///error that occurred on the calling thread, and optionally a UTF-8 encoded
-    ///human-readable description of it.  If no error has occurred since the last
-    ///call, it returns [GLFW_NO_ERROR][#GLFW_NO_ERROR] (zero) and the description pointer is
-    ///set to `NULL`.
-    ///
-    ///@param description Where to store the error description pointer, or `NULL`.
-    ///@return The last error code for the calling thread, or [GLFW_NO_ERROR][#GLFW_NO_ERROR]
-    ///(zero).
-    ///
-    ///@glfw.errors None.
-    ///
-    ///@glfw.pointer_lifetime The returned string is allocated and freed by GLFW.  You
-    ///should not free it yourself.  It is guaranteed to be valid only until the
-    ///next error occurs or the library is terminated.
-    ///
-    ///@glfw.remark This function may be called before [glfwInit][#glfwInit()].
-    ///
-    ///@glfw.thread_safety This function may be called from any thread.
-    ///
-    ///@see #glfwSetErrorCallback(MemorySegment) glfwSetErrorCallback
     public static @CType("int") int glfwGetError(@Out @CType("const char**") java.lang.String[] description) {
         try (var __overrungl_stack = MemoryStack.pushLocal()) {
             var __overrungl_ref_description = Marshal.marshal(__overrungl_stack, description);
@@ -1886,213 +718,46 @@ public final class GLFW {
         } catch (Throwable e) { throw new RuntimeException("error in glfwGetError", e); }
     }
 
-    ///Sets the error callback.
-    ///
-    ///This function sets the error callback, which is called with an error code
-    ///and a human-readable description each time a GLFW error occurs.
-    ///
-    ///The error code is set before the callback is called.  Calling
-    ///[glfwGetError][#glfwGetError(MemorySegment)] from the error callback will return the same value as the error
-    ///code argument.
-    ///
-    ///The error callback is called on the thread where the error occurred.  If you
-    ///are using GLFW from multiple threads, your error callback needs to be
-    ///written accordingly.
-    ///
-    ///Because the description string may have been generated specifically for that
-    ///error, it is not guaranteed to be valid after the callback has returned.  If
-    ///you wish to use it after the callback returns, you need to make a copy.
-    ///
-    ///Once set, the error callback remains set even after the library has been
-    ///terminated.
-    ///
-    ///@param callback The new callback, or `NULL` to remove the currently set
-    ///callback.
-    ///@return The previously set callback, or `NULL` if no callback was set.
-    ///
-    ///@glfw.callback_signature
-    ///For more information about the callback parameters, see the
-    ///[callback pointer type][GLFWErrorFun].
-    ///
-    ///@glfw.errors None.
-    ///
-    ///@glfw.remark This function may be called before [glfwInit][#glfwInit()].
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
-    ///
-    ///@see #glfwGetError(MemorySegment) glfwGetError
     public static @CType("GLFWerrorfun") java.lang.foreign.MemorySegment glfwSetErrorCallback(@CType("GLFWerrorfun") java.lang.foreign.MemorySegment callback) {
         try {
             return (java.lang.foreign.MemorySegment) Handles.MH_glfwSetErrorCallback.invokeExact(callback);
         } catch (Throwable e) { throw new RuntimeException("error in glfwSetErrorCallback", e); }
     }
 
-    ///Sets the error callback.
-    ///
-    ///This function sets the error callback, which is called with an error code
-    ///and a human-readable description each time a GLFW error occurs.
-    ///
-    ///The error code is set before the callback is called.  Calling
-    ///[glfwGetError][#glfwGetError(MemorySegment)] from the error callback will return the same value as the error
-    ///code argument.
-    ///
-    ///The error callback is called on the thread where the error occurred.  If you
-    ///are using GLFW from multiple threads, your error callback needs to be
-    ///written accordingly.
-    ///
-    ///Because the description string may have been generated specifically for that
-    ///error, it is not guaranteed to be valid after the callback has returned.  If
-    ///you wish to use it after the callback returns, you need to make a copy.
-    ///
-    ///Once set, the error callback remains set even after the library has been
-    ///terminated.
-    ///
-    ///@param callback The new callback, or `NULL` to remove the currently set
-    ///callback.
-    ///@return The previously set callback, or `NULL` if no callback was set.
-    ///
-    ///@glfw.callback_signature
-    ///For more information about the callback parameters, see the
-    ///[callback pointer type][GLFWErrorFun].
-    ///
-    ///@glfw.errors None.
-    ///
-    ///@glfw.remark This function may be called before [glfwInit][#glfwInit()].
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
-    ///
-    ///@see #glfwGetError(MemorySegment) glfwGetError
     public static @CType("GLFWerrorfun") java.lang.foreign.MemorySegment glfwSetErrorCallback(@CType("GLFWerrorfun") overrungl.glfw.GLFWErrorFun callback) {
         return glfwSetErrorCallback(callback != null ? callback.stub(Arena.global()) : MemorySegment.NULL);
     }
 
-    ///Returns the currently selected platform.
-    ///
-    ///This function returns the platform that was selected during initialization.  The
-    ///returned value will be one of `GLFW_PLATFORM_WIN32`, `GLFW_PLATFORM_COCOA`,
-    ///`GLFW_PLATFORM_WAYLAND`, `GLFW_PLATFORM_X11` or `GLFW_PLATFORM_NULL`.
-    ///
-    ///@return The currently selected platform, or zero if an error occurred.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-    ///
-    ///@glfw.thread_safety This function may be called from any thread.
-    ///
-    ///@see #glfwPlatformSupported(int) glfwPlatformSupported
     public static @CType("int") int glfwGetPlatform() {
         try {
             return (int) Handles.MH_glfwGetPlatform.invokeExact();
         } catch (Throwable e) { throw new RuntimeException("error in glfwGetPlatform", e); }
     }
 
-    ///Returns whether the library includes support for the specified platform.
-    ///
-    ///This function returns whether the library was compiled with support for the specified
-    ///platform.  The platform must be one of `GLFW_PLATFORM_WIN32`, `GLFW_PLATFORM_COCOA`,
-    ///`GLFW_PLATFORM_WAYLAND`, `GLFW_PLATFORM_X11` or `GLFW_PLATFORM_NULL`.
-    ///
-    ///@param platform The platform to query.
-    ///@return `GLFW_TRUE` if the platform is supported, or `GLFW_FALSE` otherwise.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_INVALID_ENUM][#GLFW_INVALID_ENUM].
-    ///
-    ///@glfw.remark This function may be called before [glfwInit][#glfwInit()].
-    ///
-    ///@glfw.thread_safety This function may be called from any thread.
-    ///
-    ///@see #glfwGetPlatform() glfwGetPlatform
     public static @CType("int") boolean glfwPlatformSupported(@CType("int") int platform) {
         try {
             return (int) Handles.MH_glfwPlatformSupported.invokeExact(platform) != GLFW.GLFW_FALSE;
         } catch (Throwable e) { throw new RuntimeException("error in glfwPlatformSupported", e); }
     }
 
-    ///Returns the currently connected monitors.
-    ///
-    ///This function returns an array of handles for all currently connected
-    ///monitors.  The primary monitor is always first in the returned array.  If no
-    ///monitors were found, this function returns `NULL`.
-    ///
-    ///@param count Where to store the number of monitors in the returned
-    ///array.  This is set to zero if an error occurred.
-    ///@return An array of monitor handles, or `NULL` if no monitors were found or
-    ///if an error occurred.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-    ///
-    ///@glfw.pointer_lifetime The returned array is allocated and freed by GLFW.  You
-    ///should not free it yourself.  It is guaranteed to be valid only until the
-    ///monitor configuration changes or the library is terminated.
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
-    ///
-    ///@see #glfwGetPrimaryMonitor() glfwGetPrimaryMonitor
     public static @CType("GLFWmonitor**") java.lang.foreign.MemorySegment glfwGetMonitors(@Out @CType("int*") java.lang.foreign.MemorySegment count) {
         try {
             return (java.lang.foreign.MemorySegment) Handles.MH_glfwGetMonitors.invokeExact(count);
         } catch (Throwable e) { throw new RuntimeException("error in glfwGetMonitors", e); }
     }
 
-    ///Returns the primary monitor.
-    ///
-    ///This function returns the primary monitor.  This is usually the monitor
-    ///where elements like the task bar or global menu bar are located.
-    ///
-    ///@return The primary monitor, or `NULL` if no monitors were found or if an
-    ///error occurred.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
-    ///
-    ///@glfw.remark The primary monitor is always first in the array returned by @ref
-    ///glfwGetMonitors.
-    ///
-    ///@see #glfwGetMonitors(MemorySegment) glfwGetMonitors
     public static @CType("GLFWmonitor*") java.lang.foreign.MemorySegment glfwGetPrimaryMonitor() {
         try {
             return (java.lang.foreign.MemorySegment) Handles.MH_glfwGetPrimaryMonitor.invokeExact();
         } catch (Throwable e) { throw new RuntimeException("error in glfwGetPrimaryMonitor", e); }
     }
 
-    ///Returns the position of the monitor's viewport on the virtual screen.
-    ///
-    ///This function returns the position, in screen coordinates, of the upper-left
-    ///corner of the specified monitor.
-    ///
-    ///Any or all of the position arguments may be `NULL`.  If an error occurs, all
-    ///non-`NULL` position arguments will be set to zero.
-    ///
-    ///@param monitor The monitor to query.
-    ///@param xpos Where to store the monitor x-coordinate, or `NULL`.
-    ///@param ypos Where to store the monitor y-coordinate, or `NULL`.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-    ///[GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
     public static void glfwGetMonitorPos(@CType("GLFWmonitor*") java.lang.foreign.MemorySegment monitor, @Out @CType("int*") java.lang.foreign.MemorySegment xpos, @Out @CType("int*") java.lang.foreign.MemorySegment ypos) {
         try {
             Handles.MH_glfwGetMonitorPos.invokeExact(monitor, xpos, ypos);
         } catch (Throwable e) { throw new RuntimeException("error in glfwGetMonitorPos", e); }
     }
 
-    ///Returns the position of the monitor's viewport on the virtual screen.
-    ///
-    ///This function returns the position, in screen coordinates, of the upper-left
-    ///corner of the specified monitor.
-    ///
-    ///Any or all of the position arguments may be `NULL`.  If an error occurs, all
-    ///non-`NULL` position arguments will be set to zero.
-    ///
-    ///@param monitor The monitor to query.
-    ///@param xpos Where to store the monitor x-coordinate, or `NULL`.
-    ///@param ypos Where to store the monitor y-coordinate, or `NULL`.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-    ///[GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
     public static void glfwGetMonitorPos(@CType("GLFWmonitor*") java.lang.foreign.MemorySegment monitor, @Out @CType("int*") int[] xpos, @Out @CType("int*") int[] ypos) {
         try (var __overrungl_stack = MemoryStack.pushLocal()) {
             var __overrungl_ref_xpos = Marshal.marshal(__overrungl_stack, xpos);
@@ -2103,56 +768,12 @@ public final class GLFW {
         } catch (Throwable e) { throw new RuntimeException("error in glfwGetMonitorPos", e); }
     }
 
-    ///Retrieves the work area of the monitor.
-    ///
-    ///This function returns the position, in screen coordinates, of the upper-left
-    ///corner of the work area of the specified monitor along with the work area
-    ///size in screen coordinates. The work area is defined as the area of the
-    ///monitor not occluded by the window system task bar where present. If no
-    ///task bar exists then the work area is the monitor resolution in screen
-    ///coordinates.
-    ///
-    ///Any or all of the position and size arguments may be `NULL`.  If an error
-    ///occurs, all non-`NULL` position and size arguments will be set to zero.
-    ///
-    ///@param monitor The monitor to query.
-    ///@param xpos Where to store the monitor x-coordinate, or `NULL`.
-    ///@param ypos Where to store the monitor y-coordinate, or `NULL`.
-    ///@param width Where to store the monitor width, or `NULL`.
-    ///@param height Where to store the monitor height, or `NULL`.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-    ///[GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
     public static void glfwGetMonitorWorkarea(@CType("GLFWmonitor*") java.lang.foreign.MemorySegment monitor, @Out @CType("int*") java.lang.foreign.MemorySegment xpos, @Out @CType("int*") java.lang.foreign.MemorySegment ypos, @Out @CType("int*") java.lang.foreign.MemorySegment width, @Out @CType("int*") java.lang.foreign.MemorySegment height) {
         try {
             Handles.MH_glfwGetMonitorWorkarea.invokeExact(monitor, xpos, ypos, width, height);
         } catch (Throwable e) { throw new RuntimeException("error in glfwGetMonitorWorkarea", e); }
     }
 
-    ///Retrieves the work area of the monitor.
-    ///
-    ///This function returns the position, in screen coordinates, of the upper-left
-    ///corner of the work area of the specified monitor along with the work area
-    ///size in screen coordinates. The work area is defined as the area of the
-    ///monitor not occluded by the window system task bar where present. If no
-    ///task bar exists then the work area is the monitor resolution in screen
-    ///coordinates.
-    ///
-    ///Any or all of the position and size arguments may be `NULL`.  If an error
-    ///occurs, all non-`NULL` position and size arguments will be set to zero.
-    ///
-    ///@param monitor The monitor to query.
-    ///@param xpos Where to store the monitor x-coordinate, or `NULL`.
-    ///@param ypos Where to store the monitor y-coordinate, or `NULL`.
-    ///@param width Where to store the monitor width, or `NULL`.
-    ///@param height Where to store the monitor height, or `NULL`.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-    ///[GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
     public static void glfwGetMonitorWorkarea(@CType("GLFWmonitor*") java.lang.foreign.MemorySegment monitor, @Out @CType("int*") int[] xpos, @Out @CType("int*") int[] ypos, @Out @CType("int*") int[] width, @Out @CType("int*") int[] height) {
         try (var __overrungl_stack = MemoryStack.pushLocal()) {
             var __overrungl_ref_xpos = Marshal.marshal(__overrungl_stack, xpos);
@@ -2167,60 +788,12 @@ public final class GLFW {
         } catch (Throwable e) { throw new RuntimeException("error in glfwGetMonitorWorkarea", e); }
     }
 
-    ///Returns the physical size of the monitor.
-    ///
-    ///This function returns the size, in millimetres, of the display area of the
-    ///specified monitor.
-    ///
-    ///Some platforms do not provide accurate monitor size information, either
-    ///because the monitor [EDID](https://en.wikipedia.org/wiki/Extended_display_identification_data) data is incorrect or because the driver does
-    ///not report it accurately.
-    ///
-    ///Any or all of the size arguments may be `NULL`.  If an error occurs, all
-    ///non-`NULL` size arguments will be set to zero.
-    ///
-    ///@param monitor The monitor to query.
-    ///@param widthMM Where to store the width, in millimetres, of the
-    ///monitor's display area, or `NULL`.
-    ///@param heightMM Where to store the height, in millimetres, of the
-    ///monitor's display area, or `NULL`.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-    ///
-    ///@glfw.remark __Windows:__ On Windows 8 and earlier the physical size is calculated from
-    ///the current resolution and system DPI instead of querying the monitor EDID data.
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
     public static void glfwGetMonitorPhysicalSize(@CType("GLFWmonitor*") java.lang.foreign.MemorySegment monitor, @Out @CType("int*") java.lang.foreign.MemorySegment widthMM, @Out @CType("int*") java.lang.foreign.MemorySegment heightMM) {
         try {
             Handles.MH_glfwGetMonitorPhysicalSize.invokeExact(monitor, widthMM, heightMM);
         } catch (Throwable e) { throw new RuntimeException("error in glfwGetMonitorPhysicalSize", e); }
     }
 
-    ///Returns the physical size of the monitor.
-    ///
-    ///This function returns the size, in millimetres, of the display area of the
-    ///specified monitor.
-    ///
-    ///Some platforms do not provide accurate monitor size information, either
-    ///because the monitor [EDID](https://en.wikipedia.org/wiki/Extended_display_identification_data) data is incorrect or because the driver does
-    ///not report it accurately.
-    ///
-    ///Any or all of the size arguments may be `NULL`.  If an error occurs, all
-    ///non-`NULL` size arguments will be set to zero.
-    ///
-    ///@param monitor The monitor to query.
-    ///@param widthMM Where to store the width, in millimetres, of the
-    ///monitor's display area, or `NULL`.
-    ///@param heightMM Where to store the height, in millimetres, of the
-    ///monitor's display area, or `NULL`.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-    ///
-    ///@glfw.remark __Windows:__ On Windows 8 and earlier the physical size is calculated from
-    ///the current resolution and system DPI instead of querying the monitor EDID data.
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
     public static void glfwGetMonitorPhysicalSize(@CType("GLFWmonitor*") java.lang.foreign.MemorySegment monitor, @Out @CType("int*") int[] widthMM, @Out @CType("int*") int[] heightMM) {
         try (var __overrungl_stack = MemoryStack.pushLocal()) {
             var __overrungl_ref_widthMM = Marshal.marshal(__overrungl_stack, widthMM);
@@ -2231,66 +804,12 @@ public final class GLFW {
         } catch (Throwable e) { throw new RuntimeException("error in glfwGetMonitorPhysicalSize", e); }
     }
 
-    ///Retrieves the content scale for the specified monitor.
-    ///
-    ///This function retrieves the content scale for the specified monitor.  The
-    ///content scale is the ratio between the current DPI and the platform's
-    ///default DPI.  This is especially important for text and any UI elements.  If
-    ///the pixel dimensions of your UI scaled by this look appropriate on your
-    ///machine then it should appear at a reasonable size on other machines
-    ///regardless of their DPI and scaling settings.  This relies on the system DPI
-    ///and scaling settings being somewhat correct.
-    ///
-    ///The content scale may depend on both the monitor resolution and pixel
-    ///density and on user settings.  It may be very different from the raw DPI
-    ///calculated from the physical size and current resolution.
-    ///
-    ///@param monitor The monitor to query.
-    ///@param xscale Where to store the x-axis content scale, or `NULL`.
-    ///@param yscale Where to store the y-axis content scale, or `NULL`.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-    ///[GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-    ///
-    ///@glfw.remark __Wayland:__ Fractional scaling information is not yet available for
-    ///monitors, so this function only returns integer content scales.
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
-    ///
-    ///@see #glfwGetWindowContentScale(MemorySegment, MemorySegment, MemorySegment) glfwGetWindowContentScale
     public static void glfwGetMonitorContentScale(@CType("GLFWmonitor*") java.lang.foreign.MemorySegment monitor, @Out @CType("float*") java.lang.foreign.MemorySegment xscale, @Out @CType("float*") java.lang.foreign.MemorySegment yscale) {
         try {
             Handles.MH_glfwGetMonitorContentScale.invokeExact(monitor, xscale, yscale);
         } catch (Throwable e) { throw new RuntimeException("error in glfwGetMonitorContentScale", e); }
     }
 
-    ///Retrieves the content scale for the specified monitor.
-    ///
-    ///This function retrieves the content scale for the specified monitor.  The
-    ///content scale is the ratio between the current DPI and the platform's
-    ///default DPI.  This is especially important for text and any UI elements.  If
-    ///the pixel dimensions of your UI scaled by this look appropriate on your
-    ///machine then it should appear at a reasonable size on other machines
-    ///regardless of their DPI and scaling settings.  This relies on the system DPI
-    ///and scaling settings being somewhat correct.
-    ///
-    ///The content scale may depend on both the monitor resolution and pixel
-    ///density and on user settings.  It may be very different from the raw DPI
-    ///calculated from the physical size and current resolution.
-    ///
-    ///@param monitor The monitor to query.
-    ///@param xscale Where to store the x-axis content scale, or `NULL`.
-    ///@param yscale Where to store the y-axis content scale, or `NULL`.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-    ///[GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-    ///
-    ///@glfw.remark __Wayland:__ Fractional scaling information is not yet available for
-    ///monitors, so this function only returns integer content scales.
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
-    ///
-    ///@see #glfwGetWindowContentScale(MemorySegment, MemorySegment, MemorySegment) glfwGetWindowContentScale
     public static void glfwGetMonitorContentScale(@CType("GLFWmonitor*") java.lang.foreign.MemorySegment monitor, @Out @CType("float*") float[] xscale, @Out @CType("float*") float[] yscale) {
         try (var __overrungl_stack = MemoryStack.pushLocal()) {
             var __overrungl_ref_xscale = Marshal.marshal(__overrungl_stack, xscale);
@@ -2301,1080 +820,184 @@ public final class GLFW {
         } catch (Throwable e) { throw new RuntimeException("error in glfwGetMonitorContentScale", e); }
     }
 
-    ///Returns the name of the specified monitor.
-    ///
-    ///This function returns a human-readable name, encoded as UTF-8, of the
-    ///specified monitor.  The name typically reflects the make and model of the
-    ///monitor and is not guaranteed to be unique among the connected monitors.
-    ///
-    ///@param monitor The monitor to query.
-    ///@return The UTF-8 encoded name of the monitor, or `NULL` if an
-    ///error occurred.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-    ///@glfw.pointer_lifetime The returned string is allocated and freed by GLFW.  You
-    ///should not free it yourself.  It is valid until the specified monitor is
-    ///disconnected or the library is terminated.
-    ///@glfw.thread_safety This function must only be called from the main thread.
     public static @CType("const char*") java.lang.foreign.MemorySegment glfwGetMonitorName_(@CType("GLFWmonitor*") java.lang.foreign.MemorySegment monitor) {
         try {
             return (java.lang.foreign.MemorySegment) Handles.MH_glfwGetMonitorName.invokeExact(monitor);
         } catch (Throwable e) { throw new RuntimeException("error in glfwGetMonitorName", e); }
     }
 
-    ///Returns the name of the specified monitor.
-    ///
-    ///This function returns a human-readable name, encoded as UTF-8, of the
-    ///specified monitor.  The name typically reflects the make and model of the
-    ///monitor and is not guaranteed to be unique among the connected monitors.
-    ///
-    ///@param monitor The monitor to query.
-    ///@return The UTF-8 encoded name of the monitor, or `NULL` if an
-    ///error occurred.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-    ///@glfw.pointer_lifetime The returned string is allocated and freed by GLFW.  You
-    ///should not free it yourself.  It is valid until the specified monitor is
-    ///disconnected or the library is terminated.
-    ///@glfw.thread_safety This function must only be called from the main thread.
     public static @CType("const char*") java.lang.String glfwGetMonitorName(@CType("GLFWmonitor*") java.lang.foreign.MemorySegment monitor) {
         try {
             return Unmarshal.unmarshalAsString((java.lang.foreign.MemorySegment) Handles.MH_glfwGetMonitorName.invokeExact(monitor));
         } catch (Throwable e) { throw new RuntimeException("error in glfwGetMonitorName", e); }
     }
 
-    ///Sets the user pointer of the specified monitor.
-    ///
-    ///This function sets the user-defined pointer of the specified monitor.  The
-    ///current value is retained until the monitor is disconnected.  The initial
-    ///value is `NULL`.
-    ///
-    ///This function may be called from the monitor callback, even for a monitor
-    ///that is being disconnected.
-    ///
-    ///@param monitor The monitor whose pointer to set.
-    ///@param pointer The new value.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-    ///
-    ///@glfw.thread_safety This function may be called from any thread.  Access is not
-    ///synchronized.
-    ///
-    ///@see #glfwGetMonitorUserPointer(MemorySegment) glfwGetMonitorUserPointer
     public static void glfwSetMonitorUserPointer(@CType("GLFWmonitor*") java.lang.foreign.MemorySegment monitor, @CType("void*") java.lang.foreign.MemorySegment pointer) {
         try {
             Handles.MH_glfwSetMonitorUserPointer.invokeExact(monitor, pointer);
         } catch (Throwable e) { throw new RuntimeException("error in glfwSetMonitorUserPointer", e); }
     }
 
-    ///Returns the user pointer of the specified monitor.
-    ///
-    ///This function returns the current value of the user-defined pointer of the
-    ///specified monitor.  The initial value is `NULL`.
-    ///
-    ///This function may be called from the monitor callback, even for a monitor
-    ///that is being disconnected.
-    ///
-    ///@param monitor The monitor whose pointer to return.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-    ///
-    ///@glfw.thread_safety This function may be called from any thread.  Access is not
-    ///synchronized.
-    ///
-    ///@see #glfwSetMonitorUserPointer(MemorySegment, MemorySegment) glfwSetMonitorUserPointer
     public static @CType("void*") java.lang.foreign.MemorySegment glfwGetMonitorUserPointer(@CType("GLFWmonitor*") java.lang.foreign.MemorySegment monitor) {
         try {
             return (java.lang.foreign.MemorySegment) Handles.MH_glfwGetMonitorUserPointer.invokeExact(monitor);
         } catch (Throwable e) { throw new RuntimeException("error in glfwGetMonitorUserPointer", e); }
     }
 
-    ///Sets the monitor configuration callback.
-    ///
-    ///This function sets the monitor configuration callback, or removes the
-    ///currently set callback.  This is called when a monitor is connected to or
-    ///disconnected from the system.
-    ///
-    ///@param callback The new callback, or `NULL` to remove the currently set
-    ///callback.
-    ///@return The previously set callback, or `NULL` if no callback was set or the
-    ///library had not been initialized.
-    ///
-    ///@glfw.callback_signature
-    ///For more information about the callback parameters, see the
-    ///[function pointer type][GLFWMonitorFun].
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
     public static @CType("GLFWmonitorfun") java.lang.foreign.MemorySegment glfwSetMonitorCallback(@CType("GLFWmonitorfun") java.lang.foreign.MemorySegment callback) {
         try {
             return (java.lang.foreign.MemorySegment) Handles.MH_glfwSetMonitorCallback.invokeExact(callback);
         } catch (Throwable e) { throw new RuntimeException("error in glfwSetMonitorCallback", e); }
     }
 
-    ///Sets the monitor configuration callback.
-    ///
-    ///This function sets the monitor configuration callback, or removes the
-    ///currently set callback.  This is called when a monitor is connected to or
-    ///disconnected from the system.
-    ///
-    ///@param callback The new callback, or `NULL` to remove the currently set
-    ///callback.
-    ///@return The previously set callback, or `NULL` if no callback was set or the
-    ///library had not been initialized.
-    ///
-    ///@glfw.callback_signature
-    ///For more information about the callback parameters, see the
-    ///[function pointer type][GLFWMonitorFun].
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
     public static @CType("GLFWmonitorfun") java.lang.foreign.MemorySegment glfwSetMonitorCallback(@CType("GLFWmonitorfun") overrungl.glfw.GLFWMonitorFun callback) {
         return glfwSetMonitorCallback(callback != null ? callback.stub(Arena.global()) : MemorySegment.NULL);
     }
 
-    ///Returns the available video modes for the specified monitor.
-    ///
-    ///This function returns an array of all video modes supported by the specified
-    ///monitor.  The returned array is sorted in ascending order, first by color
-    ///bit depth (the sum of all channel depths), then by resolution area (the
-    ///product of width and height), then resolution width and finally by refresh
-    ///rate.
-    ///
-    ///@param monitor The monitor to query.
-    ///@param count Where to store the number of video modes in the returned
-    ///array.  This is set to zero if an error occurred.
-    ///@return An array of video modes, or `NULL` if an
-    ///error occurred.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-    ///[GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-    ///
-    ///@glfw.pointer_lifetime The returned array is allocated and freed by GLFW.  You
-    ///should not free it yourself.  It is valid until the specified monitor is
-    ///disconnected, this function is called again for that monitor or the library
-    ///is terminated.
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
-    ///
-    ///@see #glfwGetVideoMode(MemorySegment) glfwGetVideoMode
     public static @CType("const GLFWvidmode*") java.lang.foreign.MemorySegment glfwGetVideoModes(@CType("GLFWmonitor*") java.lang.foreign.MemorySegment monitor, @Out @CType("int*") java.lang.foreign.MemorySegment count) {
         try {
             return (java.lang.foreign.MemorySegment) Handles.MH_glfwGetVideoModes.invokeExact(monitor, count);
         } catch (Throwable e) { throw new RuntimeException("error in glfwGetVideoModes", e); }
     }
 
-    ///Returns the current mode of the specified monitor.
-    ///
-    ///This function returns the current video mode of the specified monitor.  If
-    ///you have created a full screen window for that monitor, the return value
-    ///will depend on whether that window is iconified.
-    ///
-    ///@param monitor The monitor to query.
-    ///@return The current mode of the monitor, or `NULL` if an
-    ///error occurred.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-    ///[GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-    ///
-    ///@glfw.pointer_lifetime The returned array is allocated and freed by GLFW.  You
-    ///should not free it yourself.  It is valid until the specified monitor is
-    ///disconnected or the library is terminated.
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
-    ///
-    ///@see #glfwGetVideoModes(MemorySegment, MemorySegment) glfwGetVideoModes
     public static @CType("const GLFWvidmode*") java.lang.foreign.MemorySegment glfwGetVideoMode_(@CType("GLFWmonitor*") java.lang.foreign.MemorySegment monitor) {
         try {
             return (java.lang.foreign.MemorySegment) Handles.MH_glfwGetVideoMode.invokeExact(monitor);
         } catch (Throwable e) { throw new RuntimeException("error in glfwGetVideoMode", e); }
     }
 
-    ///Returns the current mode of the specified monitor.
-    ///
-    ///This function returns the current video mode of the specified monitor.  If
-    ///you have created a full screen window for that monitor, the return value
-    ///will depend on whether that window is iconified.
-    ///
-    ///@param monitor The monitor to query.
-    ///@return The current mode of the monitor, or `NULL` if an
-    ///error occurred.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-    ///[GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-    ///
-    ///@glfw.pointer_lifetime The returned array is allocated and freed by GLFW.  You
-    ///should not free it yourself.  It is valid until the specified monitor is
-    ///disconnected or the library is terminated.
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
-    ///
-    ///@see #glfwGetVideoModes(MemorySegment, MemorySegment) glfwGetVideoModes
     public static @CType("const GLFWvidmode*") overrungl.glfw.GLFWVidMode glfwGetVideoMode(@CType("GLFWmonitor*") java.lang.foreign.MemorySegment monitor) {
         try {
             return overrungl.glfw.GLFWVidMode.of((java.lang.foreign.MemorySegment) Handles.MH_glfwGetVideoMode.invokeExact(monitor));
         } catch (Throwable e) { throw new RuntimeException("error in glfwGetVideoMode", e); }
     }
 
-    ///Generates a gamma ramp and sets it for the specified monitor.
-    ///
-    ///This function generates an appropriately sized gamma ramp from the specified
-    ///exponent and then calls [glfwSetGammaRamp][#glfwSetGammaRamp(MemorySegment, MemorySegment)] with it.  The value must be
-    ///a finite number greater than zero.
-    ///
-    ///The software controlled gamma ramp is applied _in addition_ to the hardware
-    ///gamma correction, which today is usually an approximation of sRGB gamma.
-    ///This means that setting a perfectly linear ramp, or gamma 1.0, will produce
-    ///the default (usually sRGB-like) behavior.
-    ///
-    ///For gamma correct rendering with OpenGL or OpenGL ES, see the
-    ///[GLFW_SRGB_CAPABLE][#GLFW_SRGB_CAPABLE] hint.
-    ///
-    ///@param monitor The monitor whose gamma ramp to set.
-    ///@param gamma The desired exponent.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED], [GLFW_INVALID_VALUE][#GLFW_INVALID_VALUE],
-    ///[GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR] and [GLFW_FEATURE_UNAVAILABLE][#GLFW_FEATURE_UNAVAILABLE] (see remarks).
-    ///
-    ///@glfw.remark __Wayland:__ Gamma handling is a privileged protocol, this function
-    ///will thus never be implemented and emits [GLFW_FEATURE_UNAVAILABLE][#GLFW_FEATURE_UNAVAILABLE].
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
     public static void glfwSetGamma(@CType("GLFWmonitor*") java.lang.foreign.MemorySegment monitor, @CType("float") float gamma) {
         try {
             Handles.MH_glfwSetGamma.invokeExact(monitor, gamma);
         } catch (Throwable e) { throw new RuntimeException("error in glfwSetGamma", e); }
     }
 
-    ///Returns the current gamma ramp for the specified monitor.
-    ///
-    ///This function returns the current gamma ramp of the specified monitor.
-    ///
-    ///@param monitor The monitor to query.
-    ///@return The current gamma ramp, or `NULL` if an
-    ///error occurred.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED], [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR]
-    ///and [GLFW_FEATURE_UNAVAILABLE][#GLFW_FEATURE_UNAVAILABLE] (see remarks).
-    ///
-    ///@glfw.remark __Wayland:__ Gamma handling is a privileged protocol, this function
-    ///will thus never be implemented and emits [GLFW_FEATURE_UNAVAILABLE][#GLFW_FEATURE_UNAVAILABLE] while
-    ///returning `NULL`.
-    ///
-    ///@glfw.pointer_lifetime The returned structure and its arrays are allocated and
-    ///freed by GLFW.  You should not free them yourself.  They are valid until the
-    ///specified monitor is disconnected, this function is called again for that
-    ///monitor or the library is terminated.
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
     public static @CType("const GLFWgammaramp*") java.lang.foreign.MemorySegment glfwGetGammaRamp_(@CType("GLFWmonitor*") java.lang.foreign.MemorySegment monitor) {
         try {
             return (java.lang.foreign.MemorySegment) Handles.MH_glfwGetGammaRamp.invokeExact(monitor);
         } catch (Throwable e) { throw new RuntimeException("error in glfwGetGammaRamp", e); }
     }
 
-    ///Returns the current gamma ramp for the specified monitor.
-    ///
-    ///This function returns the current gamma ramp of the specified monitor.
-    ///
-    ///@param monitor The monitor to query.
-    ///@return The current gamma ramp, or `NULL` if an
-    ///error occurred.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED], [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR]
-    ///and [GLFW_FEATURE_UNAVAILABLE][#GLFW_FEATURE_UNAVAILABLE] (see remarks).
-    ///
-    ///@glfw.remark __Wayland:__ Gamma handling is a privileged protocol, this function
-    ///will thus never be implemented and emits [GLFW_FEATURE_UNAVAILABLE][#GLFW_FEATURE_UNAVAILABLE] while
-    ///returning `NULL`.
-    ///
-    ///@glfw.pointer_lifetime The returned structure and its arrays are allocated and
-    ///freed by GLFW.  You should not free them yourself.  They are valid until the
-    ///specified monitor is disconnected, this function is called again for that
-    ///monitor or the library is terminated.
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
     public static @CType("const GLFWgammaramp*") overrungl.glfw.GLFWGammaRamp glfwGetGammaRamp(@CType("GLFWmonitor*") java.lang.foreign.MemorySegment monitor) {
         try {
             return overrungl.glfw.GLFWGammaRamp.of((java.lang.foreign.MemorySegment) Handles.MH_glfwGetGammaRamp.invokeExact(monitor));
         } catch (Throwable e) { throw new RuntimeException("error in glfwGetGammaRamp", e); }
     }
 
-    ///Sets the current gamma ramp for the specified monitor.
-    ///
-    ///This function sets the current gamma ramp for the specified monitor.  The
-    ///original gamma ramp for that monitor is saved by GLFW the first time this
-    ///function is called and is restored by [glfwTerminate][#glfwTerminate()].
-    ///
-    ///The software controlled gamma ramp is applied _in addition_ to the hardware
-    ///gamma correction, which today is usually an approximation of sRGB gamma.
-    ///This means that setting a perfectly linear ramp, or gamma 1.0, will produce
-    ///the default (usually sRGB-like) behavior.
-    ///
-    ///For gamma correct rendering with OpenGL or OpenGL ES, see the
-    ///[GLFW_SRGB_CAPABLE][#GLFW_SRGB_CAPABLE] hint.
-    ///
-    ///@param monitor The monitor whose gamma ramp to set.
-    ///@param ramp The gamma ramp to use.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED], [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR]
-    ///and [GLFW_FEATURE_UNAVAILABLE][#GLFW_FEATURE_UNAVAILABLE] (see remarks).
-    ///
-    ///@glfw.remark The size of the specified gamma ramp should match the size of the
-    ///current ramp for that monitor.
-    ///- __Windows:__ The gamma ramp size must be 256.
-    ///- __Wayland:__ Gamma handling is a privileged protocol, this function
-    ///    will thus never be implemented and emits [GLFW_FEATURE_UNAVAILABLE][#GLFW_FEATURE_UNAVAILABLE].
-    ///
-    ///@glfw.pointer_lifetime The specified gamma ramp is copied before this function
-    ///returns.
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
     public static void glfwSetGammaRamp(@CType("GLFWmonitor*") java.lang.foreign.MemorySegment monitor, @CType("const GLFWgammaramp*") java.lang.foreign.MemorySegment ramp) {
         try {
             Handles.MH_glfwSetGammaRamp.invokeExact(monitor, ramp);
         } catch (Throwable e) { throw new RuntimeException("error in glfwSetGammaRamp", e); }
     }
 
-    ///Sets the current gamma ramp for the specified monitor.
-    ///
-    ///This function sets the current gamma ramp for the specified monitor.  The
-    ///original gamma ramp for that monitor is saved by GLFW the first time this
-    ///function is called and is restored by [glfwTerminate][#glfwTerminate()].
-    ///
-    ///The software controlled gamma ramp is applied _in addition_ to the hardware
-    ///gamma correction, which today is usually an approximation of sRGB gamma.
-    ///This means that setting a perfectly linear ramp, or gamma 1.0, will produce
-    ///the default (usually sRGB-like) behavior.
-    ///
-    ///For gamma correct rendering with OpenGL or OpenGL ES, see the
-    ///[GLFW_SRGB_CAPABLE][#GLFW_SRGB_CAPABLE] hint.
-    ///
-    ///@param monitor The monitor whose gamma ramp to set.
-    ///@param ramp The gamma ramp to use.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED], [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR]
-    ///and [GLFW_FEATURE_UNAVAILABLE][#GLFW_FEATURE_UNAVAILABLE] (see remarks).
-    ///
-    ///@glfw.remark The size of the specified gamma ramp should match the size of the
-    ///current ramp for that monitor.
-    ///- __Windows:__ The gamma ramp size must be 256.
-    ///- __Wayland:__ Gamma handling is a privileged protocol, this function
-    ///    will thus never be implemented and emits [GLFW_FEATURE_UNAVAILABLE][#GLFW_FEATURE_UNAVAILABLE].
-    ///
-    ///@glfw.pointer_lifetime The specified gamma ramp is copied before this function
-    ///returns.
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
     public static void glfwSetGammaRamp(@CType("GLFWmonitor*") java.lang.foreign.MemorySegment monitor, @CType("const GLFWgammaramp*") overrungl.glfw.GLFWGammaRamp ramp) {
         try {
             Handles.MH_glfwSetGammaRamp.invokeExact(monitor, Marshal.marshal(ramp));
         } catch (Throwable e) { throw new RuntimeException("error in glfwSetGammaRamp", e); }
     }
 
-    ///Resets all window hints to their default values.
-    ///
-    ///This function resets all window hints to their
-    ///default values.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
-    ///
-    ///@see #glfwWindowHint(int, int) glfwWindowHint
-    ///@see #glfwWindowHintString(int, MemorySegment) glfwWindowHintString
     public static void glfwDefaultWindowHints() {
         try {
             Handles.MH_glfwDefaultWindowHints.invokeExact();
         } catch (Throwable e) { throw new RuntimeException("error in glfwDefaultWindowHints", e); }
     }
 
-    ///Sets the specified window hint to the desired value.
-    ///
-    ///This function sets hints for the next call to [glfwCreateWindow][#glfwCreateWindow(int, int, MemorySegment, MemorySegment, MemorySegment)].  The
-    ///hints, once set, retain their values until changed by a call to this
-    ///function or [glfwDefaultWindowHints][#glfwDefaultWindowHints()], or until the library is terminated.
-    ///
-    ///Only integer value hints can be set with this function.  String value hints
-    ///are set with [glfwWindowHintString][#glfwWindowHintString(int, MemorySegment)].
-    ///
-    ///This function does not check whether the specified hint values are valid.
-    ///If you set hints to invalid values this will instead be reported by the next
-    ///call to [glfwCreateWindow][#glfwCreateWindow(int, int, MemorySegment, MemorySegment, MemorySegment)].
-    ///
-    ///Some hints are platform specific.  These may be set on any platform but they
-    ///will only affect their specific platform.  Other platforms will ignore them.
-    ///Setting these hints requires no platform specific headers or functions.
-    ///
-    ///@param hint The window hint to set.
-    ///@param value The new value of the window hint.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-    ///[GLFW_INVALID_ENUM][#GLFW_INVALID_ENUM].
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
-    ///
-    ///@see #glfwWindowHintString(int, MemorySegment) glfwWindowHintString
-    ///@see #glfwDefaultWindowHints() glfwDefaultWindowHints
     public static void glfwWindowHint(@CType("int") int hint, @CType("int") int value) {
         try {
             Handles.MH_glfwWindowHint.invokeExact(hint, value);
         } catch (Throwable e) { throw new RuntimeException("error in glfwWindowHint", e); }
     }
 
-    ///Sets the specified window hint to the desired value.
-    ///
-    ///This function sets hints for the next call to [glfwCreateWindow][#glfwCreateWindow(int, int, MemorySegment, MemorySegment, MemorySegment)].  The
-    ///hints, once set, retain their values until changed by a call to this
-    ///function or [glfwDefaultWindowHints][#glfwDefaultWindowHints()], or until the library is terminated.
-    ///
-    ///Only string type hints can be set with this function.  Integer value hints
-    ///are set with [glfwWindowHint][#glfwWindowHint(int, int)].
-    ///
-    ///This function does not check whether the specified hint values are valid.
-    ///If you set hints to invalid values this will instead be reported by the next
-    ///call to [glfwCreateWindow][#glfwCreateWindow(int, int, MemorySegment, MemorySegment, MemorySegment)].
-    ///
-    ///Some hints are platform specific.  These may be set on any platform but they
-    ///will only affect their specific platform.  Other platforms will ignore them.
-    ///Setting these hints requires no platform specific headers or functions.
-    ///
-    ///@param hint The window hint to set.
-    ///@param value The new value of the window hint.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-    ///[GLFW_INVALID_ENUM][#GLFW_INVALID_ENUM].
-    ///
-    ///@glfw.pointer_lifetime The specified string is copied before this function
-    ///returns.
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
-    ///
-    ///@see #glfwWindowHint(int, int) glfwWindowHint
-    ///@see #glfwDefaultWindowHints() glfwDefaultWindowHints
     public static void glfwWindowHintString(@CType("int") int hint, @CType("const char*") java.lang.foreign.MemorySegment value) {
         try {
             Handles.MH_glfwWindowHintString.invokeExact(hint, value);
         } catch (Throwable e) { throw new RuntimeException("error in glfwWindowHintString", e); }
     }
 
-    ///Sets the specified window hint to the desired value.
-    ///
-    ///This function sets hints for the next call to [glfwCreateWindow][#glfwCreateWindow(int, int, MemorySegment, MemorySegment, MemorySegment)].  The
-    ///hints, once set, retain their values until changed by a call to this
-    ///function or [glfwDefaultWindowHints][#glfwDefaultWindowHints()], or until the library is terminated.
-    ///
-    ///Only string type hints can be set with this function.  Integer value hints
-    ///are set with [glfwWindowHint][#glfwWindowHint(int, int)].
-    ///
-    ///This function does not check whether the specified hint values are valid.
-    ///If you set hints to invalid values this will instead be reported by the next
-    ///call to [glfwCreateWindow][#glfwCreateWindow(int, int, MemorySegment, MemorySegment, MemorySegment)].
-    ///
-    ///Some hints are platform specific.  These may be set on any platform but they
-    ///will only affect their specific platform.  Other platforms will ignore them.
-    ///Setting these hints requires no platform specific headers or functions.
-    ///
-    ///@param hint The window hint to set.
-    ///@param value The new value of the window hint.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-    ///[GLFW_INVALID_ENUM][#GLFW_INVALID_ENUM].
-    ///
-    ///@glfw.pointer_lifetime The specified string is copied before this function
-    ///returns.
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
-    ///
-    ///@see #glfwWindowHint(int, int) glfwWindowHint
-    ///@see #glfwDefaultWindowHints() glfwDefaultWindowHints
     public static void glfwWindowHintString(@CType("int") int hint, @CType("const char*") java.lang.String value) {
         try (var __overrungl_stack = MemoryStack.pushLocal()) {
             Handles.MH_glfwWindowHintString.invokeExact(hint, Marshal.marshal(__overrungl_stack, value));
         } catch (Throwable e) { throw new RuntimeException("error in glfwWindowHintString", e); }
     }
 
-    ///Creates a window and its associated context.
-    ///
-    ///This function creates a window and its associated OpenGL or OpenGL ES
-    ///context.  Most of the options controlling how the window and its context
-    ///should be created are specified with window hints.
-    ///
-    ///Successful creation does not change which context is current.  Before you
-    ///can use the newly created context, you need to
-    ///make it current.  For information about the `share`
-    ///parameter, see context_sharing.
-    ///
-    ///The created window, framebuffer and context may differ from what you
-    ///requested, as not all parameters and hints are
-    ///hard constraints.  This includes the size of the
-    ///window, especially for full screen windows.  To query the actual attributes
-    ///of the created window, framebuffer and context, see
-    ///[glfwGetWindowAttrib][#glfwGetWindowAttrib(MemorySegment, int)], [glfwGetWindowSize][#glfwGetWindowSize(MemorySegment, MemorySegment, MemorySegment)] and [glfwGetFramebufferSize][#glfwGetFramebufferSize(MemorySegment, MemorySegment, MemorySegment)].
-    ///
-    ///To create a full screen window, you need to specify the monitor the window
-    ///will cover.  If no monitor is specified, the window will be windowed mode.
-    ///Unless you have a way for the user to choose a specific monitor, it is
-    ///recommended that you pick the primary monitor.  For more information on how
-    ///to query connected monitors, see monitor_monitors.
-    ///
-    ///For full screen windows, the specified size becomes the resolution of the
-    ///window's _desired video mode_.  As long as a full screen window is not
-    ///iconified, the supported video mode most closely matching the desired video
-    ///mode is set for the specified monitor.  For more information about full
-    ///screen windows, including the creation of so called _windowed full screen_
-    ///or _borderless full screen_ windows, see window_windowed_full_screen.
-    ///
-    ///Once you have created the window, you can switch it between windowed and
-    ///full screen mode with [glfwSetWindowMonitor][#glfwSetWindowMonitor(MemorySegment, MemorySegment, int, int, int, int, int)].  This will not affect its
-    ///OpenGL or OpenGL ES context.
-    ///
-    ///By default, newly created windows use the placement recommended by the
-    ///window system.  To create the window at a specific position, set the
-    ///[GLFW_POSITION_X][#GLFW_POSITION_X] and [GLFW_POSITION_Y][#GLFW_POSITION_Y] window hints before creation.  To
-    ///restore the default behavior, set either or both hints back to
-    ///`GLFW_ANY_POSITION`.
-    ///
-    ///As long as at least one full screen window is not iconified, the screensaver
-    ///is prohibited from starting.
-    ///
-    ///Window systems put limits on window sizes.  Very large or very small window
-    ///dimensions may be overridden by the window system on creation.  Check the
-    ///actual size after creation.
-    ///
-    ///The swap interval is not set during window creation and
-    ///the initial value may vary depending on driver settings and defaults.
-    ///
-    ///@param width The desired width, in screen coordinates, of the window.
-    ///This must be greater than zero.
-    ///@param height The desired height, in screen coordinates, of the window.
-    ///This must be greater than zero.
-    ///@param title The initial, UTF-8 encoded window title.
-    ///@param monitor The monitor to use for full screen mode, or `NULL` for
-    ///windowed mode.
-    ///@param share The window whose context to share resources with, or `NULL`
-    ///to not share resources.
-    ///@return The handle of the created window, or `NULL` if an
-    ///error occurred.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED],
-    ///[GLFW_INVALID_ENUM][#GLFW_INVALID_ENUM], [GLFW_INVALID_VALUE][#GLFW_INVALID_VALUE], [GLFW_API_UNAVAILABLE][#GLFW_API_UNAVAILABLE],
-    ///[GLFW_VERSION_UNAVAILABLE][#GLFW_VERSION_UNAVAILABLE], [GLFW_FORMAT_UNAVAILABLE][#GLFW_FORMAT_UNAVAILABLE],
-    ///[GLFW_NO_WINDOW_CONTEXT][#GLFW_NO_WINDOW_CONTEXT] and [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-    ///
-    ///@glfw.remark
-    ///- __Windows:__ Window creation will fail if the Microsoft GDI software
-    ///    OpenGL implementation is the only one available.
-    ///
-    ///    If the executable has an icon resource named `GLFW_ICON,` it
-    ///    will be set as the initial icon for the window.  If no such icon is present,
-    ///    the `IDI_APPLICATION` icon will be used instead.  To set a different icon,
-    ///    see [glfwSetWindowIcon][#glfwSetWindowIcon(MemorySegment, int, MemorySegment)].
-    ///
-    ///    The context to share resources with must not be current on
-    ///    any other thread.
-    ///- __macOS:__ The OS only supports core profile contexts for OpenGL
-    ///    versions 3.2 and later.  Before creating an OpenGL context of version 3.2 or
-    ///    later you must set the [GLFW_OPENGL_PROFILE][#GLFW_OPENGL_PROFILE]
-    ///    hint accordingly.  OpenGL 3.0 and 3.1 contexts are not supported at all
-    ///    on macOS.
-    ///
-    ///    The GLFW window has no icon, as it is not a document
-    ///    window, but the dock icon will be the same as the application bundle's icon.
-    ///    For more information on bundles, see the
-    ///    [Bundle Programming Guide](https://developer.apple.com/library/mac/documentation/CoreFoundation/Conceptual/CFBundles/) in the Mac Developer Library.
-    ///
-    ///    The window frame will not be rendered at full resolution on
-    ///    Retina displays unless the
-    ///    [GLFW_SCALE_FRAMEBUFFER][#GLFW_SCALE_FRAMEBUFFER]
-    ///    hint is `GLFW_TRUE` and the `NSHighResolutionCapable` key is enabled in the
-    ///    application bundle's `Info.plist`.  For more information, see
-    ///    [High Resolution Guidelines for OS X](https://developer.apple.com/library/mac/documentation/GraphicsAnimation/Conceptual/HighResolutionOSX/Explained/Explained.html) in the Mac Developer
-    ///    Library.  The GLFW test and example programs use a custom `Info.plist`
-    ///    template for this, which can be found as `CMake/Info.plist.in` in the source
-    ///    tree.
-    ///
-    ///    When activating frame autosaving with
-    ///    [GLFW_COCOA_FRAME_NAME][#GLFW_COCOA_FRAME_NAME], the specified
-    ///    window size and position may be overridden by previously saved values.
-    ///- __Wayland:__ GLFW uses [libdecor](https://gitlab.freedesktop.org/libdecor/libdecor) where available to create its window
-    ///    decorations.  This in turn uses server-side XDG decorations where available
-    ///    and provides high quality client-side decorations on compositors like GNOME.
-    ///    If both XDG decorations and libdecor are unavailable, GLFW falls back to
-    ///    a very simple set of window decorations that only support moving, resizing
-    ///    and the window manager's right-click menu.
-    ///- __X11:__ Some window managers will not respect the placement of
-    ///    initially hidden windows.
-    ///
-    ///    Due to the asynchronous nature of X11, it may take a moment for
-    ///    a window to reach its requested state.  This means you may not be able to
-    ///    query the final size, position or other attributes directly after window
-    ///    creation.
-    ///
-    ///    The class part of the `WM_CLASS` window property will by
-    ///    default be set to the window title passed to this function.  The instance
-    ///    part will use the contents of the `RESOURCE_NAME` environment variable, if
-    ///    present and not empty, or fall back to the window title.  Set the
-    ///    [GLFW_X11_CLASS_NAME][#GLFW_X11_CLASS_NAME] and
-    ///    [GLFW_X11_INSTANCE_NAME][#GLFW_X11_INSTANCE_NAME] window hints to
-    ///    override this.
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
-    ///
-    ///@see #glfwDestroyWindow(MemorySegment) glfwDestroyWindow
     public static @CType("GLFWwindow*") java.lang.foreign.MemorySegment glfwCreateWindow(@CType("int") int width, @CType("int") int height, @CType("const char*") java.lang.foreign.MemorySegment title, @CType("GLFWmonitor*") java.lang.foreign.MemorySegment monitor, @CType("GLFWwindow*") java.lang.foreign.MemorySegment share) {
         try {
             return (java.lang.foreign.MemorySegment) Handles.MH_glfwCreateWindow.invokeExact(width, height, title, monitor, share);
         } catch (Throwable e) { throw new RuntimeException("error in glfwCreateWindow", e); }
     }
 
-    ///Creates a window and its associated context.
-    ///
-    ///This function creates a window and its associated OpenGL or OpenGL ES
-    ///context.  Most of the options controlling how the window and its context
-    ///should be created are specified with window hints.
-    ///
-    ///Successful creation does not change which context is current.  Before you
-    ///can use the newly created context, you need to
-    ///make it current.  For information about the `share`
-    ///parameter, see context_sharing.
-    ///
-    ///The created window, framebuffer and context may differ from what you
-    ///requested, as not all parameters and hints are
-    ///hard constraints.  This includes the size of the
-    ///window, especially for full screen windows.  To query the actual attributes
-    ///of the created window, framebuffer and context, see
-    ///[glfwGetWindowAttrib][#glfwGetWindowAttrib(MemorySegment, int)], [glfwGetWindowSize][#glfwGetWindowSize(MemorySegment, MemorySegment, MemorySegment)] and [glfwGetFramebufferSize][#glfwGetFramebufferSize(MemorySegment, MemorySegment, MemorySegment)].
-    ///
-    ///To create a full screen window, you need to specify the monitor the window
-    ///will cover.  If no monitor is specified, the window will be windowed mode.
-    ///Unless you have a way for the user to choose a specific monitor, it is
-    ///recommended that you pick the primary monitor.  For more information on how
-    ///to query connected monitors, see monitor_monitors.
-    ///
-    ///For full screen windows, the specified size becomes the resolution of the
-    ///window's _desired video mode_.  As long as a full screen window is not
-    ///iconified, the supported video mode most closely matching the desired video
-    ///mode is set for the specified monitor.  For more information about full
-    ///screen windows, including the creation of so called _windowed full screen_
-    ///or _borderless full screen_ windows, see window_windowed_full_screen.
-    ///
-    ///Once you have created the window, you can switch it between windowed and
-    ///full screen mode with [glfwSetWindowMonitor][#glfwSetWindowMonitor(MemorySegment, MemorySegment, int, int, int, int, int)].  This will not affect its
-    ///OpenGL or OpenGL ES context.
-    ///
-    ///By default, newly created windows use the placement recommended by the
-    ///window system.  To create the window at a specific position, set the
-    ///[GLFW_POSITION_X][#GLFW_POSITION_X] and [GLFW_POSITION_Y][#GLFW_POSITION_Y] window hints before creation.  To
-    ///restore the default behavior, set either or both hints back to
-    ///`GLFW_ANY_POSITION`.
-    ///
-    ///As long as at least one full screen window is not iconified, the screensaver
-    ///is prohibited from starting.
-    ///
-    ///Window systems put limits on window sizes.  Very large or very small window
-    ///dimensions may be overridden by the window system on creation.  Check the
-    ///actual size after creation.
-    ///
-    ///The swap interval is not set during window creation and
-    ///the initial value may vary depending on driver settings and defaults.
-    ///
-    ///@param width The desired width, in screen coordinates, of the window.
-    ///This must be greater than zero.
-    ///@param height The desired height, in screen coordinates, of the window.
-    ///This must be greater than zero.
-    ///@param title The initial, UTF-8 encoded window title.
-    ///@param monitor The monitor to use for full screen mode, or `NULL` for
-    ///windowed mode.
-    ///@param share The window whose context to share resources with, or `NULL`
-    ///to not share resources.
-    ///@return The handle of the created window, or `NULL` if an
-    ///error occurred.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED],
-    ///[GLFW_INVALID_ENUM][#GLFW_INVALID_ENUM], [GLFW_INVALID_VALUE][#GLFW_INVALID_VALUE], [GLFW_API_UNAVAILABLE][#GLFW_API_UNAVAILABLE],
-    ///[GLFW_VERSION_UNAVAILABLE][#GLFW_VERSION_UNAVAILABLE], [GLFW_FORMAT_UNAVAILABLE][#GLFW_FORMAT_UNAVAILABLE],
-    ///[GLFW_NO_WINDOW_CONTEXT][#GLFW_NO_WINDOW_CONTEXT] and [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-    ///
-    ///@glfw.remark
-    ///- __Windows:__ Window creation will fail if the Microsoft GDI software
-    ///    OpenGL implementation is the only one available.
-    ///
-    ///    If the executable has an icon resource named `GLFW_ICON,` it
-    ///    will be set as the initial icon for the window.  If no such icon is present,
-    ///    the `IDI_APPLICATION` icon will be used instead.  To set a different icon,
-    ///    see [glfwSetWindowIcon][#glfwSetWindowIcon(MemorySegment, int, MemorySegment)].
-    ///
-    ///    The context to share resources with must not be current on
-    ///    any other thread.
-    ///- __macOS:__ The OS only supports core profile contexts for OpenGL
-    ///    versions 3.2 and later.  Before creating an OpenGL context of version 3.2 or
-    ///    later you must set the [GLFW_OPENGL_PROFILE][#GLFW_OPENGL_PROFILE]
-    ///    hint accordingly.  OpenGL 3.0 and 3.1 contexts are not supported at all
-    ///    on macOS.
-    ///
-    ///    The GLFW window has no icon, as it is not a document
-    ///    window, but the dock icon will be the same as the application bundle's icon.
-    ///    For more information on bundles, see the
-    ///    [Bundle Programming Guide](https://developer.apple.com/library/mac/documentation/CoreFoundation/Conceptual/CFBundles/) in the Mac Developer Library.
-    ///
-    ///    The window frame will not be rendered at full resolution on
-    ///    Retina displays unless the
-    ///    [GLFW_SCALE_FRAMEBUFFER][#GLFW_SCALE_FRAMEBUFFER]
-    ///    hint is `GLFW_TRUE` and the `NSHighResolutionCapable` key is enabled in the
-    ///    application bundle's `Info.plist`.  For more information, see
-    ///    [High Resolution Guidelines for OS X](https://developer.apple.com/library/mac/documentation/GraphicsAnimation/Conceptual/HighResolutionOSX/Explained/Explained.html) in the Mac Developer
-    ///    Library.  The GLFW test and example programs use a custom `Info.plist`
-    ///    template for this, which can be found as `CMake/Info.plist.in` in the source
-    ///    tree.
-    ///
-    ///    When activating frame autosaving with
-    ///    [GLFW_COCOA_FRAME_NAME][#GLFW_COCOA_FRAME_NAME], the specified
-    ///    window size and position may be overridden by previously saved values.
-    ///- __Wayland:__ GLFW uses [libdecor](https://gitlab.freedesktop.org/libdecor/libdecor) where available to create its window
-    ///    decorations.  This in turn uses server-side XDG decorations where available
-    ///    and provides high quality client-side decorations on compositors like GNOME.
-    ///    If both XDG decorations and libdecor are unavailable, GLFW falls back to
-    ///    a very simple set of window decorations that only support moving, resizing
-    ///    and the window manager's right-click menu.
-    ///- __X11:__ Some window managers will not respect the placement of
-    ///    initially hidden windows.
-    ///
-    ///    Due to the asynchronous nature of X11, it may take a moment for
-    ///    a window to reach its requested state.  This means you may not be able to
-    ///    query the final size, position or other attributes directly after window
-    ///    creation.
-    ///
-    ///    The class part of the `WM_CLASS` window property will by
-    ///    default be set to the window title passed to this function.  The instance
-    ///    part will use the contents of the `RESOURCE_NAME` environment variable, if
-    ///    present and not empty, or fall back to the window title.  Set the
-    ///    [GLFW_X11_CLASS_NAME][#GLFW_X11_CLASS_NAME] and
-    ///    [GLFW_X11_INSTANCE_NAME][#GLFW_X11_INSTANCE_NAME] window hints to
-    ///    override this.
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
-    ///
-    ///@see #glfwDestroyWindow(MemorySegment) glfwDestroyWindow
     public static @CType("GLFWwindow*") java.lang.foreign.MemorySegment glfwCreateWindow(@CType("int") int width, @CType("int") int height, @CType("const char*") java.lang.String title, @CType("GLFWmonitor*") java.lang.foreign.MemorySegment monitor, @CType("GLFWwindow*") java.lang.foreign.MemorySegment share) {
         try (var __overrungl_stack = MemoryStack.pushLocal()) {
             return (java.lang.foreign.MemorySegment) Handles.MH_glfwCreateWindow.invokeExact(width, height, Marshal.marshal(__overrungl_stack, title), monitor, share);
         } catch (Throwable e) { throw new RuntimeException("error in glfwCreateWindow", e); }
     }
 
-    ///Destroys the specified window and its context.
-    ///
-    ///This function destroys the specified window and its context.  On calling
-    ///this function, no further callbacks will be called for that window.
-    ///
-    ///If the context of the specified window is current on the main thread, it is
-    ///detached before being destroyed.
-    ///
-    ///@param window The window to destroy.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-    ///[GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-    ///
-    ///@glfw.note The context of the specified window must not be current on any other
-    ///thread when this function is called.
-    ///
-    ///@glfw.reentrancy This function must not be called from a callback.
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
-    ///
-    ///@see #glfwCreateWindow(int, int, MemorySegment, MemorySegment, MemorySegment) glfwCreateWindow
     public static void glfwDestroyWindow(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window) {
         try {
             Handles.MH_glfwDestroyWindow.invokeExact(window);
         } catch (Throwable e) { throw new RuntimeException("error in glfwDestroyWindow", e); }
     }
 
-    ///Checks the close flag of the specified window.
-    ///
-    ///This function returns the value of the close flag of the specified window.
-    ///
-    ///@param window The window to query.
-    ///@return The value of the close flag.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-    ///
-    ///@glfw.thread_safety This function may be called from any thread.  Access is not
-    ///synchronized.
     public static @CType("int") boolean glfwWindowShouldClose(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window) {
         try {
             return (int) Handles.MH_glfwWindowShouldClose.invokeExact(window) != GLFW.GLFW_FALSE;
         } catch (Throwable e) { throw new RuntimeException("error in glfwWindowShouldClose", e); }
     }
 
-    ///Sets the close flag of the specified window.
-    ///
-    ///This function sets the value of the close flag of the specified window.
-    ///This can be used to override the user's attempt to close the window, or
-    ///to signal that it should be closed.
-    ///
-    ///@param window The window whose flag to change.
-    ///@param value The new value.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-    ///
-    ///@glfw.thread_safety This function may be called from any thread.  Access is not
-    ///synchronized.
     public static void glfwSetWindowShouldClose(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("int") boolean value) {
         try {
             Handles.MH_glfwSetWindowShouldClose.invokeExact(window, value ? GLFW.GLFW_TRUE : GLFW.GLFW_FALSE);
         } catch (Throwable e) { throw new RuntimeException("error in glfwSetWindowShouldClose", e); }
     }
 
-    ///Returns the title of the specified window.
-    ///
-    ///This function returns the window title, encoded as UTF-8, of the specified
-    ///window.  This is the title set previously by [glfwCreateWindow][#glfwCreateWindow(int, int, MemorySegment, MemorySegment, MemorySegment)]
-    ///or [glfwSetWindowTitle][#glfwSetWindowTitle(MemorySegment, MemorySegment)].
-    ///
-    ///@param window The window to query.
-    ///@return The UTF-8 encoded window title, or `NULL` if an
-    ///error occurred.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-    ///
-    ///@glfw.remark The returned title is currently a copy of the title last set by
-    ///[glfwCreateWindow][#glfwCreateWindow(int, int, MemorySegment, MemorySegment, MemorySegment)] or [glfwSetWindowTitle][#glfwSetWindowTitle(MemorySegment, MemorySegment)].  It does not include any
-    ///additional text which may be appended by the platform or another program.
-    ///
-    ///@glfw.pointer_lifetime The returned string is allocated and freed by GLFW.  You
-    ///should not free it yourself.  It is valid until the next call to
-    ///`glfwGetWindowTitle` or [glfwSetWindowTitle][#glfwSetWindowTitle(MemorySegment, MemorySegment)], or until the library is
-    ///terminated.
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
-    ///
-    ///@see #glfwSetWindowTitle(MemorySegment, MemorySegment) glfwSetWindowTitle
     public static @CType("const char*") java.lang.foreign.MemorySegment glfwGetWindowTitle_(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window) {
         try {
             return (java.lang.foreign.MemorySegment) Handles.MH_glfwGetWindowTitle.invokeExact(window);
         } catch (Throwable e) { throw new RuntimeException("error in glfwGetWindowTitle", e); }
     }
 
-    ///Returns the title of the specified window.
-    ///
-    ///This function returns the window title, encoded as UTF-8, of the specified
-    ///window.  This is the title set previously by [glfwCreateWindow][#glfwCreateWindow(int, int, MemorySegment, MemorySegment, MemorySegment)]
-    ///or [glfwSetWindowTitle][#glfwSetWindowTitle(MemorySegment, MemorySegment)].
-    ///
-    ///@param window The window to query.
-    ///@return The UTF-8 encoded window title, or `NULL` if an
-    ///error occurred.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-    ///
-    ///@glfw.remark The returned title is currently a copy of the title last set by
-    ///[glfwCreateWindow][#glfwCreateWindow(int, int, MemorySegment, MemorySegment, MemorySegment)] or [glfwSetWindowTitle][#glfwSetWindowTitle(MemorySegment, MemorySegment)].  It does not include any
-    ///additional text which may be appended by the platform or another program.
-    ///
-    ///@glfw.pointer_lifetime The returned string is allocated and freed by GLFW.  You
-    ///should not free it yourself.  It is valid until the next call to
-    ///`glfwGetWindowTitle` or [glfwSetWindowTitle][#glfwSetWindowTitle(MemorySegment, MemorySegment)], or until the library is
-    ///terminated.
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
-    ///
-    ///@see #glfwSetWindowTitle(MemorySegment, MemorySegment) glfwSetWindowTitle
     public static @CType("const char*") java.lang.String glfwGetWindowTitle(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window) {
         try {
             return Unmarshal.unmarshalAsString((java.lang.foreign.MemorySegment) Handles.MH_glfwGetWindowTitle.invokeExact(window));
         } catch (Throwable e) { throw new RuntimeException("error in glfwGetWindowTitle", e); }
     }
 
-    ///Sets the title of the specified window.
-    ///
-    ///This function sets the window title, encoded as UTF-8, of the specified
-    ///window.
-    ///
-    ///@param window The window whose title to change.
-    ///@param title The UTF-8 encoded window title.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-    ///[GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-    ///
-    ///@glfw.remark __macOS:__ The window title will not be updated until the next time you
-    ///process events.
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
-    ///
-    ///@see #glfwGetWindowTitle(MemorySegment) glfwGetWindowTitle
     public static void glfwSetWindowTitle(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("const char*") java.lang.foreign.MemorySegment title) {
         try {
             Handles.MH_glfwSetWindowTitle.invokeExact(window, title);
         } catch (Throwable e) { throw new RuntimeException("error in glfwSetWindowTitle", e); }
     }
 
-    ///Sets the title of the specified window.
-    ///
-    ///This function sets the window title, encoded as UTF-8, of the specified
-    ///window.
-    ///
-    ///@param window The window whose title to change.
-    ///@param title The UTF-8 encoded window title.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-    ///[GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-    ///
-    ///@glfw.remark __macOS:__ The window title will not be updated until the next time you
-    ///process events.
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
-    ///
-    ///@see #glfwGetWindowTitle(MemorySegment) glfwGetWindowTitle
     public static void glfwSetWindowTitle(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("const char*") java.lang.String title) {
         try (var __overrungl_stack = MemoryStack.pushLocal()) {
             Handles.MH_glfwSetWindowTitle.invokeExact(window, Marshal.marshal(__overrungl_stack, title));
         } catch (Throwable e) { throw new RuntimeException("error in glfwSetWindowTitle", e); }
     }
 
-    ///Sets the icon for the specified window.
-    ///
-    ///This function sets the icon of the specified window.  If passed an array of
-    ///candidate images, those of or closest to the sizes desired by the system are
-    ///selected.  If no images are specified, the window reverts to its default
-    ///icon.
-    ///
-    ///The pixels are 32-bit, little-endian, non-premultiplied RGBA, i.e. eight
-    ///bits per channel with the red channel first.  They are arranged canonically
-    ///as packed sequential rows, starting from the top-left corner.
-    ///
-    ///The desired image sizes varies depending on platform and system settings.
-    ///The selected images will be rescaled as needed.  Good sizes include 16x16,
-    ///32x32 and 48x48.
-    ///
-    ///@param window The window whose icon to set.
-    ///@param count The number of images in the specified array, or zero to
-    ///revert to the default window icon.
-    ///@param images The images to create the icon from.  This is ignored if
-    ///count is zero.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED],
-    ///[GLFW_INVALID_VALUE][#GLFW_INVALID_VALUE], [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR] and
-    ///[GLFW_FEATURE_UNAVAILABLE][#GLFW_FEATURE_UNAVAILABLE] (see remarks).
-    ///
-    ///@glfw.pointer_lifetime The specified image data is copied before this function
-    ///returns.
-    ///
-    ///@glfw.remark
-    ///- __macOS:__ Regular windows do not have icons on macOS.  This function
-    ///    will emit [GLFW_FEATURE_UNAVAILABLE][#GLFW_FEATURE_UNAVAILABLE].  The dock icon will be the same as
-    ///    the application bundle's icon.  For more information on bundles, see the
-    ///    [Bundle Programming Guide](https://developer.apple.com/library/mac/documentation/CoreFoundation/Conceptual/CFBundles/) in the Mac Developer Library.
-    ///- __Wayland:__ There is no existing protocol to change an icon, the
-    ///    window will thus inherit the one defined in the application's desktop file.
-    ///    This function will emit [GLFW_FEATURE_UNAVAILABLE][#GLFW_FEATURE_UNAVAILABLE].
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
     public static void glfwSetWindowIcon(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("int") int count, @CType("const GLFWimage*") java.lang.foreign.MemorySegment images) {
         try {
             Handles.MH_glfwSetWindowIcon.invokeExact(window, count, images);
         } catch (Throwable e) { throw new RuntimeException("error in glfwSetWindowIcon", e); }
     }
 
-    ///Sets the icon for the specified window.
-    ///
-    ///This function sets the icon of the specified window.  If passed an array of
-    ///candidate images, those of or closest to the sizes desired by the system are
-    ///selected.  If no images are specified, the window reverts to its default
-    ///icon.
-    ///
-    ///The pixels are 32-bit, little-endian, non-premultiplied RGBA, i.e. eight
-    ///bits per channel with the red channel first.  They are arranged canonically
-    ///as packed sequential rows, starting from the top-left corner.
-    ///
-    ///The desired image sizes varies depending on platform and system settings.
-    ///The selected images will be rescaled as needed.  Good sizes include 16x16,
-    ///32x32 and 48x48.
-    ///
-    ///@param window The window whose icon to set.
-    ///@param count The number of images in the specified array, or zero to
-    ///revert to the default window icon.
-    ///@param images The images to create the icon from.  This is ignored if
-    ///count is zero.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED],
-    ///[GLFW_INVALID_VALUE][#GLFW_INVALID_VALUE], [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR] and
-    ///[GLFW_FEATURE_UNAVAILABLE][#GLFW_FEATURE_UNAVAILABLE] (see remarks).
-    ///
-    ///@glfw.pointer_lifetime The specified image data is copied before this function
-    ///returns.
-    ///
-    ///@glfw.remark
-    ///- __macOS:__ Regular windows do not have icons on macOS.  This function
-    ///    will emit [GLFW_FEATURE_UNAVAILABLE][#GLFW_FEATURE_UNAVAILABLE].  The dock icon will be the same as
-    ///    the application bundle's icon.  For more information on bundles, see the
-    ///    [Bundle Programming Guide](https://developer.apple.com/library/mac/documentation/CoreFoundation/Conceptual/CFBundles/) in the Mac Developer Library.
-    ///- __Wayland:__ There is no existing protocol to change an icon, the
-    ///    window will thus inherit the one defined in the application's desktop file.
-    ///    This function will emit [GLFW_FEATURE_UNAVAILABLE][#GLFW_FEATURE_UNAVAILABLE].
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
     public static void glfwSetWindowIcon(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("int") int count, @CType("const GLFWimage*") overrungl.glfw.GLFWImage images) {
         try {
             Handles.MH_glfwSetWindowIcon.invokeExact(window, count, Marshal.marshal(images));
         } catch (Throwable e) { throw new RuntimeException("error in glfwSetWindowIcon", e); }
     }
 
-    ///Retrieves the position of the content area of the specified window.
-    ///
-    ///This function retrieves the position, in screen coordinates, of the
-    ///upper-left corner of the content area of the specified window.
-    ///
-    ///Any or all of the position arguments may be `NULL`.  If an error occurs, all
-    ///non-`NULL` position arguments will be set to zero.
-    ///
-    ///@param window The window to query.
-    ///@param xpos Where to store the x-coordinate of the upper-left corner of
-    ///the content area, or `NULL`.
-    ///@param ypos Where to store the y-coordinate of the upper-left corner of
-    ///the content area, or `NULL`.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED],
-    ///[GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR] and [GLFW_FEATURE_UNAVAILABLE][#GLFW_FEATURE_UNAVAILABLE] (see remarks).
-    ///
-    ///@glfw.remark __Wayland:__ There is no way for an application to retrieve the global
-    ///position of its windows.  This function will emit
-    ///[GLFW_FEATURE_UNAVAILABLE][#GLFW_FEATURE_UNAVAILABLE].
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
-    ///
-    ///@see #glfwSetWindowPos(MemorySegment, int, int) glfwSetWindowPos
     public static void glfwGetWindowPos(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @Out @CType("int*") java.lang.foreign.MemorySegment xpos, @Out @CType("int*") java.lang.foreign.MemorySegment ypos) {
         try {
             Handles.MH_glfwGetWindowPos.invokeExact(window, xpos, ypos);
         } catch (Throwable e) { throw new RuntimeException("error in glfwGetWindowPos", e); }
     }
 
-    ///Retrieves the position of the content area of the specified window.
-    ///
-    ///This function retrieves the position, in screen coordinates, of the
-    ///upper-left corner of the content area of the specified window.
-    ///
-    ///Any or all of the position arguments may be `NULL`.  If an error occurs, all
-    ///non-`NULL` position arguments will be set to zero.
-    ///
-    ///@param window The window to query.
-    ///@param xpos Where to store the x-coordinate of the upper-left corner of
-    ///the content area, or `NULL`.
-    ///@param ypos Where to store the y-coordinate of the upper-left corner of
-    ///the content area, or `NULL`.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED],
-    ///[GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR] and [GLFW_FEATURE_UNAVAILABLE][#GLFW_FEATURE_UNAVAILABLE] (see remarks).
-    ///
-    ///@glfw.remark __Wayland:__ There is no way for an application to retrieve the global
-    ///position of its windows.  This function will emit
-    ///[GLFW_FEATURE_UNAVAILABLE][#GLFW_FEATURE_UNAVAILABLE].
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
-    ///
-    ///@see #glfwSetWindowPos(MemorySegment, int, int) glfwSetWindowPos
     public static void glfwGetWindowPos(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @Out @CType("int*") int[] xpos, @Out @CType("int*") int[] ypos) {
         try (var __overrungl_stack = MemoryStack.pushLocal()) {
             var __overrungl_ref_xpos = Marshal.marshal(__overrungl_stack, xpos);
@@ -3385,86 +1008,18 @@ public final class GLFW {
         } catch (Throwable e) { throw new RuntimeException("error in glfwGetWindowPos", e); }
     }
 
-    ///Sets the position of the content area of the specified window.
-    ///
-    ///This function sets the position, in screen coordinates, of the upper-left
-    ///corner of the content area of the specified windowed mode window.  If the
-    ///window is a full screen window, this function does nothing.
-    ///
-    ///__Do not use this function__ to move an already visible window unless you
-    ///have very good reasons for doing so, as it will confuse and annoy the user.
-    ///
-    ///The window manager may put limits on what positions are allowed.  GLFW
-    ///cannot and should not override these limits.
-    ///
-    ///@param window The window to query.
-    ///@param xpos The x-coordinate of the upper-left corner of the content area.
-    ///@param ypos The y-coordinate of the upper-left corner of the content area.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED],
-    ///[GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR] and [GLFW_FEATURE_UNAVAILABLE][#GLFW_FEATURE_UNAVAILABLE] (see remarks).
-    ///
-    ///@glfw.remark __Wayland:__ There is no way for an application to set the global
-    ///position of its windows.  This function will emit
-    ///[GLFW_FEATURE_UNAVAILABLE][#GLFW_FEATURE_UNAVAILABLE].
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
-    ///
-    ///@see #glfwGetWindowPos(MemorySegment, MemorySegment, MemorySegment) glfwGetWindowPos
     public static void glfwSetWindowPos(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("int") int xpos, @CType("int") int ypos) {
         try {
             Handles.MH_glfwSetWindowPos.invokeExact(window, xpos, ypos);
         } catch (Throwable e) { throw new RuntimeException("error in glfwSetWindowPos", e); }
     }
 
-    ///Retrieves the size of the content area of the specified window.
-    ///
-    ///This function retrieves the size, in screen coordinates, of the content area
-    ///of the specified window.  If you wish to retrieve the size of the
-    ///framebuffer of the window in pixels, see [glfwGetFramebufferSize][#glfwGetFramebufferSize(MemorySegment, MemorySegment, MemorySegment)].
-    ///
-    ///Any or all of the size arguments may be `NULL`.  If an error occurs, all
-    ///non-`NULL` size arguments will be set to zero.
-    ///
-    ///@param window The window whose size to retrieve.
-    ///@param width Where to store the width, in screen coordinates, of the
-    ///content area, or `NULL`.
-    ///@param height Where to store the height, in screen coordinates, of the
-    ///content area, or `NULL`.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-    ///[GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
-    ///
-    ///@see #glfwSetWindowSize(MemorySegment, int, int) glfwSetWindowSize
     public static void glfwGetWindowSize(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @Out @CType("int*") java.lang.foreign.MemorySegment width, @Out @CType("int*") java.lang.foreign.MemorySegment height) {
         try {
             Handles.MH_glfwGetWindowSize.invokeExact(window, width, height);
         } catch (Throwable e) { throw new RuntimeException("error in glfwGetWindowSize", e); }
     }
 
-    ///Retrieves the size of the content area of the specified window.
-    ///
-    ///This function retrieves the size, in screen coordinates, of the content area
-    ///of the specified window.  If you wish to retrieve the size of the
-    ///framebuffer of the window in pixels, see [glfwGetFramebufferSize][#glfwGetFramebufferSize(MemorySegment, MemorySegment, MemorySegment)].
-    ///
-    ///Any or all of the size arguments may be `NULL`.  If an error occurs, all
-    ///non-`NULL` size arguments will be set to zero.
-    ///
-    ///@param window The window whose size to retrieve.
-    ///@param width Where to store the width, in screen coordinates, of the
-    ///content area, or `NULL`.
-    ///@param height Where to store the height, in screen coordinates, of the
-    ///content area, or `NULL`.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-    ///[GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
-    ///
-    ///@see #glfwSetWindowSize(MemorySegment, int, int) glfwSetWindowSize
     public static void glfwGetWindowSize(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @Out @CType("int*") int[] width, @Out @CType("int*") int[] height) {
         try (var __overrungl_stack = MemoryStack.pushLocal()) {
             var __overrungl_ref_width = Marshal.marshal(__overrungl_stack, width);
@@ -3475,169 +1030,30 @@ public final class GLFW {
         } catch (Throwable e) { throw new RuntimeException("error in glfwGetWindowSize", e); }
     }
 
-    ///Sets the size limits of the specified window.
-    ///
-    ///This function sets the size limits of the content area of the specified
-    ///window.  If the window is full screen, the size limits only take effect
-    ///once it is made windowed.  If the window is not resizable, this function
-    ///does nothing.
-    ///
-    ///The size limits are applied immediately to a windowed mode window and may
-    ///cause it to be resized.
-    ///
-    ///The maximum dimensions must be greater than or equal to the minimum
-    ///dimensions and all must be greater than or equal to zero.
-    ///
-    ///@param window The window to set limits for.
-    ///@param minwidth The minimum width, in screen coordinates, of the content
-    ///area, or `GLFW_DONT_CARE`.
-    ///@param minheight The minimum height, in screen coordinates, of the
-    ///content area, or `GLFW_DONT_CARE`.
-    ///@param maxwidth The maximum width, in screen coordinates, of the content
-    ///area, or `GLFW_DONT_CARE`.
-    ///@param maxheight The maximum height, in screen coordinates, of the
-    ///content area, or `GLFW_DONT_CARE`.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED],
-    ///[GLFW_INVALID_VALUE][#GLFW_INVALID_VALUE] and [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-    ///
-    ///@glfw.remark If you set size limits and an aspect ratio that conflict, the
-    ///results are undefined.
-    ///- __Wayland:__ The size limits will not be applied until the window is
-    ///actually resized, either by the user or by the compositor.
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
-    ///
-    ///@see #glfwSetWindowAspectRatio(MemorySegment, int, int) glfwSetWindowAspectRatio
     public static void glfwSetWindowSizeLimits(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("int") int minwidth, @CType("int") int minheight, @CType("int") int maxwidth, @CType("int") int maxheight) {
         try {
             Handles.MH_glfwSetWindowSizeLimits.invokeExact(window, minwidth, minheight, maxwidth, maxheight);
         } catch (Throwable e) { throw new RuntimeException("error in glfwSetWindowSizeLimits", e); }
     }
 
-    ///Sets the aspect ratio of the specified window.
-    ///
-    ///This function sets the required aspect ratio of the content area of the
-    ///specified window.  If the window is full screen, the aspect ratio only takes
-    ///effect once it is made windowed.  If the window is not resizable, this
-    ///function does nothing.
-    ///
-    ///The aspect ratio is specified as a numerator and a denominator and both
-    ///values must be greater than zero.  For example, the common 16:9 aspect ratio
-    ///is specified as 16 and 9, respectively.
-    ///
-    ///If the numerator and denominator is set to `GLFW_DONT_CARE` then the aspect
-    ///ratio limit is disabled.
-    ///
-    ///The aspect ratio is applied immediately to a windowed mode window and may
-    ///cause it to be resized.
-    ///
-    ///@param window The window to set limits for.
-    ///@param numer The numerator of the desired aspect ratio, or
-    ///`GLFW_DONT_CARE`.
-    ///@param denom The denominator of the desired aspect ratio, or
-    ///`GLFW_DONT_CARE`.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED],
-    ///[GLFW_INVALID_VALUE][#GLFW_INVALID_VALUE] and [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-    ///
-    ///@glfw.remark If you set size limits and an aspect ratio that conflict, the
-    ///results are undefined.
-    ///- __Wayland:__ The aspect ratio will not be applied until the window is
-    ///actually resized, either by the user or by the compositor.
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
-    ///
-    ///@see #glfwSetWindowSizeLimits(MemorySegment, int, int, int, int) glfwSetWindowSizeLimits
     public static void glfwSetWindowAspectRatio(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("int") int numer, @CType("int") int denom) {
         try {
             Handles.MH_glfwSetWindowAspectRatio.invokeExact(window, numer, denom);
         } catch (Throwable e) { throw new RuntimeException("error in glfwSetWindowAspectRatio", e); }
     }
 
-    ///Sets the size of the content area of the specified window.
-    ///
-    ///This function sets the size, in screen coordinates, of the content area of
-    ///the specified window.
-    ///
-    ///For full screen windows, this function updates the resolution of its desired
-    ///video mode and switches to the video mode closest to it, without affecting
-    ///the window's context.  As the context is unaffected, the bit depths of the
-    ///framebuffer remain unchanged.
-    ///
-    ///If you wish to update the refresh rate of the desired video mode in addition
-    ///to its resolution, see [glfwSetWindowMonitor][#glfwSetWindowMonitor(MemorySegment, MemorySegment, int, int, int, int, int)].
-    ///
-    ///The window manager may put limits on what sizes are allowed.  GLFW cannot
-    ///and should not override these limits.
-    ///
-    ///@param window The window to resize.
-    ///@param width The desired width, in screen coordinates, of the window
-    ///content area.
-    ///@param height The desired height, in screen coordinates, of the window
-    ///content area.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-    ///[GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
-    ///
-    ///@see #glfwGetWindowSize(MemorySegment, MemorySegment, MemorySegment) glfwGetWindowSize
-    ///@see #glfwSetWindowMonitor(MemorySegment, MemorySegment, int, int, int, int, int) glfwSetWindowMonitor
     public static void glfwSetWindowSize(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("int") int width, @CType("int") int height) {
         try {
             Handles.MH_glfwSetWindowSize.invokeExact(window, width, height);
         } catch (Throwable e) { throw new RuntimeException("error in glfwSetWindowSize", e); }
     }
 
-    ///Retrieves the size of the framebuffer of the specified window.
-    ///
-    ///This function retrieves the size, in pixels, of the framebuffer of the
-    ///specified window.  If you wish to retrieve the size of the window in screen
-    ///coordinates, see [glfwGetWindowSize][#glfwGetWindowSize(MemorySegment, MemorySegment, MemorySegment)].
-    ///
-    ///Any or all of the size arguments may be `NULL`.  If an error occurs, all
-    ///non-`NULL` size arguments will be set to zero.
-    ///
-    ///@param window The window whose framebuffer to query.
-    ///@param width Where to store the width, in pixels, of the framebuffer,
-    ///or `NULL`.
-    ///@param height Where to store the height, in pixels, of the framebuffer,
-    ///or `NULL`.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-    ///[GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
-    ///
-    ///@see #glfwSetFramebufferSizeCallback(MemorySegment, MemorySegment) glfwSetFramebufferSizeCallback
     public static void glfwGetFramebufferSize(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @Out @CType("int*") java.lang.foreign.MemorySegment width, @Out @CType("int*") java.lang.foreign.MemorySegment height) {
         try {
             Handles.MH_glfwGetFramebufferSize.invokeExact(window, width, height);
         } catch (Throwable e) { throw new RuntimeException("error in glfwGetFramebufferSize", e); }
     }
 
-    ///Retrieves the size of the framebuffer of the specified window.
-    ///
-    ///This function retrieves the size, in pixels, of the framebuffer of the
-    ///specified window.  If you wish to retrieve the size of the window in screen
-    ///coordinates, see [glfwGetWindowSize][#glfwGetWindowSize(MemorySegment, MemorySegment, MemorySegment)].
-    ///
-    ///Any or all of the size arguments may be `NULL`.  If an error occurs, all
-    ///non-`NULL` size arguments will be set to zero.
-    ///
-    ///@param window The window whose framebuffer to query.
-    ///@param width Where to store the width, in pixels, of the framebuffer,
-    ///or `NULL`.
-    ///@param height Where to store the height, in pixels, of the framebuffer,
-    ///or `NULL`.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-    ///[GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
-    ///
-    ///@see #glfwSetFramebufferSizeCallback(MemorySegment, MemorySegment) glfwSetFramebufferSizeCallback
     public static void glfwGetFramebufferSize(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @Out @CType("int*") int[] width, @Out @CType("int*") int[] height) {
         try (var __overrungl_stack = MemoryStack.pushLocal()) {
             var __overrungl_ref_width = Marshal.marshal(__overrungl_stack, width);
@@ -3648,68 +1064,12 @@ public final class GLFW {
         } catch (Throwable e) { throw new RuntimeException("error in glfwGetFramebufferSize", e); }
     }
 
-    ///Retrieves the size of the frame of the window.
-    ///
-    ///This function retrieves the size, in screen coordinates, of each edge of the
-    ///frame of the specified window.  This size includes the title bar, if the
-    ///window has one.  The size of the frame may vary depending on the
-    ///window-related hints used to create it.
-    ///
-    ///Because this function retrieves the size of each window frame edge and not
-    ///the offset along a particular coordinate axis, the retrieved values will
-    ///always be zero or positive.
-    ///
-    ///Any or all of the size arguments may be `NULL`.  If an error occurs, all
-    ///non-`NULL` size arguments will be set to zero.
-    ///
-    ///@param window The window whose frame size to query.
-    ///@param left Where to store the size, in screen coordinates, of the left
-    ///edge of the window frame, or `NULL`.
-    ///@param top Where to store the size, in screen coordinates, of the top
-    ///edge of the window frame, or `NULL`.
-    ///@param right Where to store the size, in screen coordinates, of the
-    ///right edge of the window frame, or `NULL`.
-    ///@param bottom Where to store the size, in screen coordinates, of the
-    ///bottom edge of the window frame, or `NULL`.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-    ///[GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
     public static void glfwGetWindowFrameSize(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @Out @CType("int*") java.lang.foreign.MemorySegment left, @Out @CType("int*") java.lang.foreign.MemorySegment top, @Out @CType("int*") java.lang.foreign.MemorySegment right, @Out @CType("int*") java.lang.foreign.MemorySegment bottom) {
         try {
             Handles.MH_glfwGetWindowFrameSize.invokeExact(window, left, top, right, bottom);
         } catch (Throwable e) { throw new RuntimeException("error in glfwGetWindowFrameSize", e); }
     }
 
-    ///Retrieves the size of the frame of the window.
-    ///
-    ///This function retrieves the size, in screen coordinates, of each edge of the
-    ///frame of the specified window.  This size includes the title bar, if the
-    ///window has one.  The size of the frame may vary depending on the
-    ///window-related hints used to create it.
-    ///
-    ///Because this function retrieves the size of each window frame edge and not
-    ///the offset along a particular coordinate axis, the retrieved values will
-    ///always be zero or positive.
-    ///
-    ///Any or all of the size arguments may be `NULL`.  If an error occurs, all
-    ///non-`NULL` size arguments will be set to zero.
-    ///
-    ///@param window The window whose frame size to query.
-    ///@param left Where to store the size, in screen coordinates, of the left
-    ///edge of the window frame, or `NULL`.
-    ///@param top Where to store the size, in screen coordinates, of the top
-    ///edge of the window frame, or `NULL`.
-    ///@param right Where to store the size, in screen coordinates, of the
-    ///right edge of the window frame, or `NULL`.
-    ///@param bottom Where to store the size, in screen coordinates, of the
-    ///bottom edge of the window frame, or `NULL`.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-    ///[GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
     public static void glfwGetWindowFrameSize(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @Out @CType("int*") int[] left, @Out @CType("int*") int[] top, @Out @CType("int*") int[] right, @Out @CType("int*") int[] bottom) {
         try (var __overrungl_stack = MemoryStack.pushLocal()) {
             var __overrungl_ref_left = Marshal.marshal(__overrungl_stack, left);
@@ -3724,62 +1084,12 @@ public final class GLFW {
         } catch (Throwable e) { throw new RuntimeException("error in glfwGetWindowFrameSize", e); }
     }
 
-    ///Retrieves the content scale for the specified window.
-    ///
-    ///This function retrieves the content scale for the specified window.  The
-    ///content scale is the ratio between the current DPI and the platform's
-    ///default DPI.  This is especially important for text and any UI elements.  If
-    ///the pixel dimensions of your UI scaled by this look appropriate on your
-    ///machine then it should appear at a reasonable size on other machines
-    ///regardless of their DPI and scaling settings.  This relies on the system DPI
-    ///and scaling settings being somewhat correct.
-    ///
-    ///On platforms where each monitors can have its own content scale, the window
-    ///content scale will depend on which monitor the system considers the window
-    ///to be on.
-    ///
-    ///@param window The window to query.
-    ///@param xscale Where to store the x-axis content scale, or `NULL`.
-    ///@param yscale Where to store the y-axis content scale, or `NULL`.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-    ///[GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
-    ///
-    ///@see #glfwSetWindowContentScaleCallback(MemorySegment, MemorySegment) glfwSetWindowContentScaleCallback
-    ///@see #glfwGetMonitorContentScale(MemorySegment, MemorySegment, MemorySegment) glfwGetMonitorContentScale
     public static void glfwGetWindowContentScale(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @Out @CType("float*") java.lang.foreign.MemorySegment xscale, @Out @CType("float*") java.lang.foreign.MemorySegment yscale) {
         try {
             Handles.MH_glfwGetWindowContentScale.invokeExact(window, xscale, yscale);
         } catch (Throwable e) { throw new RuntimeException("error in glfwGetWindowContentScale", e); }
     }
 
-    ///Retrieves the content scale for the specified window.
-    ///
-    ///This function retrieves the content scale for the specified window.  The
-    ///content scale is the ratio between the current DPI and the platform's
-    ///default DPI.  This is especially important for text and any UI elements.  If
-    ///the pixel dimensions of your UI scaled by this look appropriate on your
-    ///machine then it should appear at a reasonable size on other machines
-    ///regardless of their DPI and scaling settings.  This relies on the system DPI
-    ///and scaling settings being somewhat correct.
-    ///
-    ///On platforms where each monitors can have its own content scale, the window
-    ///content scale will depend on which monitor the system considers the window
-    ///to be on.
-    ///
-    ///@param window The window to query.
-    ///@param xscale Where to store the x-axis content scale, or `NULL`.
-    ///@param yscale Where to store the y-axis content scale, or `NULL`.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-    ///[GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
-    ///
-    ///@see #glfwSetWindowContentScaleCallback(MemorySegment, MemorySegment) glfwSetWindowContentScaleCallback
-    ///@see #glfwGetMonitorContentScale(MemorySegment, MemorySegment, MemorySegment) glfwGetMonitorContentScale
     public static void glfwGetWindowContentScale(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @Out @CType("float*") float[] xscale, @Out @CType("float*") float[] yscale) {
         try (var __overrungl_stack = MemoryStack.pushLocal()) {
             var __overrungl_ref_xscale = Marshal.marshal(__overrungl_stack, xscale);
@@ -3790,1437 +1100,264 @@ public final class GLFW {
         } catch (Throwable e) { throw new RuntimeException("error in glfwGetWindowContentScale", e); }
     }
 
-    ///Returns the opacity of the whole window.
-    ///
-    ///This function returns the opacity of the window, including any decorations.
-    ///
-    ///The opacity (or alpha) value is a positive finite number between zero and
-    ///one, where zero is fully transparent and one is fully opaque.  If the system
-    ///does not support whole window transparency, this function always returns one.
-    ///
-    ///The initial opacity value for newly created windows is one.
-    ///
-    ///@param window The window to query.
-    ///@return The opacity value of the specified window.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-    ///[GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
-    ///
-    ///@see #glfwSetWindowOpacity(MemorySegment, float) glfwSetWindowOpacity
     public static @CType("float") float glfwGetWindowOpacity(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window) {
         try {
             return (float) Handles.MH_glfwGetWindowOpacity.invokeExact(window);
         } catch (Throwable e) { throw new RuntimeException("error in glfwGetWindowOpacity", e); }
     }
 
-    ///Sets the opacity of the whole window.
-    ///
-    ///This function sets the opacity of the window, including any decorations.
-    ///
-    ///The opacity (or alpha) value is a positive finite number between zero and
-    ///one, where zero is fully transparent and one is fully opaque.
-    ///
-    ///The initial opacity value for newly created windows is one.
-    ///
-    ///A window created with framebuffer transparency may not use whole window
-    ///transparency.  The results of doing this are undefined.
-    ///
-    ///@param window The window to set the opacity for.
-    ///@param opacity The desired opacity of the specified window.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED],
-    ///[GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR] and [GLFW_FEATURE_UNAVAILABLE][#GLFW_FEATURE_UNAVAILABLE] (see remarks).
-    ///
-    ///@glfw.remark __Wayland:__ There is no way to set an opacity factor for a window.
-    ///This function will emit [GLFW_FEATURE_UNAVAILABLE][#GLFW_FEATURE_UNAVAILABLE].
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
-    ///
-    ///@see #glfwGetWindowOpacity(MemorySegment) glfwGetWindowOpacity
     public static void glfwSetWindowOpacity(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("float") float opacity) {
         try {
             Handles.MH_glfwSetWindowOpacity.invokeExact(window, opacity);
         } catch (Throwable e) { throw new RuntimeException("error in glfwSetWindowOpacity", e); }
     }
 
-    ///Iconifies the specified window.
-    ///
-    ///This function iconifies (minimizes) the specified window if it was
-    ///previously restored.  If the window is already iconified, this function does
-    ///nothing.
-    ///
-    ///If the specified window is a full screen window, GLFW restores the original
-    ///video mode of the monitor.  The window's desired video mode is set again
-    ///when the window is restored.
-    ///
-    ///@param window The window to iconify.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-    ///[GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-    ///
-    ///@glfw.remark __Wayland:__ Once a window is iconified, [glfwRestoreWindow][#glfwRestoreWindow(MemorySegment)] won't
-    ///be able to restore it.  This is a design decision of the xdg-shell
-    ///protocol.
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
-    ///
-    ///@see #glfwRestoreWindow(MemorySegment) glfwRestoreWindow
-    ///@see #glfwMaximizeWindow(MemorySegment) glfwMaximizeWindow
     public static void glfwIconifyWindow(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window) {
         try {
             Handles.MH_glfwIconifyWindow.invokeExact(window);
         } catch (Throwable e) { throw new RuntimeException("error in glfwIconifyWindow", e); }
     }
 
-    ///Restores the specified window.
-    ///
-    ///This function restores the specified window if it was previously iconified
-    ///(minimized) or maximized.  If the window is already restored, this function
-    ///does nothing.
-    ///
-    ///If the specified window is an iconified full screen window, its desired
-    ///video mode is set again for its monitor when the window is restored.
-    ///
-    ///@param window The window to restore.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-    ///[GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
-    ///
-    ///@see #glfwIconifyWindow(MemorySegment) glfwIconifyWindow
-    ///@see #glfwMaximizeWindow(MemorySegment) glfwMaximizeWindow
     public static void glfwRestoreWindow(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window) {
         try {
             Handles.MH_glfwRestoreWindow.invokeExact(window);
         } catch (Throwable e) { throw new RuntimeException("error in glfwRestoreWindow", e); }
     }
 
-    ///Maximizes the specified window.
-    ///
-    ///This function maximizes the specified window if it was previously not
-    ///maximized.  If the window is already maximized, this function does nothing.
-    ///
-    ///If the specified window is a full screen window, this function does nothing.
-    ///
-    ///@param window The window to maximize.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-    ///[GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-    ///
-    ///@glfw.thread_safety This function may only be called from the main thread.
-    ///
-    ///@see #glfwIconifyWindow(MemorySegment) glfwIconifyWindow
-    ///@see #glfwRestoreWindow(MemorySegment) glfwRestoreWindow
     public static void glfwMaximizeWindow(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window) {
         try {
             Handles.MH_glfwMaximizeWindow.invokeExact(window);
         } catch (Throwable e) { throw new RuntimeException("error in glfwMaximizeWindow", e); }
     }
 
-    ///Makes the specified window visible.
-    ///
-    ///This function makes the specified window visible if it was previously
-    ///hidden.  If the window is already visible or is in full screen mode, this
-    ///function does nothing.
-    ///
-    ///By default, windowed mode windows are focused when shown
-    ///Set the [GLFW_FOCUS_ON_SHOW][#GLFW_FOCUS_ON_SHOW] window hint
-    ///to change this behavior for all newly created windows, or change the
-    ///behavior for an existing window with [glfwSetWindowAttrib][#glfwSetWindowAttrib(MemorySegment, int, int)].
-    ///
-    ///@param window The window to make visible.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-    ///[GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-    ///
-    ///@glfw.remark __Wayland:__ Because Wayland wants every frame of the desktop to be
-    ///complete, this function does not immediately make the window visible.
-    ///Instead it will become visible the next time the window framebuffer is
-    ///updated after this call.
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
-    ///
-    ///@see #glfwHideWindow(MemorySegment) glfwHideWindow
     public static void glfwShowWindow(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window) {
         try {
             Handles.MH_glfwShowWindow.invokeExact(window);
         } catch (Throwable e) { throw new RuntimeException("error in glfwShowWindow", e); }
     }
 
-    ///Hides the specified window.
-    ///
-    ///This function hides the specified window if it was previously visible.  If
-    ///the window is already hidden or is in full screen mode, this function does
-    ///nothing.
-    ///
-    ///@param window The window to hide.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-    ///[GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
-    ///
-    ///@see #glfwShowWindow(MemorySegment) glfwShowWindow
     public static void glfwHideWindow(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window) {
         try {
             Handles.MH_glfwHideWindow.invokeExact(window);
         } catch (Throwable e) { throw new RuntimeException("error in glfwHideWindow", e); }
     }
 
-    ///Brings the specified window to front and sets input focus.
-    ///
-    ///This function brings the specified window to front and sets input focus.
-    ///The window should already be visible and not iconified.
-    ///
-    ///By default, both windowed and full screen mode windows are focused when
-    ///initially created.  Set the [GLFW_FOCUSED][#GLFW_FOCUSED] to
-    ///disable this behavior.
-    ///
-    ///Also by default, windowed mode windows are focused when shown
-    ///with [glfwShowWindow][#glfwShowWindow(MemorySegment)]. Set the
-    ///[GLFW_FOCUS_ON_SHOW][#GLFW_FOCUS_ON_SHOW] to disable this behavior.
-    ///
-    ///__Do not use this function__ to steal focus from other applications unless
-    ///you are certain that is what the user wants.  Focus stealing can be
-    ///extremely disruptive.
-    ///
-    ///For a less disruptive way of getting the user's attention, see
-    ///attention requests.
-    ///
-    ///@param window The window to give input focus.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-    ///[GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-    ///
-    ///@glfw.remark __Wayland:__ The compositor will likely ignore focus requests unless
-    ///another window created by the same application already has input focus.
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
     public static void glfwFocusWindow(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window) {
         try {
             Handles.MH_glfwFocusWindow.invokeExact(window);
         } catch (Throwable e) { throw new RuntimeException("error in glfwFocusWindow", e); }
     }
 
-    ///Requests user attention to the specified window.
-    ///
-    ///This function requests user attention to the specified window.  On
-    ///platforms where this is not supported, attention is requested to the
-    ///application as a whole.
-    ///
-    ///Once the user has given attention, usually by focusing the window or
-    ///application, the system will end the request automatically.
-    ///
-    ///@param window The window to request attention to.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-    ///[GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-    ///
-    ///@glfw.remark __macOS:__ Attention is requested to the application as a whole, not the
-    ///specific window.
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
     public static void glfwRequestWindowAttention(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window) {
         try {
             Handles.MH_glfwRequestWindowAttention.invokeExact(window);
         } catch (Throwable e) { throw new RuntimeException("error in glfwRequestWindowAttention", e); }
     }
 
-    ///Returns the monitor that the window uses for full screen mode.
-    ///
-    ///This function returns the handle of the monitor that the specified window is
-    ///in full screen on.
-    ///
-    ///@param window The window to query.
-    ///@return The monitor, or `NULL` if the window is in windowed mode or an
-    ///error occurred.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
-    ///
-    ///@see #glfwSetWindowMonitor(MemorySegment, MemorySegment, int, int, int, int, int) glfwSetWindowMonitor
     public static @CType("GLFWmonitor*") java.lang.foreign.MemorySegment glfwGetWindowMonitor(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window) {
         try {
             return (java.lang.foreign.MemorySegment) Handles.MH_glfwGetWindowMonitor.invokeExact(window);
         } catch (Throwable e) { throw new RuntimeException("error in glfwGetWindowMonitor", e); }
     }
 
-    ///Sets the mode, monitor, video mode and placement of a window.
-    ///
-    ///This function sets the monitor that the window uses for full screen mode or,
-    ///if the monitor is `NULL`, makes it windowed mode.
-    ///
-    ///When setting a monitor, this function updates the width, height and refresh
-    ///rate of the desired video mode and switches to the video mode closest to it.
-    ///The window position is ignored when setting a monitor.
-    ///
-    ///When the monitor is `NULL`, the position, width and height are used to
-    ///place the window content area.  The refresh rate is ignored when no monitor
-    ///is specified.
-    ///
-    ///If you only wish to update the resolution of a full screen window or the
-    ///size of a windowed mode window, see [glfwSetWindowSize][#glfwSetWindowSize(MemorySegment, int, int)].
-    ///
-    ///When a window transitions from full screen to windowed mode, this function
-    ///restores any previous window settings such as whether it is decorated,
-    ///floating, resizable, has size or aspect ratio limits, etc.
-    ///
-    ///@param window The window whose monitor, size or video mode to set.
-    ///@param monitor The desired monitor, or `NULL` to set windowed mode.
-    ///@param xpos The desired x-coordinate of the upper-left corner of the
-    ///content area.
-    ///@param ypos The desired y-coordinate of the upper-left corner of the
-    ///content area.
-    ///@param width The desired with, in screen coordinates, of the content
-    ///area or video mode.
-    ///@param height The desired height, in screen coordinates, of the content
-    ///area or video mode.
-    ///@param refreshRate The desired refresh rate, in Hz, of the video mode,
-    ///or `GLFW_DONT_CARE`.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-    ///[GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-    ///
-    ///@glfw.remark The OpenGL or OpenGL ES context will not be destroyed or otherwise
-    ///affected by any resizing or mode switching, although you may need to update
-    ///your viewport if the framebuffer size has changed.
-    ///- __Wayland:__ The desired window position is ignored, as there is no way
-    ///    for an application to set this property.
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
     public static void glfwSetWindowMonitor(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("GLFWmonitor*") java.lang.foreign.MemorySegment monitor, @CType("int") int xpos, @CType("int") int ypos, @CType("int") int width, @CType("int") int height, @CType("int") int refreshRate) {
         try {
             Handles.MH_glfwSetWindowMonitor.invokeExact(window, monitor, xpos, ypos, width, height, refreshRate);
         } catch (Throwable e) { throw new RuntimeException("error in glfwSetWindowMonitor", e); }
     }
 
-    ///Returns an attribute of the specified window.
-    ///
-    ///This function returns the value of an attribute of the specified window or
-    ///its OpenGL or OpenGL ES context.
-    ///
-    ///@param window The window to query.
-    ///@param attrib The window attribute whose value to
-    ///return.
-    ///@return The value of the attribute, or zero if an
-    ///error occurred.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED],
-    ///[GLFW_INVALID_ENUM][#GLFW_INVALID_ENUM] and [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-    ///
-    ///@glfw.remark Framebuffer related hints are not window attributes.  See
-    ///window_attribs_fb for more information.
-    ///
-    ///Zero is a valid value for many window and context related
-    ///attributes so you cannot use a return value of zero as an indication of
-    ///errors.  However, this function should not fail as long as it is passed
-    ///valid arguments and the library has been initialized.
-    ///- __Wayland:__ The Wayland protocol provides no way to check whether a
-    ///window is iconfied, so [GLFW_ICONIFIED][#GLFW_ICONIFIED] always returns `GLFW_FALSE`.
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
-    ///
-    ///@see #glfwSetWindowAttrib(MemorySegment, int, int) glfwSetWindowAttrib
     public static @CType("int") int glfwGetWindowAttrib(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("int") int attrib) {
         try {
             return (int) Handles.MH_glfwGetWindowAttrib.invokeExact(window, attrib);
         } catch (Throwable e) { throw new RuntimeException("error in glfwGetWindowAttrib", e); }
     }
 
-    ///Sets an attribute of the specified window.
-    ///
-    ///This function sets the value of an attribute of the specified window.
-    ///
-    ///The supported attributes are [GLFW_DECORATED][#GLFW_DECORATED],
-    ///[GLFW_RESIZABLE][#GLFW_RESIZABLE],
-    ///[GLFW_FLOATING][#GLFW_FLOATING],
-    ///[GLFW_AUTO_ICONIFY][#GLFW_AUTO_ICONIFY] and
-    ///[GLFW_FOCUS_ON_SHOW][#GLFW_FOCUS_ON_SHOW].
-    ///[GLFW_MOUSE_PASSTHROUGH][#GLFW_MOUSE_PASSTHROUGH]
-    ///
-    ///Some of these attributes are ignored for full screen windows.  The new
-    ///value will take effect if the window is later made windowed.
-    ///
-    ///Some of these attributes are ignored for windowed mode windows.  The new
-    ///value will take effect if the window is later made full screen.
-    ///
-    ///@param window The window to set the attribute for.
-    ///@param attrib A supported window attribute.
-    ///@param value `GLFW_TRUE` or `GLFW_FALSE`.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED],
-    ///[GLFW_INVALID_ENUM][#GLFW_INVALID_ENUM], [GLFW_INVALID_VALUE][#GLFW_INVALID_VALUE], [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR] and
-    ///[GLFW_FEATURE_UNAVAILABLE][#GLFW_FEATURE_UNAVAILABLE] (see remarks).
-    ///
-    ///@glfw.remark Calling glfwGetWindowAttrib will always return the latest
-    ///value, even if that value is ignored by the current mode of the window.
-    ///- __Wayland:__ The [GLFW_FLOATING][#GLFW_FLOATING] window attribute is
-    ///not supported.  Setting this will emit [GLFW_FEATURE_UNAVAILABLE][#GLFW_FEATURE_UNAVAILABLE].
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
-    ///
-    ///@see #glfwGetWindowAttrib(MemorySegment, int) glfwGetWindowAttrib
     public static void glfwSetWindowAttrib(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("int") int attrib, @CType("int") int value) {
         try {
             Handles.MH_glfwSetWindowAttrib.invokeExact(window, attrib, value);
         } catch (Throwable e) { throw new RuntimeException("error in glfwSetWindowAttrib", e); }
     }
 
-    ///Sets the user pointer of the specified window.
-    ///
-    ///This function sets the user-defined pointer of the specified window.  The
-    ///current value is retained until the window is destroyed.  The initial value
-    ///is `NULL`.
-    ///
-    ///@param window The window whose pointer to set.
-    ///@param pointer The new value.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-    ///
-    ///@glfw.thread_safety This function may be called from any thread.  Access is not
-    ///synchronized.
-    ///
-    ///@see #glfwGetWindowUserPointer(MemorySegment) glfwGetWindowUserPointer
     public static void glfwSetWindowUserPointer(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("void*") java.lang.foreign.MemorySegment pointer) {
         try {
             Handles.MH_glfwSetWindowUserPointer.invokeExact(window, pointer);
         } catch (Throwable e) { throw new RuntimeException("error in glfwSetWindowUserPointer", e); }
     }
 
-    ///Returns the user pointer of the specified window.
-    ///
-    ///This function returns the current value of the user-defined pointer of the
-    ///specified window.  The initial value is `NULL`.
-    ///
-    ///@param window The window whose pointer to return.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-    ///
-    ///@glfw.thread_safety This function may be called from any thread.  Access is not
-    ///synchronized.
-    ///
-    ///@see #glfwSetWindowUserPointer(MemorySegment, MemorySegment) glfwSetWindowUserPointer
     public static @CType("void*") java.lang.foreign.MemorySegment glfwGetWindowUserPointer(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window) {
         try {
             return (java.lang.foreign.MemorySegment) Handles.MH_glfwGetWindowUserPointer.invokeExact(window);
         } catch (Throwable e) { throw new RuntimeException("error in glfwGetWindowUserPointer", e); }
     }
 
-    ///Sets the position callback for the specified window.
-    ///
-    ///This function sets the position callback of the specified window, which is
-    ///called when the window is moved.  The callback is provided with the
-    ///position, in screen coordinates, of the upper-left corner of the content
-    ///area of the window.
-    ///
-    ///@param window The window whose callback to set.
-    ///@param callback The new callback, or `NULL` to remove the currently set
-    ///callback.
-    ///@return The previously set callback, or `NULL` if no callback was set or the
-    ///library had not been initialized.
-    ///
-    ///@glfw.callback_signature
-    ///For more information about the callback parameters, see the
-    ///[function pointer type][GLFWWindowPosFun].
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-    ///
-    ///@glfw.remark __Wayland:__ This callback will never be called, as there is no way for
-    ///an application to know its global position.
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
     public static @CType("GLFWwindowposfun") java.lang.foreign.MemorySegment glfwSetWindowPosCallback(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("GLFWwindowposfun") java.lang.foreign.MemorySegment callback) {
         try {
             return (java.lang.foreign.MemorySegment) Handles.MH_glfwSetWindowPosCallback.invokeExact(window, callback);
         } catch (Throwable e) { throw new RuntimeException("error in glfwSetWindowPosCallback", e); }
     }
 
-    ///Sets the position callback for the specified window.
-    ///
-    ///This function sets the position callback of the specified window, which is
-    ///called when the window is moved.  The callback is provided with the
-    ///position, in screen coordinates, of the upper-left corner of the content
-    ///area of the window.
-    ///
-    ///@param window The window whose callback to set.
-    ///@param callback The new callback, or `NULL` to remove the currently set
-    ///callback.
-    ///@return The previously set callback, or `NULL` if no callback was set or the
-    ///library had not been initialized.
-    ///
-    ///@glfw.callback_signature
-    ///For more information about the callback parameters, see the
-    ///[function pointer type][GLFWWindowPosFun].
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-    ///
-    ///@glfw.remark __Wayland:__ This callback will never be called, as there is no way for
-    ///an application to know its global position.
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
     public static @CType("GLFWwindowposfun") java.lang.foreign.MemorySegment glfwSetWindowPosCallback(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("GLFWwindowposfun") overrungl.glfw.GLFWWindowPosFun callback) {
         return glfwSetWindowPosCallback(window, callback != null ? callback.stub(GLFWCallbacks.create(window)) : MemorySegment.NULL);
     }
 
-    ///Sets the size callback for the specified window.
-    ///
-    ///This function sets the size callback of the specified window, which is
-    ///called when the window is resized.  The callback is provided with the size,
-    ///in screen coordinates, of the content area of the window.
-    ///
-    ///@param window The window whose callback to set.
-    ///@param callback The new callback, or `NULL` to remove the currently set
-    ///callback.
-    ///@return The previously set callback, or `NULL` if no callback was set or the
-    ///library had not been initialized.
-    ///
-    ///@glfw.callback_signature
-    ///For more information about the callback parameters, see the
-    ///[function pointer type][GLFWWindowSizeFun].
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
     public static @CType("GLFWwindowsizefun") java.lang.foreign.MemorySegment glfwSetWindowSizeCallback(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("GLFWwindowsizefun") java.lang.foreign.MemorySegment callback) {
         try {
             return (java.lang.foreign.MemorySegment) Handles.MH_glfwSetWindowSizeCallback.invokeExact(window, callback);
         } catch (Throwable e) { throw new RuntimeException("error in glfwSetWindowSizeCallback", e); }
     }
 
-    ///Sets the size callback for the specified window.
-    ///
-    ///This function sets the size callback of the specified window, which is
-    ///called when the window is resized.  The callback is provided with the size,
-    ///in screen coordinates, of the content area of the window.
-    ///
-    ///@param window The window whose callback to set.
-    ///@param callback The new callback, or `NULL` to remove the currently set
-    ///callback.
-    ///@return The previously set callback, or `NULL` if no callback was set or the
-    ///library had not been initialized.
-    ///
-    ///@glfw.callback_signature
-    ///For more information about the callback parameters, see the
-    ///[function pointer type][GLFWWindowSizeFun].
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
     public static @CType("GLFWwindowsizefun") java.lang.foreign.MemorySegment glfwSetWindowSizeCallback(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("GLFWwindowsizefun") overrungl.glfw.GLFWWindowSizeFun callback) {
         return glfwSetWindowSizeCallback(window, callback != null ? callback.stub(GLFWCallbacks.create(window)) : MemorySegment.NULL);
     }
 
-    ///Sets the close callback for the specified window.
-    ///
-    ///This function sets the close callback of the specified window, which is
-    ///called when the user attempts to close the window, for example by clicking
-    ///the close widget in the title bar.
-    ///
-    ///The close flag is set before this callback is called, but you can modify it
-    ///at any time with [glfwSetWindowShouldClose][#glfwSetWindowShouldClose(MemorySegment, boolean)].
-    ///
-    ///The close callback is not triggered by [glfwDestroyWindow][#glfwDestroyWindow(MemorySegment)].
-    ///
-    ///@param window The window whose callback to set.
-    ///@param callback The new callback, or `NULL` to remove the currently set
-    ///callback.
-    ///@return The previously set callback, or `NULL` if no callback was set or the
-    ///library had not been initialized.
-    ///
-    ///@glfw.callback_signature
-    ///For more information about the callback parameters, see the
-    ///[function pointer type][GLFWWindowCloseFun].
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-    ///
-    ///@glfw.remark __macOS:__ Selecting Quit from the application menu will trigger the
-    ///close callback for all windows.
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
     public static @CType("GLFWwindowclosefun") java.lang.foreign.MemorySegment glfwSetWindowCloseCallback(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("GLFWwindowclosefun") java.lang.foreign.MemorySegment callback) {
         try {
             return (java.lang.foreign.MemorySegment) Handles.MH_glfwSetWindowCloseCallback.invokeExact(window, callback);
         } catch (Throwable e) { throw new RuntimeException("error in glfwSetWindowCloseCallback", e); }
     }
 
-    ///Sets the close callback for the specified window.
-    ///
-    ///This function sets the close callback of the specified window, which is
-    ///called when the user attempts to close the window, for example by clicking
-    ///the close widget in the title bar.
-    ///
-    ///The close flag is set before this callback is called, but you can modify it
-    ///at any time with [glfwSetWindowShouldClose][#glfwSetWindowShouldClose(MemorySegment, boolean)].
-    ///
-    ///The close callback is not triggered by [glfwDestroyWindow][#glfwDestroyWindow(MemorySegment)].
-    ///
-    ///@param window The window whose callback to set.
-    ///@param callback The new callback, or `NULL` to remove the currently set
-    ///callback.
-    ///@return The previously set callback, or `NULL` if no callback was set or the
-    ///library had not been initialized.
-    ///
-    ///@glfw.callback_signature
-    ///For more information about the callback parameters, see the
-    ///[function pointer type][GLFWWindowCloseFun].
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-    ///
-    ///@glfw.remark __macOS:__ Selecting Quit from the application menu will trigger the
-    ///close callback for all windows.
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
     public static @CType("GLFWwindowclosefun") java.lang.foreign.MemorySegment glfwSetWindowCloseCallback(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("GLFWwindowclosefun") overrungl.glfw.GLFWWindowCloseFun callback) {
         return glfwSetWindowCloseCallback(window, callback != null ? callback.stub(GLFWCallbacks.create(window)) : MemorySegment.NULL);
     }
 
-    ///Sets the refresh callback for the specified window.
-    ///
-    ///This function sets the refresh callback of the specified window, which is
-    ///called when the content area of the window needs to be redrawn, for example
-    ///if the window has been exposed after having been covered by another window.
-    ///
-    ///On compositing window systems such as Aero, Compiz, Aqua or Wayland, where
-    ///the window contents are saved off-screen, this callback may be called only
-    ///very infrequently or never at all.
-    ///
-    ///@param window The window whose callback to set.
-    ///@param callback The new callback, or `NULL` to remove the currently set
-    ///callback.
-    ///@return The previously set callback, or `NULL` if no callback was set or the
-    ///library had not been initialized.
-    ///
-    ///@glfw.callback_signature
-    ///For more information about the callback parameters, see the
-    ///[function pointer type][GLFWWindowRefreshFun].
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
     public static @CType("GLFWwindowrefreshfun") java.lang.foreign.MemorySegment glfwSetWindowRefreshCallback(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("GLFWwindowrefreshfun") java.lang.foreign.MemorySegment callback) {
         try {
             return (java.lang.foreign.MemorySegment) Handles.MH_glfwSetWindowRefreshCallback.invokeExact(window, callback);
         } catch (Throwable e) { throw new RuntimeException("error in glfwSetWindowRefreshCallback", e); }
     }
 
-    ///Sets the refresh callback for the specified window.
-    ///
-    ///This function sets the refresh callback of the specified window, which is
-    ///called when the content area of the window needs to be redrawn, for example
-    ///if the window has been exposed after having been covered by another window.
-    ///
-    ///On compositing window systems such as Aero, Compiz, Aqua or Wayland, where
-    ///the window contents are saved off-screen, this callback may be called only
-    ///very infrequently or never at all.
-    ///
-    ///@param window The window whose callback to set.
-    ///@param callback The new callback, or `NULL` to remove the currently set
-    ///callback.
-    ///@return The previously set callback, or `NULL` if no callback was set or the
-    ///library had not been initialized.
-    ///
-    ///@glfw.callback_signature
-    ///For more information about the callback parameters, see the
-    ///[function pointer type][GLFWWindowRefreshFun].
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
     public static @CType("GLFWwindowrefreshfun") java.lang.foreign.MemorySegment glfwSetWindowRefreshCallback(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("GLFWwindowrefreshfun") overrungl.glfw.GLFWWindowRefreshFun callback) {
         return glfwSetWindowRefreshCallback(window, callback != null ? callback.stub(GLFWCallbacks.create(window)) : MemorySegment.NULL);
     }
 
-    ///Sets the focus callback for the specified window.
-    ///
-    ///This function sets the focus callback of the specified window, which is
-    ///called when the window gains or loses input focus.
-    ///
-    ///After the focus callback is called for a window that lost input focus,
-    ///synthetic key and mouse button release events will be generated for all such
-    ///that had been pressed.  For more information, see [glfwSetKeyCallback][#glfwSetKeyCallback(MemorySegment, MemorySegment)]
-    ///and [glfwSetMouseButtonCallback][#glfwSetMouseButtonCallback(MemorySegment, MemorySegment)].
-    ///
-    ///@param window The window whose callback to set.
-    ///@param callback The new callback, or `NULL` to remove the currently set
-    ///callback.
-    ///@return The previously set callback, or `NULL` if no callback was set or the
-    ///library had not been initialized.
-    ///
-    ///@glfw.callback_signature
-    ///For more information about the callback parameters, see the
-    ///[function pointer type][GLFWWindowFocusFun].
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
     public static @CType("GLFWwindowfocusfun") java.lang.foreign.MemorySegment glfwSetWindowFocusCallback(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("GLFWwindowfocusfun") java.lang.foreign.MemorySegment callback) {
         try {
             return (java.lang.foreign.MemorySegment) Handles.MH_glfwSetWindowFocusCallback.invokeExact(window, callback);
         } catch (Throwable e) { throw new RuntimeException("error in glfwSetWindowFocusCallback", e); }
     }
 
-    ///Sets the focus callback for the specified window.
-    ///
-    ///This function sets the focus callback of the specified window, which is
-    ///called when the window gains or loses input focus.
-    ///
-    ///After the focus callback is called for a window that lost input focus,
-    ///synthetic key and mouse button release events will be generated for all such
-    ///that had been pressed.  For more information, see [glfwSetKeyCallback][#glfwSetKeyCallback(MemorySegment, MemorySegment)]
-    ///and [glfwSetMouseButtonCallback][#glfwSetMouseButtonCallback(MemorySegment, MemorySegment)].
-    ///
-    ///@param window The window whose callback to set.
-    ///@param callback The new callback, or `NULL` to remove the currently set
-    ///callback.
-    ///@return The previously set callback, or `NULL` if no callback was set or the
-    ///library had not been initialized.
-    ///
-    ///@glfw.callback_signature
-    ///For more information about the callback parameters, see the
-    ///[function pointer type][GLFWWindowFocusFun].
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
     public static @CType("GLFWwindowfocusfun") java.lang.foreign.MemorySegment glfwSetWindowFocusCallback(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("GLFWwindowfocusfun") overrungl.glfw.GLFWWindowFocusFun callback) {
         return glfwSetWindowFocusCallback(window, callback != null ? callback.stub(GLFWCallbacks.create(window)) : MemorySegment.NULL);
     }
 
-    ///Sets the iconify callback for the specified window.
-    ///
-    ///This function sets the iconification callback of the specified window, which
-    ///is called when the window is iconified or restored.
-    ///
-    ///@param window The window whose callback to set.
-    ///@param callback The new callback, or `NULL` to remove the currently set
-    ///callback.
-    ///@return The previously set callback, or `NULL` if no callback was set or the
-    ///library had not been initialized.
-    ///
-    ///@glfw.callback_signature
-    ///For more information about the callback parameters, see the
-    ///[function pointer type][GLFWWindowIconifyFun].
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
     public static @CType("GLFWwindowiconifyfun") java.lang.foreign.MemorySegment glfwSetWindowIconifyCallback(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("GLFWwindowiconifyfun") java.lang.foreign.MemorySegment callback) {
         try {
             return (java.lang.foreign.MemorySegment) Handles.MH_glfwSetWindowIconifyCallback.invokeExact(window, callback);
         } catch (Throwable e) { throw new RuntimeException("error in glfwSetWindowIconifyCallback", e); }
     }
 
-    ///Sets the iconify callback for the specified window.
-    ///
-    ///This function sets the iconification callback of the specified window, which
-    ///is called when the window is iconified or restored.
-    ///
-    ///@param window The window whose callback to set.
-    ///@param callback The new callback, or `NULL` to remove the currently set
-    ///callback.
-    ///@return The previously set callback, or `NULL` if no callback was set or the
-    ///library had not been initialized.
-    ///
-    ///@glfw.callback_signature
-    ///For more information about the callback parameters, see the
-    ///[function pointer type][GLFWWindowIconifyFun].
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
     public static @CType("GLFWwindowiconifyfun") java.lang.foreign.MemorySegment glfwSetWindowIconifyCallback(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("GLFWwindowiconifyfun") overrungl.glfw.GLFWWindowIconifyFun callback) {
         return glfwSetWindowIconifyCallback(window, callback != null ? callback.stub(GLFWCallbacks.create(window)) : MemorySegment.NULL);
     }
 
-    ///Sets the maximize callback for the specified window.
-    ///
-    ///This function sets the maximization callback of the specified window, which
-    ///is called when the window is maximized or restored.
-    ///
-    ///@param window The window whose callback to set.
-    ///@param callback The new callback, or `NULL` to remove the currently set
-    ///callback.
-    ///@return The previously set callback, or `NULL` if no callback was set or the
-    ///library had not been initialized.
-    ///
-    ///@glfw.callback_signature
-    ///For more information about the callback parameters, see the
-    ///[function pointer type][GLFWWindowMaximizeFun].
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
     public static @CType("GLFWwindowmaximizefun") java.lang.foreign.MemorySegment glfwSetWindowMaximizeCallback(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("GLFWwindowmaximizefun") java.lang.foreign.MemorySegment callback) {
         try {
             return (java.lang.foreign.MemorySegment) Handles.MH_glfwSetWindowMaximizeCallback.invokeExact(window, callback);
         } catch (Throwable e) { throw new RuntimeException("error in glfwSetWindowMaximizeCallback", e); }
     }
 
-    ///Sets the maximize callback for the specified window.
-    ///
-    ///This function sets the maximization callback of the specified window, which
-    ///is called when the window is maximized or restored.
-    ///
-    ///@param window The window whose callback to set.
-    ///@param callback The new callback, or `NULL` to remove the currently set
-    ///callback.
-    ///@return The previously set callback, or `NULL` if no callback was set or the
-    ///library had not been initialized.
-    ///
-    ///@glfw.callback_signature
-    ///For more information about the callback parameters, see the
-    ///[function pointer type][GLFWWindowMaximizeFun].
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
     public static @CType("GLFWwindowmaximizefun") java.lang.foreign.MemorySegment glfwSetWindowMaximizeCallback(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("GLFWwindowmaximizefun") overrungl.glfw.GLFWWindowMaximizeFun callback) {
         return glfwSetWindowMaximizeCallback(window, callback != null ? callback.stub(GLFWCallbacks.create(window)) : MemorySegment.NULL);
     }
 
-    ///Sets the framebuffer resize callback for the specified window.
-    ///
-    ///This function sets the framebuffer resize callback of the specified window,
-    ///which is called when the framebuffer of the specified window is resized.
-    ///
-    ///@param window The window whose callback to set.
-    ///@param callback The new callback, or `NULL` to remove the currently set
-    ///callback.
-    ///@return The previously set callback, or `NULL` if no callback was set or the
-    ///library had not been initialized.
-    ///
-    ///@glfw.callback_signature
-    ///For more information about the callback parameters, see the
-    ///[function pointer type][GLFWFramebufferSizeFun].
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
     public static @CType("GLFWframebuffersizefun") java.lang.foreign.MemorySegment glfwSetFramebufferSizeCallback(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("GLFWframebuffersizefun") java.lang.foreign.MemorySegment callback) {
         try {
             return (java.lang.foreign.MemorySegment) Handles.MH_glfwSetFramebufferSizeCallback.invokeExact(window, callback);
         } catch (Throwable e) { throw new RuntimeException("error in glfwSetFramebufferSizeCallback", e); }
     }
 
-    ///Sets the framebuffer resize callback for the specified window.
-    ///
-    ///This function sets the framebuffer resize callback of the specified window,
-    ///which is called when the framebuffer of the specified window is resized.
-    ///
-    ///@param window The window whose callback to set.
-    ///@param callback The new callback, or `NULL` to remove the currently set
-    ///callback.
-    ///@return The previously set callback, or `NULL` if no callback was set or the
-    ///library had not been initialized.
-    ///
-    ///@glfw.callback_signature
-    ///For more information about the callback parameters, see the
-    ///[function pointer type][GLFWFramebufferSizeFun].
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
     public static @CType("GLFWframebuffersizefun") java.lang.foreign.MemorySegment glfwSetFramebufferSizeCallback(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("GLFWframebuffersizefun") overrungl.glfw.GLFWFramebufferSizeFun callback) {
         return glfwSetFramebufferSizeCallback(window, callback != null ? callback.stub(GLFWCallbacks.create(window)) : MemorySegment.NULL);
     }
 
-    ///Sets the window content scale callback for the specified window.
-    ///
-    ///This function sets the window content scale callback of the specified window,
-    ///which is called when the content scale of the specified window changes.
-    ///
-    ///@param window The window whose callback to set.
-    ///@param callback The new callback, or `NULL` to remove the currently set
-    ///callback.
-    ///@return The previously set callback, or `NULL` if no callback was set or the
-    ///library had not been initialized.
-    ///
-    ///@glfw.callback_signature
-    ///For more information about the callback parameters, see the
-    ///[function pointer type][GLFWWindowContentScaleFun].
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
     public static @CType("GLFWwindowcontentscalefun") java.lang.foreign.MemorySegment glfwSetWindowContentScaleCallback(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("GLFWwindowcontentscalefun") java.lang.foreign.MemorySegment callback) {
         try {
             return (java.lang.foreign.MemorySegment) Handles.MH_glfwSetWindowContentScaleCallback.invokeExact(window, callback);
         } catch (Throwable e) { throw new RuntimeException("error in glfwSetWindowContentScaleCallback", e); }
     }
 
-    ///Sets the window content scale callback for the specified window.
-    ///
-    ///This function sets the window content scale callback of the specified window,
-    ///which is called when the content scale of the specified window changes.
-    ///
-    ///@param window The window whose callback to set.
-    ///@param callback The new callback, or `NULL` to remove the currently set
-    ///callback.
-    ///@return The previously set callback, or `NULL` if no callback was set or the
-    ///library had not been initialized.
-    ///
-    ///@glfw.callback_signature
-    ///For more information about the callback parameters, see the
-    ///[function pointer type][GLFWWindowContentScaleFun].
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
     public static @CType("GLFWwindowcontentscalefun") java.lang.foreign.MemorySegment glfwSetWindowContentScaleCallback(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("GLFWwindowcontentscalefun") overrungl.glfw.GLFWWindowContentScaleFun callback) {
         return glfwSetWindowContentScaleCallback(window, callback != null ? callback.stub(GLFWCallbacks.create(window)) : MemorySegment.NULL);
     }
 
-    ///Processes all pending events.
-    ///
-    ///This function processes only those events that are already in the event
-    ///queue and then returns immediately.  Processing events will cause the window
-    ///and input callbacks associated with those events to be called.
-    ///
-    ///On some platforms, a window move, resize or menu operation will cause event
-    ///processing to block.  This is due to how event processing is designed on
-    ///those platforms.  You can use the
-    ///window refresh callback to redraw the contents of
-    ///your window when necessary during such operations.
-    ///
-    ///Do not assume that callbacks you set will _only_ be called in response to
-    ///event processing functions like this one.  While it is necessary to poll for
-    ///events, window systems that require GLFW to register callbacks of its own
-    ///can pass events to GLFW in response to many window system function calls.
-    ///GLFW will pass those events on to the application callbacks before
-    ///returning.
-    ///
-    ///Event processing is not required for joystick input to work.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-    ///[GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-    ///
-    ///@glfw.reentrancy This function must not be called from a callback.
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
-    ///
-    ///@see #glfwWaitEvents() glfwWaitEvents
-    ///@see #glfwWaitEventsTimeout(double) glfwWaitEventsTimeout
     public static void glfwPollEvents() {
         try {
             Handles.MH_glfwPollEvents.invokeExact();
         } catch (Throwable e) { throw new RuntimeException("error in glfwPollEvents", e); }
     }
 
-    ///Waits until events are queued and processes them.
-    ///
-    ///This function puts the calling thread to sleep until at least one event is
-    ///available in the event queue.  Once one or more events are available,
-    ///it behaves exactly like [glfwPollEvents][#glfwPollEvents()], i.e. the events in the queue
-    ///are processed and the function then returns immediately.  Processing events
-    ///will cause the window and input callbacks associated with those events to be
-    ///called.
-    ///
-    ///Since not all events are associated with callbacks, this function may return
-    ///without a callback having been called even if you are monitoring all
-    ///callbacks.
-    ///
-    ///On some platforms, a window move, resize or menu operation will cause event
-    ///processing to block.  This is due to how event processing is designed on
-    ///those platforms.  You can use the
-    ///window refresh callback to redraw the contents of
-    ///your window when necessary during such operations.
-    ///
-    ///Do not assume that callbacks you set will _only_ be called in response to
-    ///event processing functions like this one.  While it is necessary to poll for
-    ///events, window systems that require GLFW to register callbacks of its own
-    ///can pass events to GLFW in response to many window system function calls.
-    ///GLFW will pass those events on to the application callbacks before
-    ///returning.
-    ///
-    ///Event processing is not required for joystick input to work.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-    ///[GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-    ///
-    ///@glfw.reentrancy This function must not be called from a callback.
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
-    ///
-    ///@see #glfwPollEvents() glfwPollEvents
-    ///@see #glfwWaitEventsTimeout(double) glfwWaitEventsTimeout
     public static void glfwWaitEvents() {
         try {
             Handles.MH_glfwWaitEvents.invokeExact();
         } catch (Throwable e) { throw new RuntimeException("error in glfwWaitEvents", e); }
     }
 
-    ///Waits with timeout until events are queued and processes them.
-    ///
-    ///This function puts the calling thread to sleep until at least one event is
-    ///available in the event queue, or until the specified timeout is reached.  If
-    ///one or more events are available, it behaves exactly like
-    ///[glfwPollEvents][#glfwPollEvents()], i.e. the events in the queue are processed and the function
-    ///then returns immediately.  Processing events will cause the window and input
-    ///callbacks associated with those events to be called.
-    ///
-    ///The timeout value must be a positive finite number.
-    ///
-    ///Since not all events are associated with callbacks, this function may return
-    ///without a callback having been called even if you are monitoring all
-    ///callbacks.
-    ///
-    ///On some platforms, a window move, resize or menu operation will cause event
-    ///processing to block.  This is due to how event processing is designed on
-    ///those platforms.  You can use the
-    ///window refresh callback to redraw the contents of
-    ///your window when necessary during such operations.
-    ///
-    ///Do not assume that callbacks you set will _only_ be called in response to
-    ///event processing functions like this one.  While it is necessary to poll for
-    ///events, window systems that require GLFW to register callbacks of its own
-    ///can pass events to GLFW in response to many window system function calls.
-    ///GLFW will pass those events on to the application callbacks before
-    ///returning.
-    ///
-    ///Event processing is not required for joystick input to work.
-    ///
-    ///@param timeout The maximum amount of time, in seconds, to wait.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED],
-    ///[GLFW_INVALID_VALUE][#GLFW_INVALID_VALUE] and [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-    ///
-    ///@glfw.reentrancy This function must not be called from a callback.
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
-    ///
-    ///@see #glfwPollEvents() glfwPollEvents
-    ///@see #glfwWaitEvents() glfwWaitEvents
     public static void glfwWaitEventsTimeout(@CType("double") double timeout) {
         try {
             Handles.MH_glfwWaitEventsTimeout.invokeExact(timeout);
         } catch (Throwable e) { throw new RuntimeException("error in glfwWaitEventsTimeout", e); }
     }
 
-    ///Posts an empty event to the event queue.
-    ///
-    ///This function posts an empty event from the current thread to the event
-    ///queue, causing [glfwWaitEvents][#glfwWaitEvents()] or [glfwWaitEventsTimeout][#glfwWaitEventsTimeout(double)] to return.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-    ///[GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-    ///
-    ///@glfw.thread_safety This function may be called from any thread.
-    ///
-    ///@see #glfwWaitEvents() glfwWaitEvents
-    ///@see #glfwWaitEventsTimeout(double) glfwWaitEventsTimeout
     public static void glfwPostEmptyEvent() {
         try {
             Handles.MH_glfwPostEmptyEvent.invokeExact();
         } catch (Throwable e) { throw new RuntimeException("error in glfwPostEmptyEvent", e); }
     }
 
-    ///Returns the value of an input option for the specified window.
-    ///
-    ///This function returns the value of an input option for the specified window.
-    ///The mode must be one of [GLFW_CURSOR][#GLFW_CURSOR], [GLFW_STICKY_KEYS][#GLFW_STICKY_KEYS],
-    ///[GLFW_STICKY_MOUSE_BUTTONS][#GLFW_STICKY_MOUSE_BUTTONS], [GLFW_LOCK_KEY_MODS][#GLFW_LOCK_KEY_MODS] or
-    ///[GLFW_RAW_MOUSE_MOTION][#GLFW_RAW_MOUSE_MOTION].
-    ///
-    ///@param window The window to query.
-    ///@param mode One of `GLFW_CURSOR`, `GLFW_STICKY_KEYS`,
-    ///`GLFW_STICKY_MOUSE_BUTTONS`, `GLFW_LOCK_KEY_MODS` or
-    ///`GLFW_RAW_MOUSE_MOTION`.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-    ///[GLFW_INVALID_ENUM][#GLFW_INVALID_ENUM].
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
-    ///
-    ///@see #glfwSetInputMode(MemorySegment, int, int) glfwSetInputMode
     public static @CType("int") int glfwGetInputMode(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("int") int mode) {
         try {
             return (int) Handles.MH_glfwGetInputMode.invokeExact(window, mode);
         } catch (Throwable e) { throw new RuntimeException("error in glfwGetInputMode", e); }
     }
 
-    ///Sets an input option for the specified window.
-    ///
-    ///This function sets an input mode option for the specified window.  The mode
-    ///must be one of [GLFW_CURSOR][#GLFW_CURSOR], [GLFW_STICKY_KEYS][#GLFW_STICKY_KEYS],
-    ///[GLFW_STICKY_MOUSE_BUTTONS][#GLFW_STICKY_MOUSE_BUTTONS], [GLFW_LOCK_KEY_MODS][#GLFW_LOCK_KEY_MODS]
-    ///[GLFW_RAW_MOUSE_MOTION][#GLFW_RAW_MOUSE_MOTION], or [GLFW_UNLIMITED_MOUSE_BUTTONS][#GLFW_UNLIMITED_MOUSE_BUTTONS].
-    ///
-    ///If the mode is `GLFW_CURSOR`, the value must be one of the following cursor
-    ///modes:
-    ///- `GLFW_CURSOR_NORMAL` makes the cursor visible and behaving normally.
-    ///- `GLFW_CURSOR_HIDDEN` makes the cursor invisible when it is over the
-    ///  content area of the window but does not restrict the cursor from leaving.
-    ///- `GLFW_CURSOR_DISABLED` hides and grabs the cursor, providing virtual
-    ///  and unlimited cursor movement.  This is useful for implementing for
-    ///  example 3D camera controls.
-    ///- `GLFW_CURSOR_CAPTURED` makes the cursor visible and confines it to the
-    ///  content area of the window.
-    ///
-    ///If the mode is `GLFW_STICKY_KEYS`, the value must be either `GLFW_TRUE` to
-    ///enable sticky keys, or `GLFW_FALSE` to disable it.  If sticky keys are
-    ///enabled, a key press will ensure that [glfwGetKey][#glfwGetKey(MemorySegment, int)] returns `GLFW_PRESS`
-    ///the next time it is called even if the key had been released before the
-    ///call.  This is useful when you are only interested in whether keys have been
-    ///pressed but not when or in which order.
-    ///
-    ///If the mode is `GLFW_STICKY_MOUSE_BUTTONS`, the value must be either
-    ///`GLFW_TRUE` to enable sticky mouse buttons, or `GLFW_FALSE` to disable it.
-    ///If sticky mouse buttons are enabled, a mouse button press will ensure that
-    ///[glfwGetMouseButton][#glfwGetMouseButton(MemorySegment, int)] returns `GLFW_PRESS` the next time it is called even
-    ///if the mouse button had been released before the call.  This is useful when
-    ///you are only interested in whether mouse buttons have been pressed but not
-    ///when or in which order.
-    ///
-    ///If the mode is `GLFW_LOCK_KEY_MODS`, the value must be either `GLFW_TRUE` to
-    ///enable lock key modifier bits, or `GLFW_FALSE` to disable them.  If enabled,
-    ///callbacks that receive modifier bits will also have the
-    ///[GLFW_MOD_CAPS_LOCK][#GLFW_MOD_CAPS_LOCK] bit set when the event was generated with Caps Lock on,
-    ///and the [GLFW_MOD_NUM_LOCK][#GLFW_MOD_NUM_LOCK] bit when Num Lock was on.
-    ///
-    ///If the mode is `GLFW_RAW_MOUSE_MOTION`, the value must be either `GLFW_TRUE`
-    ///to enable raw (unscaled and unaccelerated) mouse motion when the cursor is
-    ///disabled, or `GLFW_FALSE` to disable it.  If raw motion is not supported,
-    ///attempting to set this will emit [GLFW_FEATURE_UNAVAILABLE][#GLFW_FEATURE_UNAVAILABLE].  Call
-    ///[glfwRawMouseMotionSupported][#glfwRawMouseMotionSupported()] to check for support.
-    ///
-    ///If the mode is `GLFW_UNLIMITED_MOUSE_BUTTONS`, the value must be either
-    ///`GLFW_TRUE` to disable the mouse button limit when calling the mouse button
-    ///callback, or `GLFW_FALSE` to limit the mouse buttons sent to the callback
-    ///to the mouse button token values up to `GLFW_MOUSE_BUTTON_LAST`.
-    ///
-    ///@param window The window whose input mode to set.
-    ///@param mode One of `GLFW_CURSOR`, `GLFW_STICKY_KEYS`,
-    ///`GLFW_STICKY_MOUSE_BUTTONS`, `GLFW_LOCK_KEY_MODS` or
-    ///`GLFW_RAW_MOUSE_MOTION`.
-    ///@param value The new value of the specified input mode.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED],
-    ///[GLFW_INVALID_ENUM][#GLFW_INVALID_ENUM], [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR] and
-    ///[GLFW_FEATURE_UNAVAILABLE][#GLFW_FEATURE_UNAVAILABLE] (see above).
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
-    ///
-    ///@see #glfwGetInputMode(MemorySegment, int) glfwGetInputMode
     public static void glfwSetInputMode(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("int") int mode, @CType("int") int value) {
         try {
             Handles.MH_glfwSetInputMode.invokeExact(window, mode, value);
         } catch (Throwable e) { throw new RuntimeException("error in glfwSetInputMode", e); }
     }
 
-    ///Returns whether raw mouse motion is supported.
-    ///
-    ///This function returns whether raw mouse motion is supported on the current
-    ///system.  This status does not change after GLFW has been initialized so you
-    ///only need to check this once.  If you attempt to enable raw motion on
-    ///a system that does not support it, [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR] will be emitted.
-    ///
-    ///Raw mouse motion is closer to the actual motion of the mouse across
-    ///a surface.  It is not affected by the scaling and acceleration applied to
-    ///the motion of the desktop cursor.  That processing is suitable for a cursor
-    ///while raw motion is better for controlling for example a 3D camera.  Because
-    ///of this, raw mouse motion is only provided when the cursor is disabled.
-    ///
-    ///@return `GLFW_TRUE` if raw mouse motion is supported on the current machine,
-    ///or `GLFW_FALSE` otherwise.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
-    ///
-    ///@see #glfwSetInputMode(MemorySegment, int, int) glfwSetInputMode
     public static @CType("int") boolean glfwRawMouseMotionSupported() {
         try {
             return (int) Handles.MH_glfwRawMouseMotionSupported.invokeExact() != GLFW.GLFW_FALSE;
         } catch (Throwable e) { throw new RuntimeException("error in glfwRawMouseMotionSupported", e); }
     }
 
-    ///Returns the layout-specific name of the specified printable key.
-    ///
-    ///This function returns the name of the specified printable key, encoded as
-    ///UTF-8.  This is typically the character that key would produce without any
-    ///modifier keys, intended for displaying key bindings to the user.  For dead
-    ///keys, it is typically the diacritic it would add to a character.
-    ///
-    ///__Do not use this function__ for text input.  You will
-    ///break text input for many languages even if it happens to work for yours.
-    ///
-    ///If the key is `GLFW_KEY_UNKNOWN`, the scancode is used to identify the key,
-    ///otherwise the scancode is ignored.  If you specify a non-printable key, or
-    ///`GLFW_KEY_UNKNOWN` and a scancode that maps to a non-printable key, this
-    ///function returns `NULL` but does not emit an error.
-    ///
-    ///This behavior allows you to always pass in the arguments in the
-    ///key callback without modification.
-    ///
-    ///The printable keys are:
-    ///- `GLFW_KEY_APOSTROPHE`
-    ///- `GLFW_KEY_COMMA`
-    ///- `GLFW_KEY_MINUS`
-    ///- `GLFW_KEY_PERIOD`
-    ///- `GLFW_KEY_SLASH`
-    ///- `GLFW_KEY_SEMICOLON`
-    ///- `GLFW_KEY_EQUAL`
-    ///- `GLFW_KEY_LEFT_BRACKET`
-    ///- `GLFW_KEY_RIGHT_BRACKET`
-    ///- `GLFW_KEY_BACKSLASH`
-    ///- `GLFW_KEY_WORLD_1`
-    ///- `GLFW_KEY_WORLD_2`
-    ///- `GLFW_KEY_0` to `GLFW_KEY_9`
-    ///- `GLFW_KEY_A` to `GLFW_KEY_Z`
-    ///- `GLFW_KEY_KP_0` to `GLFW_KEY_KP_9`
-    ///- `GLFW_KEY_KP_DECIMAL`
-    ///- `GLFW_KEY_KP_DIVIDE`
-    ///- `GLFW_KEY_KP_MULTIPLY`
-    ///- `GLFW_KEY_KP_SUBTRACT`
-    ///- `GLFW_KEY_KP_ADD`
-    ///- `GLFW_KEY_KP_EQUAL`
-    ///
-    ///Names for printable keys depend on keyboard layout, while names for
-    ///non-printable keys are the same across layouts but depend on the application
-    ///language and should be localized along with other user interface text.
-    ///
-    ///@param key The key to query, or `GLFW_KEY_UNKNOWN`.
-    ///@param scancode The scancode of the key to query.
-    ///@return The UTF-8 encoded, layout-specific name of the key, or `NULL`.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED],
-    ///[GLFW_INVALID_VALUE][#GLFW_INVALID_VALUE], [GLFW_INVALID_ENUM][#GLFW_INVALID_ENUM] and [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-    ///
-    ///@glfw.remark The contents of the returned string may change when a keyboard
-    ///layout change event is received.
-    ///
-    ///@glfw.pointer_lifetime The returned string is allocated and freed by GLFW.  You
-    ///should not free it yourself.  It is valid until the library is terminated.
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
     public static @CType("const char*") java.lang.foreign.MemorySegment glfwGetKeyName_(@CType("int") int key, @CType("int") int scancode) {
         try {
             return (java.lang.foreign.MemorySegment) Handles.MH_glfwGetKeyName.invokeExact(key, scancode);
         } catch (Throwable e) { throw new RuntimeException("error in glfwGetKeyName", e); }
     }
 
-    ///Returns the layout-specific name of the specified printable key.
-    ///
-    ///This function returns the name of the specified printable key, encoded as
-    ///UTF-8.  This is typically the character that key would produce without any
-    ///modifier keys, intended for displaying key bindings to the user.  For dead
-    ///keys, it is typically the diacritic it would add to a character.
-    ///
-    ///__Do not use this function__ for text input.  You will
-    ///break text input for many languages even if it happens to work for yours.
-    ///
-    ///If the key is `GLFW_KEY_UNKNOWN`, the scancode is used to identify the key,
-    ///otherwise the scancode is ignored.  If you specify a non-printable key, or
-    ///`GLFW_KEY_UNKNOWN` and a scancode that maps to a non-printable key, this
-    ///function returns `NULL` but does not emit an error.
-    ///
-    ///This behavior allows you to always pass in the arguments in the
-    ///key callback without modification.
-    ///
-    ///The printable keys are:
-    ///- `GLFW_KEY_APOSTROPHE`
-    ///- `GLFW_KEY_COMMA`
-    ///- `GLFW_KEY_MINUS`
-    ///- `GLFW_KEY_PERIOD`
-    ///- `GLFW_KEY_SLASH`
-    ///- `GLFW_KEY_SEMICOLON`
-    ///- `GLFW_KEY_EQUAL`
-    ///- `GLFW_KEY_LEFT_BRACKET`
-    ///- `GLFW_KEY_RIGHT_BRACKET`
-    ///- `GLFW_KEY_BACKSLASH`
-    ///- `GLFW_KEY_WORLD_1`
-    ///- `GLFW_KEY_WORLD_2`
-    ///- `GLFW_KEY_0` to `GLFW_KEY_9`
-    ///- `GLFW_KEY_A` to `GLFW_KEY_Z`
-    ///- `GLFW_KEY_KP_0` to `GLFW_KEY_KP_9`
-    ///- `GLFW_KEY_KP_DECIMAL`
-    ///- `GLFW_KEY_KP_DIVIDE`
-    ///- `GLFW_KEY_KP_MULTIPLY`
-    ///- `GLFW_KEY_KP_SUBTRACT`
-    ///- `GLFW_KEY_KP_ADD`
-    ///- `GLFW_KEY_KP_EQUAL`
-    ///
-    ///Names for printable keys depend on keyboard layout, while names for
-    ///non-printable keys are the same across layouts but depend on the application
-    ///language and should be localized along with other user interface text.
-    ///
-    ///@param key The key to query, or `GLFW_KEY_UNKNOWN`.
-    ///@param scancode The scancode of the key to query.
-    ///@return The UTF-8 encoded, layout-specific name of the key, or `NULL`.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED],
-    ///[GLFW_INVALID_VALUE][#GLFW_INVALID_VALUE], [GLFW_INVALID_ENUM][#GLFW_INVALID_ENUM] and [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-    ///
-    ///@glfw.remark The contents of the returned string may change when a keyboard
-    ///layout change event is received.
-    ///
-    ///@glfw.pointer_lifetime The returned string is allocated and freed by GLFW.  You
-    ///should not free it yourself.  It is valid until the library is terminated.
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
     public static @CType("const char*") java.lang.String glfwGetKeyName(@CType("int") int key, @CType("int") int scancode) {
         try {
             return Unmarshal.unmarshalAsString((java.lang.foreign.MemorySegment) Handles.MH_glfwGetKeyName.invokeExact(key, scancode));
         } catch (Throwable e) { throw new RuntimeException("error in glfwGetKeyName", e); }
     }
 
-    ///Returns the platform-specific scancode of the specified key.
-    ///
-    ///This function returns the platform-specific scancode of the specified key.
-    ///
-    ///If the specified key token corresponds to a physical key not
-    ///supported on the current platform then this method will return `-1`.
-    ///Calling this function with anything other than a key token will return `-1`
-    ///and generate a [GLFW_INVALID_ENUM][#GLFW_INVALID_ENUM] error.
-    ///
-    ///@param key Any key token.
-    ///@return The platform-specific scancode for the key, or `-1` if the key is
-    ///not supported on the current platform or an error
-    ///occurred.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-    ///[GLFW_INVALID_ENUM][#GLFW_INVALID_ENUM].
-    ///
-    ///@glfw.thread_safety This function may be called from any thread.
     public static @CType("int") int glfwGetKeyScancode(@CType("int") int key) {
         try {
             return (int) Handles.MH_glfwGetKeyScancode.invokeExact(key);
         } catch (Throwable e) { throw new RuntimeException("error in glfwGetKeyScancode", e); }
     }
 
-    ///Returns the last reported state of a keyboard key for the specified
-    ///window.
-    ///
-    ///This function returns the last state reported for the specified key to the
-    ///specified window.  The returned state is one of `GLFW_PRESS` or
-    ///`GLFW_RELEASE`.  The action `GLFW_REPEAT` is only reported to the key callback.
-    ///
-    ///If the [GLFW_STICKY_KEYS][#GLFW_STICKY_KEYS] input mode is enabled, this function returns
-    ///`GLFW_PRESS` the first time you call it for a key that was pressed, even if
-    ///that key has already been released.
-    ///
-    ///The key functions deal with physical keys, with key tokens
-    ///named after their use on the standard US keyboard layout.  If you want to
-    ///input text, use the Unicode character callback instead.
-    ///
-    ///The modifier key bit masks are not key tokens and cannot be
-    ///used with this function.
-    ///
-    ///__Do not use this function__ to implement text input.
-    ///
-    ///@param window The desired window.
-    ///@param key The desired keyboard key.  `GLFW_KEY_UNKNOWN` is
-    ///not a valid key for this function.
-    ///@return One of `GLFW_PRESS` or `GLFW_RELEASE`.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-    ///[GLFW_INVALID_ENUM][#GLFW_INVALID_ENUM].
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
     public static @CType("int") int glfwGetKey(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("int") int key) {
         try {
             return (int) Handles.MH_glfwGetKey.invokeExact(window, key);
         } catch (Throwable e) { throw new RuntimeException("error in glfwGetKey", e); }
     }
 
-    ///Returns the last reported state of a mouse button for the specified
-    ///window.
-    ///
-    ///This function returns the last state reported for the specified mouse button
-    ///to the specified window.  The returned state is one of `GLFW_PRESS` or
-    ///`GLFW_RELEASE`.
-    ///
-    ///If the [GLFW_STICKY_MOUSE_BUTTONS][#GLFW_STICKY_MOUSE_BUTTONS] input mode is enabled, this function
-    ///returns `GLFW_PRESS` the first time you call it for a mouse button that was
-    ///pressed, even if that mouse button has already been released.
-    ///
-    ///The [GLFW_UNLIMITED_MOUSE_BUTTONS][#GLFW_UNLIMITED_MOUSE_BUTTONS] input mode does not effect the
-    ///limit on buttons which can be polled with this function.
-    ///
-    ///@param window The desired window.
-    ///@param button The desired mouse button token.
-    ///@return One of `GLFW_PRESS` or `GLFW_RELEASE`.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-    ///[GLFW_INVALID_ENUM][#GLFW_INVALID_ENUM].
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
     public static @CType("int") int glfwGetMouseButton(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("int") int button) {
         try {
             return (int) Handles.MH_glfwGetMouseButton.invokeExact(window, button);
         } catch (Throwable e) { throw new RuntimeException("error in glfwGetMouseButton", e); }
     }
 
-    ///Retrieves the position of the cursor relative to the content area of
-    ///the window.
-    ///
-    ///This function returns the position of the cursor, in screen coordinates,
-    ///relative to the upper-left corner of the content area of the specified
-    ///window.
-    ///
-    ///If the cursor is disabled (with `GLFW_CURSOR_DISABLED`) then the cursor
-    ///position is unbounded and limited only by the minimum and maximum values of
-    ///a `double`.
-    ///
-    ///The coordinate can be converted to their integer equivalents with the
-    ///`floor` function.  Casting directly to an integer type works for positive
-    ///coordinates, but fails for negative ones.
-    ///
-    ///Any or all of the position arguments may be `NULL`.  If an error occurs, all
-    ///non-`NULL` position arguments will be set to zero.
-    ///
-    ///@param window The desired window.
-    ///@param xpos Where to store the cursor x-coordinate, relative to the
-    ///left edge of the content area, or `NULL`.
-    ///@param ypos Where to store the cursor y-coordinate, relative to the to
-    ///top edge of the content area, or `NULL`.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-    ///[GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
-    ///
-    ///@see #glfwSetCursorPos(MemorySegment, double, double) glfwSetCursorPos
     public static void glfwGetCursorPos(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @Out @CType("double*") java.lang.foreign.MemorySegment xpos, @Out @CType("double*") java.lang.foreign.MemorySegment ypos) {
         try {
             Handles.MH_glfwGetCursorPos.invokeExact(window, xpos, ypos);
         } catch (Throwable e) { throw new RuntimeException("error in glfwGetCursorPos", e); }
     }
 
-    ///Retrieves the position of the cursor relative to the content area of
-    ///the window.
-    ///
-    ///This function returns the position of the cursor, in screen coordinates,
-    ///relative to the upper-left corner of the content area of the specified
-    ///window.
-    ///
-    ///If the cursor is disabled (with `GLFW_CURSOR_DISABLED`) then the cursor
-    ///position is unbounded and limited only by the minimum and maximum values of
-    ///a `double`.
-    ///
-    ///The coordinate can be converted to their integer equivalents with the
-    ///`floor` function.  Casting directly to an integer type works for positive
-    ///coordinates, but fails for negative ones.
-    ///
-    ///Any or all of the position arguments may be `NULL`.  If an error occurs, all
-    ///non-`NULL` position arguments will be set to zero.
-    ///
-    ///@param window The desired window.
-    ///@param xpos Where to store the cursor x-coordinate, relative to the
-    ///left edge of the content area, or `NULL`.
-    ///@param ypos Where to store the cursor y-coordinate, relative to the to
-    ///top edge of the content area, or `NULL`.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-    ///[GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
-    ///
-    ///@see #glfwSetCursorPos(MemorySegment, double, double) glfwSetCursorPos
     public static void glfwGetCursorPos(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @Out @CType("double*") double[] xpos, @Out @CType("double*") double[] ypos) {
         try (var __overrungl_stack = MemoryStack.pushLocal()) {
             var __overrungl_ref_xpos = Marshal.marshal(__overrungl_stack, xpos);
@@ -5231,1762 +1368,320 @@ public final class GLFW {
         } catch (Throwable e) { throw new RuntimeException("error in glfwGetCursorPos", e); }
     }
 
-    ///Sets the position of the cursor, relative to the content area of the
-    ///window.
-    ///
-    ///This function sets the position, in screen coordinates, of the cursor
-    ///relative to the upper-left corner of the content area of the specified
-    ///window.  The window must have input focus.  If the window does not have
-    ///input focus when this function is called, it fails silently.
-    ///
-    ///__Do not use this function__ to implement things like camera controls.  GLFW
-    ///already provides the `GLFW_CURSOR_DISABLED` cursor mode that hides the
-    ///cursor, transparently re-centers it and provides unconstrained cursor
-    ///motion.  See [glfwSetInputMode][#glfwSetInputMode(MemorySegment, int, int)] for more information.
-    ///
-    ///If the cursor mode is `GLFW_CURSOR_DISABLED` then the cursor position is
-    ///unconstrained and limited only by the minimum and maximum values of
-    ///a `double`.
-    ///
-    ///@param window The desired window.
-    ///@param xpos The desired x-coordinate, relative to the left edge of the
-    ///content area.
-    ///@param ypos The desired y-coordinate, relative to the top edge of the
-    ///content area.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED],
-    ///[GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR] and [GLFW_FEATURE_UNAVAILABLE][#GLFW_FEATURE_UNAVAILABLE] (see remarks).
-    ///
-    ///@glfw.remark @wayland This function will only work when the cursor mode is
-    ///`GLFW_CURSOR_DISABLED`, otherwise it will emit [GLFW_FEATURE_UNAVAILABLE][#GLFW_FEATURE_UNAVAILABLE].
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
-    ///
-    ///@see #glfwGetCursorPos(MemorySegment, MemorySegment, MemorySegment) glfwGetCursorPos
     public static void glfwSetCursorPos(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("double") double xpos, @CType("double") double ypos) {
         try {
             Handles.MH_glfwSetCursorPos.invokeExact(window, xpos, ypos);
         } catch (Throwable e) { throw new RuntimeException("error in glfwSetCursorPos", e); }
     }
 
-    ///Creates a custom cursor.
-    ///
-    ///Creates a new custom cursor image that can be set for a window with
-    ///[glfwSetCursor][#glfwSetCursor(MemorySegment, MemorySegment)].  The cursor can be destroyed with [glfwDestroyCursor][#glfwDestroyCursor(MemorySegment)].
-    ///Any remaining cursors are destroyed by [glfwTerminate][#glfwTerminate()].
-    ///
-    ///The pixels are 32-bit, little-endian, non-premultiplied RGBA, i.e. eight
-    ///bits per channel with the red channel first.  They are arranged canonically
-    ///as packed sequential rows, starting from the top-left corner.
-    ///
-    ///The cursor hotspot is specified in pixels, relative to the upper-left corner
-    ///of the cursor image.  Like all other coordinate systems in GLFW, the X-axis
-    ///points to the right and the Y-axis points down.
-    ///
-    ///@param image The desired cursor image.
-    ///@param xhot The desired x-coordinate, in pixels, of the cursor hotspot.
-    ///@param yhot The desired y-coordinate, in pixels, of the cursor hotspot.
-    ///@return The handle of the created cursor, or `NULL` if an
-    ///error occurred.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED],
-    ///[GLFW_INVALID_VALUE][#GLFW_INVALID_VALUE] and [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-    ///
-    ///@glfw.pointer_lifetime The specified image data is copied before this function
-    ///returns.
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
-    ///
-    ///@see #glfwDestroyCursor(MemorySegment) glfwDestroyCursor
-    ///@see #glfwCreateStandardCursor(int) glfwCreateStandardCursor
     public static @CType("GLFWcursor*") java.lang.foreign.MemorySegment glfwCreateCursor(@CType("const GLFWimage*") java.lang.foreign.MemorySegment image, @CType("int") int xhot, @CType("int") int yhot) {
         try {
             return (java.lang.foreign.MemorySegment) Handles.MH_glfwCreateCursor.invokeExact(image, xhot, yhot);
         } catch (Throwable e) { throw new RuntimeException("error in glfwCreateCursor", e); }
     }
 
-    ///Creates a cursor with a standard shape.
-    ///
-    ///Returns a cursor with a standard shape, that can be set for a window with
-    ///[glfwSetCursor][#glfwSetCursor(MemorySegment, MemorySegment)].  The images for these cursors come from the system
-    ///cursor theme and their exact appearance will vary between platforms.
-    ///
-    ///Most of these shapes are guaranteed to exist on every supported platform but
-    ///a few may not be present.  See the table below for details.
-    ///
-    ///| Cursor shape                   | Windows | macOS | X11    | Wayland |
-    ///| ------------------------------ | ------- | ----- | ------ | ------- |
-    ///| [GLFW_ARROW_CURSOR][#GLFW_ARROW_CURSOR]         | Yes     | Yes   | Yes    | Yes |
-    ///| [GLFW_IBEAM_CURSOR][#GLFW_IBEAM_CURSOR]         | Yes     | Yes   | Yes    | Yes |
-    ///| [GLFW_CROSSHAIR_CURSOR][#GLFW_CROSSHAIR_CURSOR]     | Yes     | Yes   | Yes    | Yes |
-    ///| [GLFW_POINTING_HAND_CURSOR][#GLFW_POINTING_HAND_CURSOR] | Yes     | Yes   | Yes    | Yes |
-    ///| [GLFW_RESIZE_EW_CURSOR][#GLFW_RESIZE_EW_CURSOR]     | Yes     | Yes   | Yes    | Yes |
-    ///| [GLFW_RESIZE_NS_CURSOR][#GLFW_RESIZE_NS_CURSOR]     | Yes     | Yes   | Yes    | Yes |
-    ///| [GLFW_RESIZE_NWSE_CURSOR][#GLFW_RESIZE_NWSE_CURSOR]   | Yes     | Yes<sup>1</sup> | Maybe<sup>2</sup> | Maybe<sup>2</sup> |
-    ///| [GLFW_RESIZE_NESW_CURSOR][#GLFW_RESIZE_NESW_CURSOR]   | Yes     | Yes<sup>1</sup> | Maybe<sup>2</sup> | Maybe<sup>2</sup> |
-    ///| [GLFW_RESIZE_ALL_CURSOR][#GLFW_RESIZE_ALL_CURSOR]    | Yes     | Yes   | Yes    | Yes |
-    ///| [GLFW_NOT_ALLOWED_CURSOR][#GLFW_NOT_ALLOWED_CURSOR]   | Yes     | Yes   | Maybe<sup>2</sup> | Maybe<sup>2</sup> |
-    ///
-    ///1. This uses a private system API and may fail in the future.
-    ///2. This uses a newer standard that not all cursor themes support.
-    ///
-    ///If the requested shape is not available, this function emits a
-    ///[GLFW_CURSOR_UNAVAILABLE][#GLFW_CURSOR_UNAVAILABLE] error and returns `NULL`.
-    ///
-    ///@param shape One of the standard shapes.
-    ///@return A new cursor ready to use or `NULL` if an
-    ///error occurred.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED],
-    ///[GLFW_INVALID_ENUM][#GLFW_INVALID_ENUM], [GLFW_CURSOR_UNAVAILABLE][#GLFW_CURSOR_UNAVAILABLE] and
-    ///[GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
-    ///
-    ///@see #glfwCreateCursor(MemorySegment, int, int) glfwCreateCursor
     public static @CType("GLFWcursor*") java.lang.foreign.MemorySegment glfwCreateStandardCursor(@CType("int") int shape) {
         try {
             return (java.lang.foreign.MemorySegment) Handles.MH_glfwCreateStandardCursor.invokeExact(shape);
         } catch (Throwable e) { throw new RuntimeException("error in glfwCreateStandardCursor", e); }
     }
 
-    ///Destroys a cursor.
-    ///
-    ///This function destroys a cursor previously created with
-    ///[glfwCreateCursor][#glfwCreateCursor(MemorySegment, int, int)].  Any remaining cursors will be destroyed by
-    ///[glfwTerminate][#glfwTerminate()].
-    ///
-    ///If the specified cursor is current for any window, that window will be
-    ///reverted to the default cursor.  This does not affect the cursor mode.
-    ///
-    ///@param cursor The cursor object to destroy.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-    ///[GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-    ///
-    ///@glfw.reentrancy This function must not be called from a callback.
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
-    ///
-    ///@see #glfwCreateCursor(MemorySegment, int, int) glfwCreateCursor
     public static void glfwDestroyCursor(@CType("GLFWcursor*") java.lang.foreign.MemorySegment cursor) {
         try {
             Handles.MH_glfwDestroyCursor.invokeExact(cursor);
         } catch (Throwable e) { throw new RuntimeException("error in glfwDestroyCursor", e); }
     }
 
-    ///Sets the cursor for the window.
-    ///
-    ///This function sets the cursor image to be used when the cursor is over the
-    ///content area of the specified window.  The set cursor will only be visible
-    ///when the cursor mode of the window is
-    ///`GLFW_CURSOR_NORMAL`.
-    ///
-    ///On some platforms, the set cursor may not be visible unless the window also
-    ///has input focus.
-    ///
-    ///@param window The window to set the cursor for.
-    ///@param cursor The cursor to set, or `NULL` to switch back to the default
-    ///arrow cursor.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-    ///[GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
     public static void glfwSetCursor(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("GLFWcursor*") java.lang.foreign.MemorySegment cursor) {
         try {
             Handles.MH_glfwSetCursor.invokeExact(window, cursor);
         } catch (Throwable e) { throw new RuntimeException("error in glfwSetCursor", e); }
     }
 
-    ///Sets the key callback.
-    ///
-    ///This function sets the key callback of the specified window, which is called
-    ///when a key is pressed, repeated or released.
-    ///
-    ///The key functions deal with physical keys, with layout independent
-    ///key tokens named after their values in the standard US keyboard
-    ///layout.  If you want to input text, use the
-    ///[character callback][#glfwSetCharCallback(MemorySegment, MemorySegment)] instead.
-    ///
-    ///When a window loses input focus, it will generate synthetic key release
-    ///events for all pressed keys with associated key tokens.  You can tell these
-    ///events from user-generated events by the fact that the synthetic ones are
-    ///generated after the focus loss event has been processed, i.e. after the
-    ///[window focus callback][#glfwSetWindowFocusCallback(MemorySegment, MemorySegment)] has been called.
-    ///
-    ///The scancode of a key is specific to that platform or sometimes even to that
-    ///machine.  Scancodes are intended to allow users to bind keys that don't have
-    ///a GLFW key token.  Such keys have `key` set to `GLFW_KEY_UNKNOWN`, their
-    ///state is not saved and so it cannot be queried with [glfwGetKey][#glfwGetKey(MemorySegment, int)].
-    ///
-    ///Sometimes GLFW needs to generate synthetic key events, in which case the
-    ///scancode may be zero.
-    ///
-    ///@param window The window whose callback to set.
-    ///@param callback The new key callback, or `NULL` to remove the currently
-    ///set callback.
-    ///@return The previously set callback, or `NULL` if no callback was set or the
-    ///library had not been initialized.
-    ///
-    ///@glfw.callback_signature
-    ///For more information about the callback parameters, see the
-    ///[function pointer type][GLFWKeyFun].
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
     public static @CType("GLFWkeyfun") java.lang.foreign.MemorySegment glfwSetKeyCallback(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("GLFWkeyfun") java.lang.foreign.MemorySegment callback) {
         try {
             return (java.lang.foreign.MemorySegment) Handles.MH_glfwSetKeyCallback.invokeExact(window, callback);
         } catch (Throwable e) { throw new RuntimeException("error in glfwSetKeyCallback", e); }
     }
 
-    ///Sets the key callback.
-    ///
-    ///This function sets the key callback of the specified window, which is called
-    ///when a key is pressed, repeated or released.
-    ///
-    ///The key functions deal with physical keys, with layout independent
-    ///key tokens named after their values in the standard US keyboard
-    ///layout.  If you want to input text, use the
-    ///[character callback][#glfwSetCharCallback(MemorySegment, MemorySegment)] instead.
-    ///
-    ///When a window loses input focus, it will generate synthetic key release
-    ///events for all pressed keys with associated key tokens.  You can tell these
-    ///events from user-generated events by the fact that the synthetic ones are
-    ///generated after the focus loss event has been processed, i.e. after the
-    ///[window focus callback][#glfwSetWindowFocusCallback(MemorySegment, MemorySegment)] has been called.
-    ///
-    ///The scancode of a key is specific to that platform or sometimes even to that
-    ///machine.  Scancodes are intended to allow users to bind keys that don't have
-    ///a GLFW key token.  Such keys have `key` set to `GLFW_KEY_UNKNOWN`, their
-    ///state is not saved and so it cannot be queried with [glfwGetKey][#glfwGetKey(MemorySegment, int)].
-    ///
-    ///Sometimes GLFW needs to generate synthetic key events, in which case the
-    ///scancode may be zero.
-    ///
-    ///@param window The window whose callback to set.
-    ///@param callback The new key callback, or `NULL` to remove the currently
-    ///set callback.
-    ///@return The previously set callback, or `NULL` if no callback was set or the
-    ///library had not been initialized.
-    ///
-    ///@glfw.callback_signature
-    ///For more information about the callback parameters, see the
-    ///[function pointer type][GLFWKeyFun].
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
     public static @CType("GLFWkeyfun") java.lang.foreign.MemorySegment glfwSetKeyCallback(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("GLFWkeyfun") overrungl.glfw.GLFWKeyFun callback) {
         return glfwSetKeyCallback(window, callback != null ? callback.stub(GLFWCallbacks.create(window)) : MemorySegment.NULL);
     }
 
-    ///Sets the Unicode character callback.
-    ///
-    ///This function sets the character callback of the specified window, which is
-    ///called when a Unicode character is input.
-    ///
-    ///The character callback is intended for Unicode text input.  As it deals with
-    ///characters, it is keyboard layout dependent, whereas the
-    ///[key callback][#glfwSetKeyCallback(MemorySegment, MemorySegment)] is not.  Characters do not map 1:1
-    ///to physical keys, as a key may produce zero, one or more characters.  If you
-    ///want to know whether a specific physical key was pressed or released, see
-    ///the key callback instead.
-    ///
-    ///The character callback behaves as system text input normally does and will
-    ///not be called if modifier keys are held down that would prevent normal text
-    ///input on that platform, for example a Super (Command) key on macOS or Alt key
-    ///on Windows.
-    ///
-    ///@param window The window whose callback to set.
-    ///@param callback The new callback, or `NULL` to remove the currently set
-    ///callback.
-    ///@return The previously set callback, or `NULL` if no callback was set or the
-    ///library had not been initialized.
-    ///
-    ///@glfw.callback_signature
-    ///For more information about the callback parameters, see the
-    ///[function pointer type][GLFWCharFun].
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
     public static @CType("GLFWcharfun") java.lang.foreign.MemorySegment glfwSetCharCallback(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("GLFWcharfun") java.lang.foreign.MemorySegment callback) {
         try {
             return (java.lang.foreign.MemorySegment) Handles.MH_glfwSetCharCallback.invokeExact(window, callback);
         } catch (Throwable e) { throw new RuntimeException("error in glfwSetCharCallback", e); }
     }
 
-    ///Sets the Unicode character callback.
-    ///
-    ///This function sets the character callback of the specified window, which is
-    ///called when a Unicode character is input.
-    ///
-    ///The character callback is intended for Unicode text input.  As it deals with
-    ///characters, it is keyboard layout dependent, whereas the
-    ///[key callback][#glfwSetKeyCallback(MemorySegment, MemorySegment)] is not.  Characters do not map 1:1
-    ///to physical keys, as a key may produce zero, one or more characters.  If you
-    ///want to know whether a specific physical key was pressed or released, see
-    ///the key callback instead.
-    ///
-    ///The character callback behaves as system text input normally does and will
-    ///not be called if modifier keys are held down that would prevent normal text
-    ///input on that platform, for example a Super (Command) key on macOS or Alt key
-    ///on Windows.
-    ///
-    ///@param window The window whose callback to set.
-    ///@param callback The new callback, or `NULL` to remove the currently set
-    ///callback.
-    ///@return The previously set callback, or `NULL` if no callback was set or the
-    ///library had not been initialized.
-    ///
-    ///@glfw.callback_signature
-    ///For more information about the callback parameters, see the
-    ///[function pointer type][GLFWCharFun].
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
     public static @CType("GLFWcharfun") java.lang.foreign.MemorySegment glfwSetCharCallback(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("GLFWcharfun") overrungl.glfw.GLFWCharFun callback) {
         return glfwSetCharCallback(window, callback != null ? callback.stub(GLFWCallbacks.create(window)) : MemorySegment.NULL);
     }
 
-    ///Sets the mouse button callback.
-    ///
-    ///This function sets the mouse button callback of the specified window, which
-    ///is called when a mouse button is pressed or released.
-    ///
-    ///When a window loses input focus, it will generate synthetic mouse button
-    ///release events for all pressed mouse buttons with associated button tokens.
-    ///You can tell these events from user-generated events by the fact that the
-    ///synthetic ones are generated after the focus loss event has been processed,
-    ///i.e. after the [window focus callback][#glfwSetWindowFocusCallback(MemorySegment, MemorySegment)] has
-    ///been called.
-    ///
-    ///The reported `button` value can be higher than `GLFW_MOUSE_BUTTON_LAST` if
-    ///the button does not have an associated button token and the
-    ///[GLFW_UNLIMITED_MOUSE_BUTTONS][#GLFW_UNLIMITED_MOUSE_BUTTONS] input mode is set.
-    ///
-    ///@param window The window whose callback to set.
-    ///@param callback The new callback, or `NULL` to remove the currently set
-    ///callback.
-    ///@return The previously set callback, or `NULL` if no callback was set or the
-    ///library had not been initialized.
-    ///
-    ///@glfw.callback_signature
-    ///For more information about the callback parameters, see the
-    ///[function pointer type][GLFWMouseButtonFun].
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
     public static @CType("GLFWmousebuttonfun") java.lang.foreign.MemorySegment glfwSetMouseButtonCallback(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("GLFWmousebuttonfun") java.lang.foreign.MemorySegment callback) {
         try {
             return (java.lang.foreign.MemorySegment) Handles.MH_glfwSetMouseButtonCallback.invokeExact(window, callback);
         } catch (Throwable e) { throw new RuntimeException("error in glfwSetMouseButtonCallback", e); }
     }
 
-    ///Sets the mouse button callback.
-    ///
-    ///This function sets the mouse button callback of the specified window, which
-    ///is called when a mouse button is pressed or released.
-    ///
-    ///When a window loses input focus, it will generate synthetic mouse button
-    ///release events for all pressed mouse buttons with associated button tokens.
-    ///You can tell these events from user-generated events by the fact that the
-    ///synthetic ones are generated after the focus loss event has been processed,
-    ///i.e. after the [window focus callback][#glfwSetWindowFocusCallback(MemorySegment, MemorySegment)] has
-    ///been called.
-    ///
-    ///The reported `button` value can be higher than `GLFW_MOUSE_BUTTON_LAST` if
-    ///the button does not have an associated button token and the
-    ///[GLFW_UNLIMITED_MOUSE_BUTTONS][#GLFW_UNLIMITED_MOUSE_BUTTONS] input mode is set.
-    ///
-    ///@param window The window whose callback to set.
-    ///@param callback The new callback, or `NULL` to remove the currently set
-    ///callback.
-    ///@return The previously set callback, or `NULL` if no callback was set or the
-    ///library had not been initialized.
-    ///
-    ///@glfw.callback_signature
-    ///For more information about the callback parameters, see the
-    ///[function pointer type][GLFWMouseButtonFun].
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
     public static @CType("GLFWmousebuttonfun") java.lang.foreign.MemorySegment glfwSetMouseButtonCallback(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("GLFWmousebuttonfun") overrungl.glfw.GLFWMouseButtonFun callback) {
         return glfwSetMouseButtonCallback(window, callback != null ? callback.stub(GLFWCallbacks.create(window)) : MemorySegment.NULL);
     }
 
-    ///Sets the cursor position callback.
-    ///
-    ///This function sets the cursor position callback of the specified window,
-    ///which is called when the cursor is moved.  The callback is provided with the
-    ///position, in screen coordinates, relative to the upper-left corner of the
-    ///content area of the window.
-    ///
-    ///@param window The window whose callback to set.
-    ///@param callback The new callback, or `NULL` to remove the currently set
-    ///callback.
-    ///@return The previously set callback, or `NULL` if no callback was set or the
-    ///library had not been initialized.
-    ///
-    ///@glfw.callback_signature
-    ///For more information about the callback parameters, see the
-    ///[function pointer type][GLFWCursorPosFun].
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
     public static @CType("GLFWcursorposfun") java.lang.foreign.MemorySegment glfwSetCursorPosCallback(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("GLFWcursorposfun") java.lang.foreign.MemorySegment callback) {
         try {
             return (java.lang.foreign.MemorySegment) Handles.MH_glfwSetCursorPosCallback.invokeExact(window, callback);
         } catch (Throwable e) { throw new RuntimeException("error in glfwSetCursorPosCallback", e); }
     }
 
-    ///Sets the cursor position callback.
-    ///
-    ///This function sets the cursor position callback of the specified window,
-    ///which is called when the cursor is moved.  The callback is provided with the
-    ///position, in screen coordinates, relative to the upper-left corner of the
-    ///content area of the window.
-    ///
-    ///@param window The window whose callback to set.
-    ///@param callback The new callback, or `NULL` to remove the currently set
-    ///callback.
-    ///@return The previously set callback, or `NULL` if no callback was set or the
-    ///library had not been initialized.
-    ///
-    ///@glfw.callback_signature
-    ///For more information about the callback parameters, see the
-    ///[function pointer type][GLFWCursorPosFun].
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
     public static @CType("GLFWcursorposfun") java.lang.foreign.MemorySegment glfwSetCursorPosCallback(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("GLFWcursorposfun") overrungl.glfw.GLFWCursorPosFun callback) {
         return glfwSetCursorPosCallback(window, callback != null ? callback.stub(GLFWCallbacks.create(window)) : MemorySegment.NULL);
     }
 
-    ///Sets the cursor enter/leave callback.
-    ///
-    ///This function sets the cursor boundary crossing callback of the specified
-    ///window, which is called when the cursor enters or leaves the content area of
-    ///the window.
-    ///
-    ///@param window The window whose callback to set.
-    ///@param callback The new callback, or `NULL` to remove the currently set
-    ///callback.
-    ///@return The previously set callback, or `NULL` if no callback was set or the
-    ///library had not been initialized.
-    ///
-    ///@glfw.callback_signature
-    ///For more information about the callback parameters, see the
-    ///[function pointer type][GLFWCursorEnterFun].
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
     public static @CType("GLFWcursorenterfun") java.lang.foreign.MemorySegment glfwSetCursorEnterCallback(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("GLFWcursorenterfun") java.lang.foreign.MemorySegment callback) {
         try {
             return (java.lang.foreign.MemorySegment) Handles.MH_glfwSetCursorEnterCallback.invokeExact(window, callback);
         } catch (Throwable e) { throw new RuntimeException("error in glfwSetCursorEnterCallback", e); }
     }
 
-    ///Sets the cursor enter/leave callback.
-    ///
-    ///This function sets the cursor boundary crossing callback of the specified
-    ///window, which is called when the cursor enters or leaves the content area of
-    ///the window.
-    ///
-    ///@param window The window whose callback to set.
-    ///@param callback The new callback, or `NULL` to remove the currently set
-    ///callback.
-    ///@return The previously set callback, or `NULL` if no callback was set or the
-    ///library had not been initialized.
-    ///
-    ///@glfw.callback_signature
-    ///For more information about the callback parameters, see the
-    ///[function pointer type][GLFWCursorEnterFun].
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
     public static @CType("GLFWcursorenterfun") java.lang.foreign.MemorySegment glfwSetCursorEnterCallback(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("GLFWcursorenterfun") overrungl.glfw.GLFWCursorEnterFun callback) {
         return glfwSetCursorEnterCallback(window, callback != null ? callback.stub(GLFWCallbacks.create(window)) : MemorySegment.NULL);
     }
 
-    ///Sets the scroll callback.
-    ///
-    ///This function sets the scroll callback of the specified window, which is
-    ///called when a scrolling device is used, such as a mouse wheel or scrolling
-    ///area of a touchpad.
-    ///
-    ///The scroll callback receives all scrolling input, like that from a mouse
-    ///wheel or a touchpad scrolling area.
-    ///
-    ///@param window The window whose callback to set.
-    ///@param callback The new scroll callback, or `NULL` to remove the
-    ///currently set callback.
-    ///@return The previously set callback, or `NULL` if no callback was set or the
-    ///library had not been initialized.
-    ///
-    ///@glfw.callback_signature
-    ///For more information about the callback parameters, see the
-    ///[function pointer type][GLFWScrollFun].
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
     public static @CType("GLFWscrollfun") java.lang.foreign.MemorySegment glfwSetScrollCallback(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("GLFWscrollfun") java.lang.foreign.MemorySegment callback) {
         try {
             return (java.lang.foreign.MemorySegment) Handles.MH_glfwSetScrollCallback.invokeExact(window, callback);
         } catch (Throwable e) { throw new RuntimeException("error in glfwSetScrollCallback", e); }
     }
 
-    ///Sets the scroll callback.
-    ///
-    ///This function sets the scroll callback of the specified window, which is
-    ///called when a scrolling device is used, such as a mouse wheel or scrolling
-    ///area of a touchpad.
-    ///
-    ///The scroll callback receives all scrolling input, like that from a mouse
-    ///wheel or a touchpad scrolling area.
-    ///
-    ///@param window The window whose callback to set.
-    ///@param callback The new scroll callback, or `NULL` to remove the
-    ///currently set callback.
-    ///@return The previously set callback, or `NULL` if no callback was set or the
-    ///library had not been initialized.
-    ///
-    ///@glfw.callback_signature
-    ///For more information about the callback parameters, see the
-    ///[function pointer type][GLFWScrollFun].
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
     public static @CType("GLFWscrollfun") java.lang.foreign.MemorySegment glfwSetScrollCallback(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("GLFWscrollfun") overrungl.glfw.GLFWScrollFun callback) {
         return glfwSetScrollCallback(window, callback != null ? callback.stub(GLFWCallbacks.create(window)) : MemorySegment.NULL);
     }
 
-    ///Sets the path drop callback.
-    ///
-    ///This function sets the path drop callback of the specified window, which is
-    ///called when one or more dragged paths are dropped on the window.
-    ///
-    ///Because the path array and its strings may have been generated specifically
-    ///for that event, they are not guaranteed to be valid after the callback has
-    ///returned.  If you wish to use them after the callback returns, you need to
-    ///make a deep copy.
-    ///
-    ///@param window The window whose callback to set.
-    ///@param callback The new file drop callback, or `NULL` to remove the
-    ///currently set callback.
-    ///@return The previously set callback, or `NULL` if no callback was set or the
-    ///library had not been initialized.
-    ///
-    ///@glfw.callback_signature
-    ///For more information about the callback parameters, see the
-    ///[function pointer type][GLFWDropFun].
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
     public static @CType("GLFWdropfun") java.lang.foreign.MemorySegment glfwSetDropCallback(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("GLFWdropfun") java.lang.foreign.MemorySegment callback) {
         try {
             return (java.lang.foreign.MemorySegment) Handles.MH_glfwSetDropCallback.invokeExact(window, callback);
         } catch (Throwable e) { throw new RuntimeException("error in glfwSetDropCallback", e); }
     }
 
-    ///Sets the path drop callback.
-    ///
-    ///This function sets the path drop callback of the specified window, which is
-    ///called when one or more dragged paths are dropped on the window.
-    ///
-    ///Because the path array and its strings may have been generated specifically
-    ///for that event, they are not guaranteed to be valid after the callback has
-    ///returned.  If you wish to use them after the callback returns, you need to
-    ///make a deep copy.
-    ///
-    ///@param window The window whose callback to set.
-    ///@param callback The new file drop callback, or `NULL` to remove the
-    ///currently set callback.
-    ///@return The previously set callback, or `NULL` if no callback was set or the
-    ///library had not been initialized.
-    ///
-    ///@glfw.callback_signature
-    ///For more information about the callback parameters, see the
-    ///[function pointer type][GLFWDropFun].
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
     public static @CType("GLFWdropfun") java.lang.foreign.MemorySegment glfwSetDropCallback(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("GLFWdropfun") overrungl.glfw.GLFWDropFun callback) {
         return glfwSetDropCallback(window, callback != null ? callback.stub(GLFWCallbacks.create(window)) : MemorySegment.NULL);
     }
 
-    ///Returns whether the specified joystick is present.
-    ///
-    ///This function returns whether the specified joystick is present.
-    ///
-    ///There is no need to call this function before other functions that accept
-    ///a joystick ID, as they all check for presence before performing any other
-    ///work.
-    ///
-    ///@param jid The joystick to query.
-    ///@return `GLFW_TRUE` if the joystick is present, or `GLFW_FALSE` otherwise.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED],
-    ///[GLFW_INVALID_ENUM][#GLFW_INVALID_ENUM] and [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
     public static @CType("int") boolean glfwJoystickPresent(@CType("int") int jid) {
         try {
             return (int) Handles.MH_glfwJoystickPresent.invokeExact(jid) != GLFW.GLFW_FALSE;
         } catch (Throwable e) { throw new RuntimeException("error in glfwJoystickPresent", e); }
     }
 
-    ///Returns the values of all axes of the specified joystick.
-    ///
-    ///This function returns the values of all axes of the specified joystick.
-    ///Each element in the array is a value between -1.0 and 1.0.
-    ///
-    ///If the specified joystick is not present this function will return `NULL`
-    ///but will not generate an error.  This can be used instead of first calling
-    ///[glfwJoystickPresent][#glfwJoystickPresent(int)].
-    ///
-    ///@param jid The joystick to query.
-    ///@param count Where to store the number of axis values in the returned
-    ///array.  This is set to zero if the joystick is not present or an error
-    ///occurred.
-    ///@return An array of axis values, or `NULL` if the joystick is not present or
-    ///an error occurred.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED],
-    ///[GLFW_INVALID_ENUM][#GLFW_INVALID_ENUM] and [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-    ///
-    ///@glfw.pointer_lifetime The returned array is allocated and freed by GLFW.  You
-    ///should not free it yourself.  It is valid until the specified joystick is
-    ///disconnected or the library is terminated.
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
     public static @CType("const float*") java.lang.foreign.MemorySegment glfwGetJoystickAxes(@CType("int") int jid, @Out @CType("int*") java.lang.foreign.MemorySegment count) {
         try {
             return (java.lang.foreign.MemorySegment) Handles.MH_glfwGetJoystickAxes.invokeExact(jid, count);
         } catch (Throwable e) { throw new RuntimeException("error in glfwGetJoystickAxes", e); }
     }
 
-    ///Returns the state of all buttons of the specified joystick.
-    ///
-    ///This function returns the state of all buttons of the specified joystick.
-    ///Each element in the array is either `GLFW_PRESS` or `GLFW_RELEASE`.
-    ///
-    ///For backward compatibility with earlier versions that did not have
-    ///[glfwGetJoystickHats][#glfwGetJoystickHats(int, MemorySegment)], the button array also includes all hats, each
-    ///represented as four buttons.  The hats are in the same order as returned by
-    ///__glfwGetJoystickHats__ and are in the order _up_, _right_, _down_ and
-    ///_left_.  To disable these extra buttons, set the
-    ///[GLFW_JOYSTICK_HAT_BUTTONS][#GLFW_JOYSTICK_HAT_BUTTONS] init hint before initialization.
-    ///
-    ///If the specified joystick is not present this function will return `NULL`
-    ///but will not generate an error.  This can be used instead of first calling
-    ///[glfwJoystickPresent][#glfwJoystickPresent(int)].
-    ///
-    ///@param jid The joystick to query.
-    ///@param count Where to store the number of button states in the returned
-    ///array.  This is set to zero if the joystick is not present or an error
-    ///occurred.
-    ///@return An array of button states, or `NULL` if the joystick is not present
-    ///or an error occurred.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED],
-    ///[GLFW_INVALID_ENUM][#GLFW_INVALID_ENUM] and [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-    ///
-    ///@glfw.pointer_lifetime The returned array is allocated and freed by GLFW.  You
-    ///should not free it yourself.  It is valid until the specified joystick is
-    ///disconnected or the library is terminated.
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
     public static @CType("const unsigned char*") java.lang.foreign.MemorySegment glfwGetJoystickButtons(@CType("int") int jid, @Out @CType("int*") java.lang.foreign.MemorySegment count) {
         try {
             return (java.lang.foreign.MemorySegment) Handles.MH_glfwGetJoystickButtons.invokeExact(jid, count);
         } catch (Throwable e) { throw new RuntimeException("error in glfwGetJoystickButtons", e); }
     }
 
-    ///Returns the state of all hats of the specified joystick.
-    ///
-    ///This function returns the state of all hats of the specified joystick.
-    ///Each element in the array is one of the following values:
-    ///
-    ///| Name                  | Value |
-    ///| ----                  | ----- |
-    ///| `GLFW_HAT_CENTERED`   | 0 |
-    ///| `GLFW_HAT_UP`         | 1 |
-    ///| `GLFW_HAT_RIGHT`      | 2 |
-    ///| `GLFW_HAT_DOWN`       | 4 |
-    ///| `GLFW_HAT_LEFT`       | 8 |
-    ///| `GLFW_HAT_RIGHT_UP`   | `GLFW_HAT_RIGHT` \| `GLFW_HAT_UP` |
-    ///| `GLFW_HAT_RIGHT_DOWN` | `GLFW_HAT_RIGHT` \| `GLFW_HAT_DOWN` |
-    ///| `GLFW_HAT_LEFT_UP`    | `GLFW_HAT_LEFT` \| `GLFW_HAT_UP` |
-    ///| `GLFW_HAT_LEFT_DOWN`  | `GLFW_HAT_LEFT` \| `GLFW_HAT_DOWN` |
-    ///
-    ///The diagonal directions are bitwise combinations of the primary (up, right,
-    ///down and left) directions and you can test for these individually by ANDing
-    ///it with the corresponding direction.
-    ///
-    ///```java
-    ///if (hats[2] & GLFW_HAT_RIGHT)
-    ///{
-    ///    // State of hat 2 could be right-up, right or right-down
-    ///}
-    ///```
-    ///
-    ///If the specified joystick is not present this function will return `NULL`
-    ///but will not generate an error.  This can be used instead of first calling
-    ///[glfwJoystickPresent][#glfwJoystickPresent(int)].
-    ///
-    ///@param jid The joystick to query.
-    ///@param count Where to store the number of hat states in the returned
-    ///array.  This is set to zero if the joystick is not present or an error
-    ///occurred.
-    ///@return An array of hat states, or `NULL` if the joystick is not present
-    ///or an error occurred.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED],
-    ///[GLFW_INVALID_ENUM][#GLFW_INVALID_ENUM] and [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-    ///
-    ///@glfw.pointer_lifetime The returned array is allocated and freed by GLFW.  You
-    ///should not free it yourself.  It is valid until the specified joystick is
-    ///disconnected, this function is called again for that joystick or the library
-    ///is terminated.
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
     public static @CType("const unsigned char*") java.lang.foreign.MemorySegment glfwGetJoystickHats(@CType("int") int jid, @Out @CType("int*") java.lang.foreign.MemorySegment count) {
         try {
             return (java.lang.foreign.MemorySegment) Handles.MH_glfwGetJoystickHats.invokeExact(jid, count);
         } catch (Throwable e) { throw new RuntimeException("error in glfwGetJoystickHats", e); }
     }
 
-    ///Returns the name of the specified joystick.
-    ///
-    ///This function returns the name, encoded as UTF-8, of the specified joystick.
-    ///The returned string is allocated and freed by GLFW.  You should not free it
-    ///yourself.
-    ///
-    ///If the specified joystick is not present this function will return `NULL`
-    ///but will not generate an error.  This can be used instead of first calling
-    ///[glfwJoystickPresent][#glfwJoystickPresent(int)].
-    ///
-    ///@param jid The joystick to query.
-    ///@return The UTF-8 encoded name of the joystick, or `NULL` if the joystick
-    ///is not present or an error occurred.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED],
-    ///[GLFW_INVALID_ENUM][#GLFW_INVALID_ENUM] and [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-    ///
-    ///@glfw.pointer_lifetime The returned string is allocated and freed by GLFW.  You
-    ///should not free it yourself.  It is valid until the specified joystick is
-    ///disconnected or the library is terminated.
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
     public static @CType("const char*") java.lang.foreign.MemorySegment glfwGetJoystickName_(@CType("int") int jid) {
         try {
             return (java.lang.foreign.MemorySegment) Handles.MH_glfwGetJoystickName.invokeExact(jid);
         } catch (Throwable e) { throw new RuntimeException("error in glfwGetJoystickName", e); }
     }
 
-    ///Returns the name of the specified joystick.
-    ///
-    ///This function returns the name, encoded as UTF-8, of the specified joystick.
-    ///The returned string is allocated and freed by GLFW.  You should not free it
-    ///yourself.
-    ///
-    ///If the specified joystick is not present this function will return `NULL`
-    ///but will not generate an error.  This can be used instead of first calling
-    ///[glfwJoystickPresent][#glfwJoystickPresent(int)].
-    ///
-    ///@param jid The joystick to query.
-    ///@return The UTF-8 encoded name of the joystick, or `NULL` if the joystick
-    ///is not present or an error occurred.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED],
-    ///[GLFW_INVALID_ENUM][#GLFW_INVALID_ENUM] and [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-    ///
-    ///@glfw.pointer_lifetime The returned string is allocated and freed by GLFW.  You
-    ///should not free it yourself.  It is valid until the specified joystick is
-    ///disconnected or the library is terminated.
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
     public static @CType("const char*") java.lang.String glfwGetJoystickName(@CType("int") int jid) {
         try {
             return Unmarshal.unmarshalAsString((java.lang.foreign.MemorySegment) Handles.MH_glfwGetJoystickName.invokeExact(jid));
         } catch (Throwable e) { throw new RuntimeException("error in glfwGetJoystickName", e); }
     }
 
-    ///Returns the SDL compatible GUID of the specified joystick.
-    ///
-    ///This function returns the SDL compatible GUID, as a UTF-8 encoded
-    ///hexadecimal string, of the specified joystick.  The returned string is
-    ///allocated and freed by GLFW.  You should not free it yourself.
-    ///
-    ///The GUID is what connects a joystick to a gamepad mapping.  A connected
-    ///joystick will always have a GUID even if there is no gamepad mapping
-    ///assigned to it.
-    ///
-    ///If the specified joystick is not present this function will return `NULL`
-    ///but will not generate an error.  This can be used instead of first calling
-    ///[glfwJoystickPresent][#glfwJoystickPresent(int)].
-    ///
-    ///The GUID uses the format introduced in SDL 2.0.5.  This GUID tries to
-    ///uniquely identify the make and model of a joystick but does not identify
-    ///a specific unit, e.g. all wired Xbox 360 controllers will have the same
-    ///GUID on that platform.  The GUID for a unit may vary between platforms
-    ///depending on what hardware information the platform specific APIs provide.
-    ///
-    ///@param jid The joystick to query.
-    ///@return The UTF-8 encoded GUID of the joystick, or `NULL` if the joystick
-    ///is not present or an error occurred.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED],
-    ///[GLFW_INVALID_ENUM][#GLFW_INVALID_ENUM] and [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-    ///
-    ///@glfw.pointer_lifetime The returned string is allocated and freed by GLFW.  You
-    ///should not free it yourself.  It is valid until the specified joystick is
-    ///disconnected or the library is terminated.
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
     public static @CType("const char*") java.lang.foreign.MemorySegment glfwGetJoystickGUID_(@CType("int") int jid) {
         try {
             return (java.lang.foreign.MemorySegment) Handles.MH_glfwGetJoystickGUID.invokeExact(jid);
         } catch (Throwable e) { throw new RuntimeException("error in glfwGetJoystickGUID", e); }
     }
 
-    ///Returns the SDL compatible GUID of the specified joystick.
-    ///
-    ///This function returns the SDL compatible GUID, as a UTF-8 encoded
-    ///hexadecimal string, of the specified joystick.  The returned string is
-    ///allocated and freed by GLFW.  You should not free it yourself.
-    ///
-    ///The GUID is what connects a joystick to a gamepad mapping.  A connected
-    ///joystick will always have a GUID even if there is no gamepad mapping
-    ///assigned to it.
-    ///
-    ///If the specified joystick is not present this function will return `NULL`
-    ///but will not generate an error.  This can be used instead of first calling
-    ///[glfwJoystickPresent][#glfwJoystickPresent(int)].
-    ///
-    ///The GUID uses the format introduced in SDL 2.0.5.  This GUID tries to
-    ///uniquely identify the make and model of a joystick but does not identify
-    ///a specific unit, e.g. all wired Xbox 360 controllers will have the same
-    ///GUID on that platform.  The GUID for a unit may vary between platforms
-    ///depending on what hardware information the platform specific APIs provide.
-    ///
-    ///@param jid The joystick to query.
-    ///@return The UTF-8 encoded GUID of the joystick, or `NULL` if the joystick
-    ///is not present or an error occurred.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED],
-    ///[GLFW_INVALID_ENUM][#GLFW_INVALID_ENUM] and [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-    ///
-    ///@glfw.pointer_lifetime The returned string is allocated and freed by GLFW.  You
-    ///should not free it yourself.  It is valid until the specified joystick is
-    ///disconnected or the library is terminated.
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
     public static @CType("const char*") java.lang.String glfwGetJoystickGUID(@CType("int") int jid) {
         try {
             return Unmarshal.unmarshalAsString((java.lang.foreign.MemorySegment) Handles.MH_glfwGetJoystickGUID.invokeExact(jid));
         } catch (Throwable e) { throw new RuntimeException("error in glfwGetJoystickGUID", e); }
     }
 
-    ///Sets the user pointer of the specified joystick.
-    ///
-    ///This function sets the user-defined pointer of the specified joystick.  The
-    ///current value is retained until the joystick is disconnected.  The initial
-    ///value is `NULL`.
-    ///
-    ///This function may be called from the joystick callback, even for a joystick
-    ///that is being disconnected.
-    ///
-    ///@param jid The joystick whose pointer to set.
-    ///@param pointer The new value.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-    ///
-    ///@glfw.thread_safety This function may be called from any thread.  Access is not
-    ///synchronized.
-    ///
-    ///@see #glfwGetJoystickUserPointer(int) glfwGetJoystickUserPointer
     public static void glfwSetJoystickUserPointer(@CType("int") int jid, @CType("void*") java.lang.foreign.MemorySegment pointer) {
         try {
             Handles.MH_glfwSetJoystickUserPointer.invokeExact(jid, pointer);
         } catch (Throwable e) { throw new RuntimeException("error in glfwSetJoystickUserPointer", e); }
     }
 
-    ///Returns the user pointer of the specified joystick.
-    ///
-    ///This function returns the current value of the user-defined pointer of the
-    ///specified joystick.  The initial value is `NULL`.
-    ///
-    ///This function may be called from the joystick callback, even for a joystick
-    ///that is being disconnected.
-    ///
-    ///@param jid The joystick whose pointer to return.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-    ///
-    ///@glfw.thread_safety This function may be called from any thread.  Access is not
-    ///synchronized.
-    ///
-    ///@see #glfwSetJoystickUserPointer(int, MemorySegment) glfwSetJoystickUserPointer
     public static @CType("void*") java.lang.foreign.MemorySegment glfwGetJoystickUserPointer(@CType("int") int jid) {
         try {
             return (java.lang.foreign.MemorySegment) Handles.MH_glfwGetJoystickUserPointer.invokeExact(jid);
         } catch (Throwable e) { throw new RuntimeException("error in glfwGetJoystickUserPointer", e); }
     }
 
-    ///Returns whether the specified joystick has a gamepad mapping.
-    ///
-    ///This function returns whether the specified joystick is both present and has
-    ///a gamepad mapping.
-    ///
-    ///If the specified joystick is present but does not have a gamepad mapping
-    ///this function will return `GLFW_FALSE` but will not generate an error.  Call
-    ///[glfwJoystickPresent][#glfwJoystickPresent(int)] to check if a joystick is present regardless of
-    ///whether it has a mapping.
-    ///
-    ///@param jid The joystick to query.
-    ///@return `GLFW_TRUE` if a joystick is both present and has a gamepad mapping,
-    ///or `GLFW_FALSE` otherwise.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-    ///[GLFW_INVALID_ENUM][#GLFW_INVALID_ENUM].
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
-    ///
-    ///@see #glfwGetGamepadState(int, MemorySegment) glfwGetGamepadState
     public static @CType("int") boolean glfwJoystickIsGamepad(@CType("int") int jid) {
         try {
             return (int) Handles.MH_glfwJoystickIsGamepad.invokeExact(jid) != GLFW.GLFW_FALSE;
         } catch (Throwable e) { throw new RuntimeException("error in glfwJoystickIsGamepad", e); }
     }
 
-    ///Sets the joystick configuration callback.
-    ///
-    ///This function sets the joystick configuration callback, or removes the
-    ///currently set callback.  This is called when a joystick is connected to or
-    ///disconnected from the system.
-    ///
-    ///For joystick connection and disconnection events to be delivered on all
-    ///platforms, you need to call one of the [event processing](@ref events)
-    ///functions.  Joystick disconnection may also be detected and the callback
-    ///called by joystick functions.  The function will then return whatever it
-    ///returns if the joystick is not present.
-    ///
-    ///@param callback The new callback, or `NULL` to remove the currently set
-    ///callback.
-    ///@return The previously set callback, or `NULL` if no callback was set or the
-    ///library had not been initialized.
-    ///
-    ///@glfw.callback_signature
-    ///For more information about the callback parameters, see the
-    ///[function pointer type][GLFWJoystickFun].
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
     public static @CType("GLFWjoystickfun") java.lang.foreign.MemorySegment glfwSetJoystickCallback(@CType("GLFWjoystickfun") java.lang.foreign.MemorySegment callback) {
         try {
             return (java.lang.foreign.MemorySegment) Handles.MH_glfwSetJoystickCallback.invokeExact(callback);
         } catch (Throwable e) { throw new RuntimeException("error in glfwSetJoystickCallback", e); }
     }
 
-    ///Sets the joystick configuration callback.
-    ///
-    ///This function sets the joystick configuration callback, or removes the
-    ///currently set callback.  This is called when a joystick is connected to or
-    ///disconnected from the system.
-    ///
-    ///For joystick connection and disconnection events to be delivered on all
-    ///platforms, you need to call one of the [event processing](@ref events)
-    ///functions.  Joystick disconnection may also be detected and the callback
-    ///called by joystick functions.  The function will then return whatever it
-    ///returns if the joystick is not present.
-    ///
-    ///@param callback The new callback, or `NULL` to remove the currently set
-    ///callback.
-    ///@return The previously set callback, or `NULL` if no callback was set or the
-    ///library had not been initialized.
-    ///
-    ///@glfw.callback_signature
-    ///For more information about the callback parameters, see the
-    ///[function pointer type][GLFWJoystickFun].
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
     public static @CType("GLFWjoystickfun") java.lang.foreign.MemorySegment glfwSetJoystickCallback(@CType("GLFWjoystickfun") overrungl.glfw.GLFWJoystickFun callback) {
         return glfwSetJoystickCallback(callback != null ? callback.stub(Arena.global()) : MemorySegment.NULL);
     }
 
-    ///Adds the specified SDL_GameControllerDB gamepad mappings.
-    ///
-    ///This function parses the specified ASCII encoded string and updates the
-    ///internal list with any gamepad mappings it finds.  This string may
-    ///contain either a single gamepad mapping or many mappings separated by
-    ///newlines.  The parser supports the full format of the `gamecontrollerdb.txt`
-    ///source file including empty lines and comments.
-    ///
-    ///See gamepad_mapping for a description of the format.
-    ///
-    ///If there is already a gamepad mapping for a given GUID in the internal list,
-    ///it will be replaced by the one passed to this function.  If the library is
-    ///terminated and re-initialized the internal list will revert to the built-in
-    ///default.
-    ///
-    ///@param string The string containing the gamepad mappings.
-    ///@return `GLFW_TRUE` if successful, or `GLFW_FALSE` if an
-    ///error occurred.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-    ///[GLFW_INVALID_VALUE][#GLFW_INVALID_VALUE].
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
-    ///
-    ///@see #glfwJoystickIsGamepad(int) glfwJoystickIsGamepad
-    ///@see #glfwGetGamepadName(int) glfwGetGamepadName
     public static @CType("int") boolean glfwUpdateGamepadMappings(@CType("const char*") java.lang.foreign.MemorySegment string) {
         try {
             return (int) Handles.MH_glfwUpdateGamepadMappings.invokeExact(string) != GLFW.GLFW_FALSE;
         } catch (Throwable e) { throw new RuntimeException("error in glfwUpdateGamepadMappings", e); }
     }
 
-    ///Adds the specified SDL_GameControllerDB gamepad mappings.
-    ///
-    ///This function parses the specified ASCII encoded string and updates the
-    ///internal list with any gamepad mappings it finds.  This string may
-    ///contain either a single gamepad mapping or many mappings separated by
-    ///newlines.  The parser supports the full format of the `gamecontrollerdb.txt`
-    ///source file including empty lines and comments.
-    ///
-    ///See gamepad_mapping for a description of the format.
-    ///
-    ///If there is already a gamepad mapping for a given GUID in the internal list,
-    ///it will be replaced by the one passed to this function.  If the library is
-    ///terminated and re-initialized the internal list will revert to the built-in
-    ///default.
-    ///
-    ///@param string The string containing the gamepad mappings.
-    ///@return `GLFW_TRUE` if successful, or `GLFW_FALSE` if an
-    ///error occurred.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-    ///[GLFW_INVALID_VALUE][#GLFW_INVALID_VALUE].
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
-    ///
-    ///@see #glfwJoystickIsGamepad(int) glfwJoystickIsGamepad
-    ///@see #glfwGetGamepadName(int) glfwGetGamepadName
     public static @CType("int") boolean glfwUpdateGamepadMappings(@CType("const char*") java.lang.String string) {
         try (var __overrungl_stack = MemoryStack.pushLocal()) {
             return (int) Handles.MH_glfwUpdateGamepadMappings.invokeExact(Marshal.marshal(__overrungl_stack, string)) != GLFW.GLFW_FALSE;
         } catch (Throwable e) { throw new RuntimeException("error in glfwUpdateGamepadMappings", e); }
     }
 
-    ///Returns the human-readable gamepad name for the specified joystick.
-    ///
-    ///This function returns the human-readable name of the gamepad from the
-    ///gamepad mapping assigned to the specified joystick.
-    ///
-    ///If the specified joystick is not present or does not have a gamepad mapping
-    ///this function will return `NULL` but will not generate an error.  Call
-    ///[glfwJoystickPresent][#glfwJoystickPresent(int)] to check whether it is present regardless of
-    ///whether it has a mapping.
-    ///
-    ///@param jid The joystick to query.
-    ///@return The UTF-8 encoded name of the gamepad, or `NULL` if the
-    ///joystick is not present, does not have a mapping or an
-    ///error occurred.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and [GLFW_INVALID_ENUM][#GLFW_INVALID_ENUM].
-    ///
-    ///@glfw.pointer_lifetime The returned string is allocated and freed by GLFW.  You
-    ///should not free it yourself.  It is valid until the specified joystick is
-    ///disconnected, the gamepad mappings are updated or the library is terminated.
-    ///@glfw.thread_safety This function must only be called from the main thread.
-    ///
-    ///@see #glfwJoystickIsGamepad(int) glfwJoystickIsGamepad
     public static @CType("const char*") java.lang.foreign.MemorySegment glfwGetGamepadName_(@CType("int") int jid) {
         try {
             return (java.lang.foreign.MemorySegment) Handles.MH_glfwGetGamepadName.invokeExact(jid);
         } catch (Throwable e) { throw new RuntimeException("error in glfwGetGamepadName", e); }
     }
 
-    ///Returns the human-readable gamepad name for the specified joystick.
-    ///
-    ///This function returns the human-readable name of the gamepad from the
-    ///gamepad mapping assigned to the specified joystick.
-    ///
-    ///If the specified joystick is not present or does not have a gamepad mapping
-    ///this function will return `NULL` but will not generate an error.  Call
-    ///[glfwJoystickPresent][#glfwJoystickPresent(int)] to check whether it is present regardless of
-    ///whether it has a mapping.
-    ///
-    ///@param jid The joystick to query.
-    ///@return The UTF-8 encoded name of the gamepad, or `NULL` if the
-    ///joystick is not present, does not have a mapping or an
-    ///error occurred.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and [GLFW_INVALID_ENUM][#GLFW_INVALID_ENUM].
-    ///
-    ///@glfw.pointer_lifetime The returned string is allocated and freed by GLFW.  You
-    ///should not free it yourself.  It is valid until the specified joystick is
-    ///disconnected, the gamepad mappings are updated or the library is terminated.
-    ///@glfw.thread_safety This function must only be called from the main thread.
-    ///
-    ///@see #glfwJoystickIsGamepad(int) glfwJoystickIsGamepad
     public static @CType("const char*") java.lang.String glfwGetGamepadName(@CType("int") int jid) {
         try {
             return Unmarshal.unmarshalAsString((java.lang.foreign.MemorySegment) Handles.MH_glfwGetGamepadName.invokeExact(jid));
         } catch (Throwable e) { throw new RuntimeException("error in glfwGetGamepadName", e); }
     }
 
-    ///Retrieves the state of the specified joystick remapped as a gamepad.
-    ///
-    ///This function retrieves the state of the specified joystick remapped to
-    ///an Xbox-like gamepad.
-    ///
-    ///If the specified joystick is not present or does not have a gamepad mapping
-    ///this function will return `GLFW_FALSE` but will not generate an error.  Call
-    ///[glfwJoystickPresent][#glfwJoystickPresent(int)] to check whether it is present regardless of
-    ///whether it has a mapping.
-    ///
-    ///The Guide button may not be available for input as it is often hooked by the
-    ///system or the Steam client.
-    ///
-    ///Not all devices have all the buttons or axes provided by
-    ///[GLFWGamepadState].  Unavailable buttons and axes will always report
-    ///`GLFW_RELEASE` and 0.0 respectively.
-    ///
-    ///@param jid The joystick to query.
-    ///@param state The gamepad input state of the joystick.
-    ///@return `GLFW_TRUE` if successful, or `GLFW_FALSE` if no joystick is
-    ///connected, it has no gamepad mapping or an error
-    ///occurred.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-    ///[GLFW_INVALID_ENUM][#GLFW_INVALID_ENUM].
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
-    ///
-    ///@see #glfwUpdateGamepadMappings(MemorySegment) glfwUpdateGamepadMappings
-    ///@see #glfwJoystickIsGamepad(int) glfwJoystickIsGamepad
     public static @CType("int") boolean glfwGetGamepadState(@CType("int") int jid, @CType("GLFWgamepadstate*") java.lang.foreign.MemorySegment state) {
         try {
             return (int) Handles.MH_glfwGetGamepadState.invokeExact(jid, state) != GLFW.GLFW_FALSE;
         } catch (Throwable e) { throw new RuntimeException("error in glfwGetGamepadState", e); }
     }
 
-    ///Retrieves the state of the specified joystick remapped as a gamepad.
-    ///
-    ///This function retrieves the state of the specified joystick remapped to
-    ///an Xbox-like gamepad.
-    ///
-    ///If the specified joystick is not present or does not have a gamepad mapping
-    ///this function will return `GLFW_FALSE` but will not generate an error.  Call
-    ///[glfwJoystickPresent][#glfwJoystickPresent(int)] to check whether it is present regardless of
-    ///whether it has a mapping.
-    ///
-    ///The Guide button may not be available for input as it is often hooked by the
-    ///system or the Steam client.
-    ///
-    ///Not all devices have all the buttons or axes provided by
-    ///[GLFWGamepadState].  Unavailable buttons and axes will always report
-    ///`GLFW_RELEASE` and 0.0 respectively.
-    ///
-    ///@param jid The joystick to query.
-    ///@param state The gamepad input state of the joystick.
-    ///@return `GLFW_TRUE` if successful, or `GLFW_FALSE` if no joystick is
-    ///connected, it has no gamepad mapping or an error
-    ///occurred.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-    ///[GLFW_INVALID_ENUM][#GLFW_INVALID_ENUM].
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
-    ///
-    ///@see #glfwUpdateGamepadMappings(MemorySegment) glfwUpdateGamepadMappings
-    ///@see #glfwJoystickIsGamepad(int) glfwJoystickIsGamepad
     public static @CType("int") boolean glfwGetGamepadState(@CType("int") int jid, @CType("GLFWgamepadstate*") overrungl.glfw.GLFWGamepadState state) {
         try {
             return (int) Handles.MH_glfwGetGamepadState.invokeExact(jid, Marshal.marshal(state)) != GLFW.GLFW_FALSE;
         } catch (Throwable e) { throw new RuntimeException("error in glfwGetGamepadState", e); }
     }
 
-    ///Sets the clipboard to the specified string.
-    ///
-    ///This function sets the system clipboard to the specified, UTF-8 encoded
-    ///string.
-    ///
-    ///@param window Deprecated.  Any valid window or `NULL`.
-    ///@param string A UTF-8 encoded string.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-    ///[GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-    ///
-    ///@glfw.remark __Windows:__ The clipboard on Windows has a single global lock for reading and
-    ///writing.  GLFW tries to acquire it a few times, which is almost always enough.  If it
-    ///cannot acquire the lock then this function emits [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR] and returns.
-    ///It is safe to try this multiple times.
-    ///
-    ///@glfw.pointer_lifetime The specified string is copied before this function
-    ///returns.
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
-    ///
-    ///@see #glfwGetClipboardString(MemorySegment) glfwGetClipboardString
     public static void glfwSetClipboardString(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("const char*") java.lang.foreign.MemorySegment string) {
         try {
             Handles.MH_glfwSetClipboardString.invokeExact(window, string);
         } catch (Throwable e) { throw new RuntimeException("error in glfwSetClipboardString", e); }
     }
 
-    ///Sets the clipboard to the specified string.
-    ///
-    ///This function sets the system clipboard to the specified, UTF-8 encoded
-    ///string.
-    ///
-    ///@param window Deprecated.  Any valid window or `NULL`.
-    ///@param string A UTF-8 encoded string.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-    ///[GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-    ///
-    ///@glfw.remark __Windows:__ The clipboard on Windows has a single global lock for reading and
-    ///writing.  GLFW tries to acquire it a few times, which is almost always enough.  If it
-    ///cannot acquire the lock then this function emits [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR] and returns.
-    ///It is safe to try this multiple times.
-    ///
-    ///@glfw.pointer_lifetime The specified string is copied before this function
-    ///returns.
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
-    ///
-    ///@see #glfwGetClipboardString(MemorySegment) glfwGetClipboardString
     public static void glfwSetClipboardString(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("const char*") java.lang.String string) {
         try (var __overrungl_stack = MemoryStack.pushLocal()) {
             Handles.MH_glfwSetClipboardString.invokeExact(window, Marshal.marshal(__overrungl_stack, string));
         } catch (Throwable e) { throw new RuntimeException("error in glfwSetClipboardString", e); }
     }
 
-    ///Returns the contents of the clipboard as a string.
-    ///
-    ///This function returns the contents of the system clipboard, if it contains
-    ///or is convertible to a UTF-8 encoded string.  If the clipboard is empty or
-    ///if its contents cannot be converted, `NULL` is returned and a
-    ///[GLFW_FORMAT_UNAVAILABLE][#GLFW_FORMAT_UNAVAILABLE] error is generated.
-    ///
-    ///@param window Deprecated.  Any valid window or `NULL`.
-    ///@return The contents of the clipboard as a UTF-8 encoded string, or `NULL`
-    ///if an error occurred.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED],
-    ///[GLFW_FORMAT_UNAVAILABLE][#GLFW_FORMAT_UNAVAILABLE] and [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-    ///
-    ///@glfw.remark __Windows:__ The clipboard on Windows has a single global lock for reading and
-    ///writing.  GLFW tries to acquire it a few times, which is almost always enough.  If it
-    ///cannot acquire the lock then this function emits [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR] and returns.
-    ///It is safe to try this multiple times.
-    ///
-    ///@glfw.pointer_lifetime The returned string is allocated and freed by GLFW.  You
-    ///should not free it yourself.  It is valid until the next call to
-    ///`glfwGetClipboardString` or [glfwSetClipboardString][#glfwSetClipboardString(MemorySegment, MemorySegment)], or until the library
-    ///is terminated.
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
-    ///
-    ///@see #glfwSetClipboardString(MemorySegment, MemorySegment) glfwSetClipboardString
     public static @CType("const char*") java.lang.foreign.MemorySegment glfwGetClipboardString_(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window) {
         try {
             return (java.lang.foreign.MemorySegment) Handles.MH_glfwGetClipboardString.invokeExact(window);
         } catch (Throwable e) { throw new RuntimeException("error in glfwGetClipboardString", e); }
     }
 
-    ///Returns the contents of the clipboard as a string.
-    ///
-    ///This function returns the contents of the system clipboard, if it contains
-    ///or is convertible to a UTF-8 encoded string.  If the clipboard is empty or
-    ///if its contents cannot be converted, `NULL` is returned and a
-    ///[GLFW_FORMAT_UNAVAILABLE][#GLFW_FORMAT_UNAVAILABLE] error is generated.
-    ///
-    ///@param window Deprecated.  Any valid window or `NULL`.
-    ///@return The contents of the clipboard as a UTF-8 encoded string, or `NULL`
-    ///if an error occurred.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED],
-    ///[GLFW_FORMAT_UNAVAILABLE][#GLFW_FORMAT_UNAVAILABLE] and [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-    ///
-    ///@glfw.remark __Windows:__ The clipboard on Windows has a single global lock for reading and
-    ///writing.  GLFW tries to acquire it a few times, which is almost always enough.  If it
-    ///cannot acquire the lock then this function emits [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR] and returns.
-    ///It is safe to try this multiple times.
-    ///
-    ///@glfw.pointer_lifetime The returned string is allocated and freed by GLFW.  You
-    ///should not free it yourself.  It is valid until the next call to
-    ///`glfwGetClipboardString` or [glfwSetClipboardString][#glfwSetClipboardString(MemorySegment, MemorySegment)], or until the library
-    ///is terminated.
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
-    ///
-    ///@see #glfwSetClipboardString(MemorySegment, MemorySegment) glfwSetClipboardString
     public static @CType("const char*") java.lang.String glfwGetClipboardString(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window) {
         try {
             return Unmarshal.unmarshalAsString((java.lang.foreign.MemorySegment) Handles.MH_glfwGetClipboardString.invokeExact(window));
         } catch (Throwable e) { throw new RuntimeException("error in glfwGetClipboardString", e); }
     }
 
-    ///Returns the GLFW time.
-    ///
-    ///This function returns the current GLFW time, in seconds.  Unless the time
-    ///has been set using [glfwSetTime][#glfwSetTime(double)] it measures time elapsed since GLFW was
-    ///initialized.
-    ///
-    ///This function and [glfwSetTime][#glfwSetTime(double)] are helper functions on top of
-    ///[glfwGetTimerFrequency][#glfwGetTimerFrequency()] and [glfwGetTimerValue][#glfwGetTimerValue()].
-    ///
-    ///The resolution of the timer is system dependent, but is usually on the order
-    ///of a few micro- or nanoseconds.  It uses the highest-resolution monotonic
-    ///time source on each operating system.
-    ///
-    ///@return The current time, in seconds, or zero if an
-    ///error occurred.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-    ///
-    ///@glfw.thread_safety This function may be called from any thread.  Reading and
-    ///writing of the internal base time is not atomic, so it needs to be
-    ///externally synchronized with calls to [glfwSetTime][#glfwSetTime(double)].
     public static @CType("double") double glfwGetTime() {
         try {
             return (double) Handles.MH_glfwGetTime.invokeExact();
         } catch (Throwable e) { throw new RuntimeException("error in glfwGetTime", e); }
     }
 
-    ///Sets the GLFW time.
-    ///
-    ///This function sets the current GLFW time, in seconds.  The value must be
-    ///a positive finite number less than or equal to 18446744073.0, which is
-    ///approximately 584.5 years.
-    ///
-    ///This function and [glfwGetTime][#glfwGetTime()] are helper functions on top of
-    ///[glfwGetTimerFrequency][#glfwGetTimerFrequency()] and [glfwGetTimerValue][#glfwGetTimerValue()].
-    ///
-    ///@param time The new value, in seconds.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-    ///[GLFW_INVALID_VALUE][#GLFW_INVALID_VALUE].
-    ///
-    ///@glfw.remark The upper limit of GLFW time is calculated as
-    ///floor((2<sup>64</sup> - 1) / 10<sup>9</sup>) and is due to implementations
-    ///storing nanoseconds in 64 bits.  The limit may be increased in the future.
-    ///
-    ///@glfw.thread_safety This function may be called from any thread.  Reading and
-    ///writing of the internal base time is not atomic, so it needs to be
-    ///externally synchronized with calls to [glfwGetTime][#glfwGetTime()].
     public static void glfwSetTime(@CType("double") double time) {
         try {
             Handles.MH_glfwSetTime.invokeExact(time);
         } catch (Throwable e) { throw new RuntimeException("error in glfwSetTime", e); }
     }
 
-    ///Returns the current value of the raw timer.
-    ///
-    ///This function returns the current value of the raw timer, measured in
-    ///1&nbsp;/&nbsp;frequency seconds.  To get the frequency, call
-    ///[glfwGetTimerFrequency][#glfwGetTimerFrequency()].
-    ///
-    ///@return The value of the timer, or zero if an
-    ///error occurred.
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-    ///@glfw.thread_safety This function may be called from any thread.
-    ///
-    ///@see #glfwGetTimerFrequency() glfwGetTimerFrequency
     public static @CType("uint64_t") long glfwGetTimerValue() {
         try {
             return (long) Handles.MH_glfwGetTimerValue.invokeExact();
         } catch (Throwable e) { throw new RuntimeException("error in glfwGetTimerValue", e); }
     }
 
-    ///Returns the frequency, in Hz, of the raw timer.
-    ///
-    ///This function returns the frequency, in Hz, of the raw timer.
-    ///
-    ///@return The frequency of the timer, in Hz, or zero if an
-    ///error occurred.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-    ///
-    ///@glfw.thread_safety This function may be called from any thread.
-    ///
-    ///@see #glfwGetTimerValue() glfwGetTimerValue
     public static @CType("uint64_t") long glfwGetTimerFrequency() {
         try {
             return (long) Handles.MH_glfwGetTimerFrequency.invokeExact();
         } catch (Throwable e) { throw new RuntimeException("error in glfwGetTimerFrequency", e); }
     }
 
-    ///Makes the context of the specified window current for the calling
-    ///thread.
-    ///
-    ///This function makes the OpenGL or OpenGL ES context of the specified window
-    ///current on the calling thread.  It can also detach the current context from
-    ///the calling thread without making a new one current by passing in `NULL`.
-    ///
-    ///A context must only be made current on a single thread at a time and each
-    ///thread can have only a single current context at a time.  Making a context
-    ///current detaches any previously current context on the calling thread.
-    ///
-    ///When moving a context between threads, you must detach it (make it
-    ///non-current) on the old thread before making it current on the new one.
-    ///
-    ///By default, making a context non-current implicitly forces a pipeline flush.
-    ///On machines that support `GL_KHR_context_flush_control`, you can control
-    ///whether a context performs this flush by setting the
-    ///[GLFW_CONTEXT_RELEASE_BEHAVIOR][#GLFW_CONTEXT_RELEASE_BEHAVIOR]
-    ///hint.
-    ///
-    ///The specified window must have an OpenGL or OpenGL ES context.  Specifying
-    ///a window without a context will generate a [GLFW_NO_WINDOW_CONTEXT][#GLFW_NO_WINDOW_CONTEXT]
-    ///error.
-    ///
-    ///@param window The window whose context to make current, or `NULL` to
-    ///detach the current context.
-    ///
-    ///@glfw.remark If the previously current context was created via a different
-    ///context creation API than the one passed to this function, GLFW will still
-    ///detach the previous one from its API before making the new one current.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED],
-    ///[GLFW_NO_WINDOW_CONTEXT][#GLFW_NO_WINDOW_CONTEXT] and [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-    ///
-    ///@glfw.thread_safety This function may be called from any thread.
-    ///
-    ///@see #glfwGetCurrentContext() glfwGetCurrentContext
     public static void glfwMakeContextCurrent(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window) {
         try {
             Handles.MH_glfwMakeContextCurrent.invokeExact(window);
         } catch (Throwable e) { throw new RuntimeException("error in glfwMakeContextCurrent", e); }
     }
 
-    ///Returns the window whose context is current on the calling thread.
-    ///
-    ///This function returns the window whose OpenGL or OpenGL ES context is
-    ///current on the calling thread.
-    ///
-    ///@return The window whose context is current, or `NULL` if no window's
-    ///context is current.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-    ///
-    ///@glfw.thread_safety This function may be called from any thread.
-    ///
-    ///@see #glfwMakeContextCurrent(MemorySegment) glfwMakeContextCurrent
     public static @CType("GLFWwindow*") java.lang.foreign.MemorySegment glfwGetCurrentContext() {
         try {
             return (java.lang.foreign.MemorySegment) Handles.MH_glfwGetCurrentContext.invokeExact();
         } catch (Throwable e) { throw new RuntimeException("error in glfwGetCurrentContext", e); }
     }
 
-    ///Swaps the front and back buffers of the specified window.
-    ///
-    ///This function swaps the front and back buffers of the specified window when
-    ///rendering with OpenGL or OpenGL ES.  If the swap interval is greater than
-    ///zero, the GPU driver waits the specified number of screen updates before
-    ///swapping the buffers.
-    ///
-    ///The specified window must have an OpenGL or OpenGL ES context.  Specifying
-    ///a window without a context will generate a [GLFW_NO_WINDOW_CONTEXT][#GLFW_NO_WINDOW_CONTEXT]
-    ///error.
-    ///
-    ///This function does not apply to Vulkan.  If you are rendering with Vulkan,
-    ///see `vkQueuePresentKHR` instead.
-    ///
-    ///@param window The window whose buffers to swap.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED],
-    ///[GLFW_NO_WINDOW_CONTEXT][#GLFW_NO_WINDOW_CONTEXT] and [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-    ///
-    ///@glfw.remark __EGL:__ The context of the specified window must be current on the
-    ///calling thread.
-    ///
-    ///@glfw.thread_safety This function may be called from any thread.
-    ///
-    ///@see #glfwSwapInterval(int) glfwSwapInterval
     public static void glfwSwapBuffers(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window) {
         try {
             Handles.MH_glfwSwapBuffers.invokeExact(window);
         } catch (Throwable e) { throw new RuntimeException("error in glfwSwapBuffers", e); }
     }
 
-    ///Sets the swap interval for the current context.
-    ///
-    ///This function sets the swap interval for the current OpenGL or OpenGL ES
-    ///context, i.e. the number of screen updates to wait from the time
-    ///[glfwSwapBuffers][#glfwSwapBuffers(MemorySegment)] was called before swapping the buffers and returning.  This
-    ///is sometimes called _vertical synchronization_, _vertical retrace
-    ///synchronization_ or just _vsync_.
-    ///
-    ///A context that supports either of the `WGL_EXT_swap_control_tear` and
-    ///`GLX_EXT_swap_control_tear` extensions also accepts _negative_ swap
-    ///intervals, which allows the driver to swap immediately even if a frame
-    ///arrives a little bit late.  You can check for these extensions with
-    ///[glfwExtensionSupported][#glfwExtensionSupported(MemorySegment)].
-    ///
-    ///A context must be current on the calling thread.  Calling this function
-    ///without a current context will cause a [GLFW_NO_CURRENT_CONTEXT][#GLFW_NO_CURRENT_CONTEXT] error.
-    ///
-    ///This function does not apply to Vulkan.  If you are rendering with Vulkan,
-    ///see the present mode of your swapchain instead.
-    ///
-    ///@param interval The minimum number of screen updates to wait for
-    ///until the buffers are swapped by [glfwSwapBuffers][#glfwSwapBuffers(MemorySegment)].
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED],
-    ///[GLFW_NO_CURRENT_CONTEXT][#GLFW_NO_CURRENT_CONTEXT] and [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-    ///
-    ///@glfw.remark This function is not called during context creation, leaving the
-    ///swap interval set to whatever is the default for that API.  This is done
-    ///because some swap interval extensions used by GLFW do not allow the swap
-    ///interval to be reset to zero once it has been set to a non-zero value.
-    ///
-    ///Some GPU drivers do not honor the requested swap interval, either
-    ///because of a user setting that overrides the application's request or due to
-    ///bugs in the driver.
-    ///
-    ///@glfw.thread_safety This function may be called from any thread.
-    ///
-    ///@see #glfwSwapBuffers(MemorySegment) glfwSwapBuffers
     public static void glfwSwapInterval(@CType("int") int interval) {
         try {
             Handles.MH_glfwSwapInterval.invokeExact(interval);
         } catch (Throwable e) { throw new RuntimeException("error in glfwSwapInterval", e); }
     }
 
-    ///Returns whether the specified extension is available.
-    ///
-    ///This function returns whether the specified
-    ///API extension is supported by the current OpenGL or
-    ///OpenGL ES context.  It searches both for client API extension and context
-    ///creation API extensions.
-    ///
-    ///A context must be current on the calling thread.  Calling this function
-    ///without a current context will cause a [GLFW_NO_CURRENT_CONTEXT][#GLFW_NO_CURRENT_CONTEXT] error.
-    ///
-    ///As this functions retrieves and searches one or more extension strings each
-    ///call, it is recommended that you cache its results if it is going to be used
-    ///frequently.  The extension strings will not change during the lifetime of
-    ///a context, so there is no danger in doing this.
-    ///
-    ///This function does not apply to Vulkan.  If you are using Vulkan, see
-    ///[glfwGetRequiredInstanceExtensions][#glfwGetRequiredInstanceExtensions(MemorySegment)], `vkEnumerateInstanceExtensionProperties`
-    ///and `vkEnumerateDeviceExtensionProperties` instead.
-    ///
-    ///@param extension The ASCII encoded name of the extension.
-    ///@return `GLFW_TRUE` if the extension is available, or `GLFW_FALSE`
-    ///otherwise.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED],
-    ///[GLFW_NO_CURRENT_CONTEXT][#GLFW_NO_CURRENT_CONTEXT], [GLFW_INVALID_VALUE][#GLFW_INVALID_VALUE] and
-    ///[GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-    ///
-    ///@glfw.thread_safety This function may be called from any thread.
-    ///
-    ///@see #glfwGetProcAddress(MemorySegment) glfwGetProcAddress
     public static @CType("int") boolean glfwExtensionSupported(@CType("const char*") java.lang.foreign.MemorySegment extension) {
         try {
             return (int) Handles.MH_glfwExtensionSupported.invokeExact(extension) != GLFW.GLFW_FALSE;
         } catch (Throwable e) { throw new RuntimeException("error in glfwExtensionSupported", e); }
     }
 
-    ///Returns whether the specified extension is available.
-    ///
-    ///This function returns whether the specified
-    ///API extension is supported by the current OpenGL or
-    ///OpenGL ES context.  It searches both for client API extension and context
-    ///creation API extensions.
-    ///
-    ///A context must be current on the calling thread.  Calling this function
-    ///without a current context will cause a [GLFW_NO_CURRENT_CONTEXT][#GLFW_NO_CURRENT_CONTEXT] error.
-    ///
-    ///As this functions retrieves and searches one or more extension strings each
-    ///call, it is recommended that you cache its results if it is going to be used
-    ///frequently.  The extension strings will not change during the lifetime of
-    ///a context, so there is no danger in doing this.
-    ///
-    ///This function does not apply to Vulkan.  If you are using Vulkan, see
-    ///[glfwGetRequiredInstanceExtensions][#glfwGetRequiredInstanceExtensions(MemorySegment)], `vkEnumerateInstanceExtensionProperties`
-    ///and `vkEnumerateDeviceExtensionProperties` instead.
-    ///
-    ///@param extension The ASCII encoded name of the extension.
-    ///@return `GLFW_TRUE` if the extension is available, or `GLFW_FALSE`
-    ///otherwise.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED],
-    ///[GLFW_NO_CURRENT_CONTEXT][#GLFW_NO_CURRENT_CONTEXT], [GLFW_INVALID_VALUE][#GLFW_INVALID_VALUE] and
-    ///[GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-    ///
-    ///@glfw.thread_safety This function may be called from any thread.
-    ///
-    ///@see #glfwGetProcAddress(MemorySegment) glfwGetProcAddress
     public static @CType("int") boolean glfwExtensionSupported(@CType("const char*") java.lang.String extension) {
         try (var __overrungl_stack = MemoryStack.pushLocal()) {
             return (int) Handles.MH_glfwExtensionSupported.invokeExact(Marshal.marshal(__overrungl_stack, extension)) != GLFW.GLFW_FALSE;
         } catch (Throwable e) { throw new RuntimeException("error in glfwExtensionSupported", e); }
     }
 
-    ///Returns the address of the specified function for the current
-    ///context.
-    ///
-    ///This function returns the address of the specified OpenGL or OpenGL ES
-    ///core or extension function, if it is supported
-    ///by the current context.
-    ///
-    ///A context must be current on the calling thread.  Calling this function
-    ///without a current context will cause a [GLFW_NO_CURRENT_CONTEXT][#GLFW_NO_CURRENT_CONTEXT] error.
-    ///
-    ///This function does not apply to Vulkan.  If you are rendering with Vulkan,
-    ///see [glfwGetInstanceProcAddress][GLFWVulkan#glfwGetInstanceProcAddress(MemorySegment, MemorySegment)], `vkGetInstanceProcAddr` and
-    ///`vkGetDeviceProcAddr` instead.
-    ///
-    ///@param procname The ASCII encoded name of the function.
-    ///@return The address of the function, or `NULL` if an
-    ///error occurred.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED],
-    ///[GLFW_NO_CURRENT_CONTEXT][#GLFW_NO_CURRENT_CONTEXT] and [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-    ///
-    ///@glfw.remark The address of a given function is not guaranteed to be the same
-    ///between contexts.
-    ///
-    ///This function may return a non-`NULL` address despite the
-    ///associated version or extension not being available.  Always check the
-    ///context version or extension string first.
-    ///
-    ///@glfw.pointer_lifetime The returned function pointer is valid until the context
-    ///is destroyed or the library is terminated.
-    ///
-    ///@glfw.thread_safety This function may be called from any thread.
-    ///
-    ///@see #glfwExtensionSupported(MemorySegment) glfwExtensionSupported
     public static @CType("GLFWglproc") java.lang.foreign.MemorySegment glfwGetProcAddress(@CType("const char*") java.lang.foreign.MemorySegment procname) {
         try {
             return (java.lang.foreign.MemorySegment) Handles.MH_glfwGetProcAddress.invokeExact(procname);
         } catch (Throwable e) { throw new RuntimeException("error in glfwGetProcAddress", e); }
     }
 
-    ///Returns the address of the specified function for the current
-    ///context.
-    ///
-    ///This function returns the address of the specified OpenGL or OpenGL ES
-    ///core or extension function, if it is supported
-    ///by the current context.
-    ///
-    ///A context must be current on the calling thread.  Calling this function
-    ///without a current context will cause a [GLFW_NO_CURRENT_CONTEXT][#GLFW_NO_CURRENT_CONTEXT] error.
-    ///
-    ///This function does not apply to Vulkan.  If you are rendering with Vulkan,
-    ///see [glfwGetInstanceProcAddress][GLFWVulkan#glfwGetInstanceProcAddress(MemorySegment, MemorySegment)], `vkGetInstanceProcAddr` and
-    ///`vkGetDeviceProcAddr` instead.
-    ///
-    ///@param procname The ASCII encoded name of the function.
-    ///@return The address of the function, or `NULL` if an
-    ///error occurred.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED],
-    ///[GLFW_NO_CURRENT_CONTEXT][#GLFW_NO_CURRENT_CONTEXT] and [GLFW_PLATFORM_ERROR][#GLFW_PLATFORM_ERROR].
-    ///
-    ///@glfw.remark The address of a given function is not guaranteed to be the same
-    ///between contexts.
-    ///
-    ///This function may return a non-`NULL` address despite the
-    ///associated version or extension not being available.  Always check the
-    ///context version or extension string first.
-    ///
-    ///@glfw.pointer_lifetime The returned function pointer is valid until the context
-    ///is destroyed or the library is terminated.
-    ///
-    ///@glfw.thread_safety This function may be called from any thread.
-    ///
-    ///@see #glfwExtensionSupported(MemorySegment) glfwExtensionSupported
     public static @CType("GLFWglproc") java.lang.foreign.MemorySegment glfwGetProcAddress(@CType("const char*") java.lang.String procname) {
         try (var __overrungl_stack = MemoryStack.pushLocal()) {
             return (java.lang.foreign.MemorySegment) Handles.MH_glfwGetProcAddress.invokeExact(Marshal.marshal(__overrungl_stack, procname));
         } catch (Throwable e) { throw new RuntimeException("error in glfwGetProcAddress", e); }
     }
 
-    ///Returns whether the Vulkan loader and an ICD have been found.
-    ///
-    ///This function returns whether the Vulkan loader and any minimally functional
-    ///ICD have been found.
-    ///
-    ///The availability of a Vulkan loader and even an ICD does not by itself guarantee that
-    ///surface creation or even instance creation is possible.  Call
-    ///[glfwGetRequiredInstanceExtensions][#glfwGetRequiredInstanceExtensions(MemorySegment)] to check whether the extensions necessary for Vulkan
-    ///surface creation are available and [glfwGetPhysicalDevicePresentationSupport][GLFWVulkan#glfwGetPhysicalDevicePresentationSupport(MemorySegment, MemorySegment, int)] to
-    ///check whether a queue family of a physical device supports image presentation.
-    ///
-    ///@return `GLFW_TRUE` if Vulkan is minimally available, or `GLFW_FALSE`
-    ///otherwise.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED].
-    ///
-    ///@glfw.thread_safety This function may be called from any thread.
     public static @CType("int") boolean glfwVulkanSupported() {
         try {
             return (int) Handles.MH_glfwVulkanSupported.invokeExact() != GLFW.GLFW_FALSE;
         } catch (Throwable e) { throw new RuntimeException("error in glfwVulkanSupported", e); }
     }
 
-    ///Returns the Vulkan instance extensions required by GLFW.
-    ///
-    ///This function returns an array of names of Vulkan instance extensions required
-    ///by GLFW for creating Vulkan surfaces for GLFW windows.  If successful, the
-    ///list will always contain `VK_KHR_surface`, so if you don't require any
-    ///additional extensions you can pass this list directly to the
-    ///`VkInstanceCreateInfo` struct.
-    ///
-    ///If Vulkan is not available on the machine, this function returns `NULL` and
-    ///generates a [GLFW_API_UNAVAILABLE][#GLFW_API_UNAVAILABLE] error.  Call [glfwVulkanSupported][#glfwVulkanSupported()]
-    ///to check whether Vulkan is at least minimally available.
-    ///
-    ///If Vulkan is available but no set of extensions allowing window surface
-    ///creation was found, this function returns `NULL`.  You may still use Vulkan
-    ///for off-screen rendering and compute work.
-    ///
-    ///@param count Where to store the number of extensions in the returned
-    ///array.  This is set to zero if an error occurred.
-    ///@return An array of ASCII encoded extension names, or `NULL` if an
-    ///error occurred.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][#GLFW_NOT_INITIALIZED] and
-    ///[GLFW_API_UNAVAILABLE][#GLFW_API_UNAVAILABLE].
-    ///
-    ///@glfw.remark Additional extensions may be required by future versions of GLFW.
-    ///You should check if any extensions you wish to enable are already in the
-    ///returned array, as it is an error to specify an extension more than once in
-    ///the `VkInstanceCreateInfo` struct.
-    ///
-    ///@glfw.pointer_lifetime The returned array is allocated and freed by GLFW.  You
-    ///should not free it yourself.  It is guaranteed to be valid only until the
-    ///library is terminated.
-    ///
-    ///@glfw.thread_safety This function may be called from any thread.
-    ///
-    ///@see GLFWVulkan#glfwCreateWindowSurface(MemorySegment, MemorySegment, MemorySegment, MemorySegment) glfwCreateWindowSurface
     public static @CType("const char**") java.lang.foreign.MemorySegment glfwGetRequiredInstanceExtensions(@Out @CType("uint32_t*") java.lang.foreign.MemorySegment count) {
         try {
             return (java.lang.foreign.MemorySegment) Handles.MH_glfwGetRequiredInstanceExtensions.invokeExact(count);
@@ -6999,11 +1694,6 @@ public final class GLFW {
     private GLFW() {
     }
 
-    /// Returns the currently connected monitors.
-    ///
-    /// @return An array of monitor handles, or `NULL` if no monitors were found or
-    /// if an error occurred.
-    /// @see #glfwGetMonitors(MemorySegment)
     public static MemorySegment[] glfwGetMonitors() {
         try (var stack = MemoryStack.pushLocal()) {
             MemorySegment c = stack.allocate(JAVA_INT);
@@ -7012,12 +1702,6 @@ public final class GLFW {
         }
     }
 
-    /// Returns the available video modes for the specified monitor.
-    ///
-    /// @param monitor The monitor to query.
-    /// @return An array of video modes, or `NULL` if an
-    /// error occurred.
-    /// @see #glfwGetVideoModes(MemorySegment, MemorySegment)
     public static GLFWVidMode glfwGetVideoModes(MemorySegment monitor) {
         try (var stack = MemoryStack.pushLocal()) {
             MemorySegment c = stack.allocate(JAVA_INT);
@@ -7026,21 +1710,10 @@ public final class GLFW {
         }
     }
 
-    /// Sets the icon for the specified window.
-    ///
-    /// @param window The window whose icon to set.
-    /// @param images The images to create the icon from.  This is ignored if count is zero.
-    /// @see #glfwSetWindowIcon(MemorySegment, int, MemorySegment)
     public static void glfwSetWindowIcon(MemorySegment window, GLFWImage images) {
         glfwSetWindowIcon(window, images != null ? Math.toIntExact(images.estimateCount()) : 0, images);
     }
 
-    /// Returns the values of all axes of the specified joystick.
-    ///
-    /// @param jid The joystick to query.
-    /// @return An array of axis values, or `NULL` if the joystick is not present or
-    /// an error occurred.
-    /// @see #glfwGetJoystickAxes(int, MemorySegment)
     public static float[] glfwGetJoystickAxes(int jid) {
         try (var stack = MemoryStack.pushLocal()) {
             MemorySegment c = stack.allocate(JAVA_INT);
@@ -7049,12 +1722,6 @@ public final class GLFW {
         }
     }
 
-    /// Returns the state of all buttons of the specified joystick.
-    ///
-    /// @param jid The joystick to query.
-    /// @return An array of button states, or `NULL` if the joystick is not present
-    /// or an error occurred.
-    /// @see #glfwGetJoystickButtons(int, MemorySegment)
     public static byte[] glfwGetJoystickButtons(int jid) {
         try (var stack = MemoryStack.pushLocal()) {
             MemorySegment c = stack.allocate(JAVA_INT);
@@ -7063,12 +1730,6 @@ public final class GLFW {
         }
     }
 
-    /// Returns the state of all hats of the specified joystick.
-    ///
-    /// @param jid The joystick to query.
-    /// @return An array of hat states, or `NULL` if the joystick is not present
-    /// or an error occurred.
-    /// @see #glfwGetJoystickHats(int, MemorySegment)
     public static byte[] glfwGetJoystickHats(int jid) {
         try (var stack = MemoryStack.pushLocal()) {
             MemorySegment c = stack.allocate(JAVA_INT);
@@ -7077,11 +1738,6 @@ public final class GLFW {
         }
     }
 
-    /// Returns the Vulkan instance extensions required by GLFW.
-    ///
-    /// @return An array of ASCII encoded extension names, or `NULL` if an
-    /// error occurred.
-    /// @see #glfwGetRequiredInstanceExtensions(MemorySegment)
     public static String[] glfwGetRequiredInstanceExtensions() {
         try (var stack = MemoryStack.pushLocal()) {
             MemorySegment c = stack.allocate(JAVA_INT);

--- a/modules/overrungl.glfw/src/main/java/overrungl/glfw/GLFWAllocateFun.java
+++ b/modules/overrungl.glfw/src/main/java/overrungl/glfw/GLFWAllocateFun.java
@@ -23,15 +23,6 @@ import overrungl.annotation.*;
 import overrungl.upcall.*;
 import overrungl.util.*;
 
-/// The function pointer type for memory allocation callbacks.
-/// 
-/// This is the function pointer type for memory allocation callbacks.  A memory
-/// allocation callback function has the following signature:
-/// ```java
-/// MemorySegment function_name(long size, MemorySegment user)
-/// ```
-/// 
-/// @see GLFWAllocator
 @FunctionalInterface
 public interface GLFWAllocateFun extends Upcall {
     /// The function descriptor.
@@ -39,86 +30,14 @@ public interface GLFWAllocateFun extends Upcall {
     /// The method handle of the target method.
     MethodHandle HANDLE = Upcall.findTarget(GLFWAllocateFun.class, "invoke", DESCRIPTOR);
 
-    ///The target method of the upcall.
-    ///
-    ///This function must return either a memory block at least `size` bytes long,
-    ///or `NULL` if allocation failed.  Note that not all parts of GLFW handle allocation
-    ///failures gracefully yet.
-    ///
-    ///This function must support being called during [glfwInit][GLFW#glfwInit()] but before the library is
-    ///flagged as initialized, as well as during [glfwTerminate][GLFW#glfwTerminate()] after the library is no
-    ///longer flagged as initialized.
-    ///
-    ///Any memory allocated via this function will be deallocated via the same allocator
-    ///during library termination or earlier.
-    ///
-    ///Any memory allocated via this function must be suitably aligned for any object type.
-    ///If you are using C99 or earlier, this alignment is platform-dependent but will be the
-    ///same as what `malloc` provides.  If you are using C11 or later, this is the value of
-    ///`alignof(max_align_t)`.
-    ///
-    ///The size will always be greater than zero.  Allocations of size zero are filtered out
-    ///before reaching the custom allocator.
-    ///
-    ///If this function returns `NULL`, GLFW will emit [GLFW_OUT_OF_MEMORY][GLFW#GLFW_OUT_OF_MEMORY].
-    ///
-    ///This function must not call any GLFW function.
-    ///
-    ///@param size The minimum size, in bytes, of the memory block.
-    ///@param user The user-defined pointer from the allocator.
-    ///@return The address of the newly allocated memory block, or `NULL` if an
-    ///error occurred.
-    ///
-    ///@glfw.pointer_lifetime The returned memory block must be valid at least until it
-    ///is deallocated.
-    ///
-    ///@glfw.reentrancy This function should not call any GLFW function.
-    ///
-    ///@glfw.thread_safety This function must support being called from any thread that calls GLFW
-    ///functions.
+    /// The target method of the upcall.
     @CType("void*") java.lang.foreign.MemorySegment invoke(@CType("size_t") long size, @CType("void*") java.lang.foreign.MemorySegment user);
 
     @Override
     default MemorySegment stub(Arena arena) { return Linker.nativeLinker().upcallStub(HANDLE.bindTo(this), DESCRIPTOR, arena); }
 
-    ///A static invoker of the target method.
-    ///
-    ///This function must return either a memory block at least `size` bytes long,
-    ///or `NULL` if allocation failed.  Note that not all parts of GLFW handle allocation
-    ///failures gracefully yet.
-    ///
-    ///This function must support being called during [glfwInit][GLFW#glfwInit()] but before the library is
-    ///flagged as initialized, as well as during [glfwTerminate][GLFW#glfwTerminate()] after the library is no
-    ///longer flagged as initialized.
-    ///
-    ///Any memory allocated via this function will be deallocated via the same allocator
-    ///during library termination or earlier.
-    ///
-    ///Any memory allocated via this function must be suitably aligned for any object type.
-    ///If you are using C99 or earlier, this alignment is platform-dependent but will be the
-    ///same as what `malloc` provides.  If you are using C11 or later, this is the value of
-    ///`alignof(max_align_t)`.
-    ///
-    ///The size will always be greater than zero.  Allocations of size zero are filtered out
-    ///before reaching the custom allocator.
-    ///
-    ///If this function returns `NULL`, GLFW will emit [GLFW_OUT_OF_MEMORY][GLFW#GLFW_OUT_OF_MEMORY].
-    ///
-    ///This function must not call any GLFW function.
-    ///
-    ///@param size The minimum size, in bytes, of the memory block.
-    ///@param user The user-defined pointer from the allocator.
-    ///@return The address of the newly allocated memory block, or `NULL` if an
-    ///error occurred.
-    ///
-    ///@glfw.pointer_lifetime The returned memory block must be valid at least until it
-    ///is deallocated.
-    ///
-    ///@glfw.reentrancy This function should not call any GLFW function.
-    ///
-    ///@glfw.thread_safety This function must support being called from any thread that calls GLFW
-    ///functions.
-    ///@param stub the upcall stub
+    /// A static invoker of the target method.
+    /// @param stub the upcall stub
     static @CType("void*") java.lang.foreign.MemorySegment invoke(MemorySegment stub, @CType("size_t") long size, @CType("void*") java.lang.foreign.MemorySegment user) {
         try { return (java.lang.foreign.MemorySegment) HANDLE.invokeExact(stub, size, user); }
         catch (Throwable e) { throw new RuntimeException("error in GLFWAllocateFun::invoke (static invoker)", e); }

--- a/modules/overrungl.glfw/src/main/java/overrungl/glfw/GLFWAllocator.java
+++ b/modules/overrungl.glfw/src/main/java/overrungl/glfw/GLFWAllocator.java
@@ -24,36 +24,15 @@ import overrungl.annotation.*;
 import overrungl.struct.*;
 import overrungl.util.*;
 
-/// Custom heap memory allocator.
-/// 
-/// This describes a custom heap memory allocator for GLFW.  To set an allocator, pass it
-/// to [glfwInitAllocator][GLFW#glfwInitAllocator(MemorySegment)] before initializing the library.
-///
 /// ## Members
 /// ### allocate
 /// [VarHandle][#VH_allocate] - [Getter][#allocate()] - [Setter][#allocate(java.lang.foreign.MemorySegment)]
-///
-/// The memory allocation function.  See [GLFWAllocateFun] for details about
-/// allocation function.
-///
 /// ### reallocate
 /// [VarHandle][#VH_reallocate] - [Getter][#reallocate()] - [Setter][#reallocate(java.lang.foreign.MemorySegment)]
-///
-/// The memory reallocation function.  See [GLFWReallocateFun] for details about
-/// reallocation function.
-///
 /// ### deallocate
 /// [VarHandle][#VH_deallocate] - [Getter][#deallocate()] - [Setter][#deallocate(java.lang.foreign.MemorySegment)]
-///
-/// The memory deallocation function.  See [GLFWDeallocateFun] for details about
-/// deallocation function.
-///
 /// ### user
 /// [VarHandle][#VH_user] - [Getter][#user()] - [Setter][#user(java.lang.foreign.MemorySegment)]
-///
-/// The user pointer for this custom allocator.  This value will be passed to the
-/// allocator functions.
-///
 /// ## Layout
 /// [Java definition][#LAYOUT]
 /// ```c

--- a/modules/overrungl.glfw/src/main/java/overrungl/glfw/GLFWCharFun.java
+++ b/modules/overrungl.glfw/src/main/java/overrungl/glfw/GLFWCharFun.java
@@ -23,15 +23,6 @@ import overrungl.annotation.*;
 import overrungl.upcall.*;
 import overrungl.util.*;
 
-/// The function pointer type for Unicode character callbacks.
-/// 
-/// This is the function pointer type for Unicode character callbacks.
-/// A Unicode character callback function has the following signature:
-/// ```java
-/// void function_name(MemorySegment window, int codepoint)
-/// ```
-/// 
-/// @see GLFW#glfwSetCharCallback(MemorySegment, MemorySegment)
 @FunctionalInterface
 public interface GLFWCharFun extends Upcall {
     /// The function descriptor.
@@ -39,24 +30,14 @@ public interface GLFWCharFun extends Upcall {
     /// The method handle of the target method.
     MethodHandle HANDLE = Upcall.findTarget(GLFWCharFun.class, "invoke", DESCRIPTOR);
 
-    ///The target method of the upcall.
-    ///
-    ///Invoke
-    ///
-    ///@param window The window that received the event.
-    ///@param codepoint The Unicode code point of the character.
+    /// The target method of the upcall.
     void invoke(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("unsigned int") int codepoint);
 
     @Override
     default MemorySegment stub(Arena arena) { return Linker.nativeLinker().upcallStub(HANDLE.bindTo(this), DESCRIPTOR, arena); }
 
-    ///A static invoker of the target method.
-    ///
-    ///Invoke
-    ///
-    ///@param window The window that received the event.
-    ///@param codepoint The Unicode code point of the character.
-    ///@param stub the upcall stub
+    /// A static invoker of the target method.
+    /// @param stub the upcall stub
     static void invoke(MemorySegment stub, @CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("unsigned int") int codepoint) {
         try { HANDLE.invokeExact(stub, window, codepoint); }
         catch (Throwable e) { throw new RuntimeException("error in GLFWCharFun::invoke (static invoker)", e); }

--- a/modules/overrungl.glfw/src/main/java/overrungl/glfw/GLFWCursorEnterFun.java
+++ b/modules/overrungl.glfw/src/main/java/overrungl/glfw/GLFWCursorEnterFun.java
@@ -23,15 +23,6 @@ import overrungl.annotation.*;
 import overrungl.upcall.*;
 import overrungl.util.*;
 
-/// The function pointer type for cursor enter/leave callbacks.
-/// 
-/// This is the function pointer type for cursor enter/leave callbacks.
-/// A cursor enter/leave callback function has the following signature:
-/// ```java
-/// void function_name(MemorySegment window, boolean entered)
-/// ```
-/// 
-/// @see GLFW#glfwSetCursorEnterCallback(MemorySegment, MemorySegment)
 @FunctionalInterface
 public interface GLFWCursorEnterFun extends Upcall {
     /// The function descriptor.
@@ -39,22 +30,10 @@ public interface GLFWCursorEnterFun extends Upcall {
     /// The method handle of the target method.
     MethodHandle HANDLE = Upcall.findTarget(GLFWCursorEnterFun.class, "invoke", DESCRIPTOR);
 
-    ///The interface target method of the upcall.
-    ///
-    ///Invoke
-    ///
-    ///@param window The window that received the event.
-    ///@param entered `GLFW_TRUE` if the cursor entered the window's content
-    ///area, or `GLFW_FALSE` if it left it.
+    /// The interface target method of the upcall.
     void invoke(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("int") boolean entered);
 
-    ///The target method of the upcall.
-    ///
-    ///Invoke
-    ///
-    ///@param window The window that received the event.
-    ///@param entered `GLFW_TRUE` if the cursor entered the window's content
-    ///area, or `GLFW_FALSE` if it left it.
+    /// The target method of the upcall.
     default void invoke(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("int") int entered) {
         invoke(window, entered != GLFW.GLFW_FALSE);
     }
@@ -62,14 +41,8 @@ public interface GLFWCursorEnterFun extends Upcall {
     @Override
     default MemorySegment stub(Arena arena) { return Linker.nativeLinker().upcallStub(HANDLE.bindTo(this), DESCRIPTOR, arena); }
 
-    ///A static invoker of the target method.
-    ///
-    ///Invoke
-    ///
-    ///@param window The window that received the event.
-    ///@param entered `GLFW_TRUE` if the cursor entered the window's content
-    ///area, or `GLFW_FALSE` if it left it.
-    ///@param stub the upcall stub
+    /// A static invoker of the target method.
+    /// @param stub the upcall stub
     static void invoke(MemorySegment stub, @CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("int") int entered) {
         try { HANDLE.invokeExact(stub, window, entered); }
         catch (Throwable e) { throw new RuntimeException("error in GLFWCursorEnterFun::invoke (static invoker)", e); }

--- a/modules/overrungl.glfw/src/main/java/overrungl/glfw/GLFWCursorPosFun.java
+++ b/modules/overrungl.glfw/src/main/java/overrungl/glfw/GLFWCursorPosFun.java
@@ -23,15 +23,6 @@ import overrungl.annotation.*;
 import overrungl.upcall.*;
 import overrungl.util.*;
 
-/// The function pointer type for cursor position callbacks.
-/// 
-/// This is the function pointer type for cursor position callbacks.  A cursor
-/// position callback function has the following signature:
-/// ```java
-/// void function_name(MemorySegment window, double xpos, double ypos);
-/// ```
-/// 
-/// @see GLFW#glfwSetCursorPosCallback(MemorySegment, MemorySegment)
 @FunctionalInterface
 public interface GLFWCursorPosFun extends Upcall {
     /// The function descriptor.
@@ -39,30 +30,14 @@ public interface GLFWCursorPosFun extends Upcall {
     /// The method handle of the target method.
     MethodHandle HANDLE = Upcall.findTarget(GLFWCursorPosFun.class, "invoke", DESCRIPTOR);
 
-    ///The target method of the upcall.
-    ///
-    ///Invoke
-    ///
-    ///@param window The window that received the event.
-    ///@param xpos The new cursor x-coordinate, relative to the left edge of
-    ///the content area.
-    ///@param ypos The new cursor y-coordinate, relative to the top edge of the
-    ///content area.
+    /// The target method of the upcall.
     void invoke(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("double") double xpos, @CType("double") double ypos);
 
     @Override
     default MemorySegment stub(Arena arena) { return Linker.nativeLinker().upcallStub(HANDLE.bindTo(this), DESCRIPTOR, arena); }
 
-    ///A static invoker of the target method.
-    ///
-    ///Invoke
-    ///
-    ///@param window The window that received the event.
-    ///@param xpos The new cursor x-coordinate, relative to the left edge of
-    ///the content area.
-    ///@param ypos The new cursor y-coordinate, relative to the top edge of the
-    ///content area.
-    ///@param stub the upcall stub
+    /// A static invoker of the target method.
+    /// @param stub the upcall stub
     static void invoke(MemorySegment stub, @CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("double") double xpos, @CType("double") double ypos) {
         try { HANDLE.invokeExact(stub, window, xpos, ypos); }
         catch (Throwable e) { throw new RuntimeException("error in GLFWCursorPosFun::invoke (static invoker)", e); }

--- a/modules/overrungl.glfw/src/main/java/overrungl/glfw/GLFWDeallocateFun.java
+++ b/modules/overrungl.glfw/src/main/java/overrungl/glfw/GLFWDeallocateFun.java
@@ -23,15 +23,6 @@ import overrungl.annotation.*;
 import overrungl.upcall.*;
 import overrungl.util.*;
 
-/// The function pointer type for memory deallocation callbacks.
-/// 
-/// This is the function pointer type for memory deallocation callbacks.
-/// A memory deallocation callback function has the following signature:
-/// ```java
-/// void function_name(MemorySegment block, MemorySegment user)
-/// ```
-/// 
-/// @see GLFWAllocator
 @FunctionalInterface
 public interface GLFWDeallocateFun extends Upcall {
     /// The function descriptor.
@@ -39,64 +30,14 @@ public interface GLFWDeallocateFun extends Upcall {
     /// The method handle of the target method.
     MethodHandle HANDLE = Upcall.findTarget(GLFWDeallocateFun.class, "invoke", DESCRIPTOR);
 
-    ///The target method of the upcall.
-    ///
-    ///This function may deallocate the specified memory block.  This memory block
-    ///will have been allocated with the same allocator.
-    ///
-    ///This function must support being called during [glfwInit][GLFW#glfwInit()] but before the library is
-    ///flagged as initialized, as well as during [glfwTerminate][GLFW#glfwTerminate()] after the library is no
-    ///longer flagged as initialized.
-    ///
-    ///The block address will never be `NULL`.  Deallocations of `NULL` are filtered out
-    ///before reaching the custom allocator.
-    ///
-    ///If this function returns `NULL`, GLFW will emit [GLFW_OUT_OF_MEMORY][GLFW#GLFW_OUT_OF_MEMORY].
-    ///
-    ///This function must not call any GLFW function.
-    ///
-    ///@param block The address of the memory block to deallocate.
-    ///@param user The user-defined pointer from the allocator.
-    ///
-    ///@glfw.pointer_lifetime The specified memory block will not be accessed by GLFW
-    ///after this function is called.
-    ///
-    ///@glfw.reentrancy This function should not call any GLFW function.
-    ///
-    ///@glfw.thread_safety This function must support being called from any thread that calls GLFW
-    ///functions.
+    /// The target method of the upcall.
     void invoke(@CType("void*") java.lang.foreign.MemorySegment block, @CType("void*") java.lang.foreign.MemorySegment user);
 
     @Override
     default MemorySegment stub(Arena arena) { return Linker.nativeLinker().upcallStub(HANDLE.bindTo(this), DESCRIPTOR, arena); }
 
-    ///A static invoker of the target method.
-    ///
-    ///This function may deallocate the specified memory block.  This memory block
-    ///will have been allocated with the same allocator.
-    ///
-    ///This function must support being called during [glfwInit][GLFW#glfwInit()] but before the library is
-    ///flagged as initialized, as well as during [glfwTerminate][GLFW#glfwTerminate()] after the library is no
-    ///longer flagged as initialized.
-    ///
-    ///The block address will never be `NULL`.  Deallocations of `NULL` are filtered out
-    ///before reaching the custom allocator.
-    ///
-    ///If this function returns `NULL`, GLFW will emit [GLFW_OUT_OF_MEMORY][GLFW#GLFW_OUT_OF_MEMORY].
-    ///
-    ///This function must not call any GLFW function.
-    ///
-    ///@param block The address of the memory block to deallocate.
-    ///@param user The user-defined pointer from the allocator.
-    ///
-    ///@glfw.pointer_lifetime The specified memory block will not be accessed by GLFW
-    ///after this function is called.
-    ///
-    ///@glfw.reentrancy This function should not call any GLFW function.
-    ///
-    ///@glfw.thread_safety This function must support being called from any thread that calls GLFW
-    ///functions.
-    ///@param stub the upcall stub
+    /// A static invoker of the target method.
+    /// @param stub the upcall stub
     static void invoke(MemorySegment stub, @CType("void*") java.lang.foreign.MemorySegment block, @CType("void*") java.lang.foreign.MemorySegment user) {
         try { HANDLE.invokeExact(stub, block, user); }
         catch (Throwable e) { throw new RuntimeException("error in GLFWDeallocateFun::invoke (static invoker)", e); }

--- a/modules/overrungl.glfw/src/main/java/overrungl/glfw/GLFWDropFun.java
+++ b/modules/overrungl.glfw/src/main/java/overrungl/glfw/GLFWDropFun.java
@@ -23,15 +23,6 @@ import overrungl.annotation.*;
 import overrungl.upcall.*;
 import overrungl.util.*;
 
-/// The function pointer type for path drop callbacks.
-/// 
-/// This is the function pointer type for path drop callbacks.  A path drop
-/// callback function has the following signature:
-/// ```
-/// void function_name(MemorySegment window, String[] paths)
-/// ```
-/// 
-/// @see GLFW#glfwSetDropCallback(MemorySegment, MemorySegment)
 @FunctionalInterface
 public interface GLFWDropFun extends Upcall {
     /// The function descriptor.
@@ -39,27 +30,10 @@ public interface GLFWDropFun extends Upcall {
     /// The method handle of the target method.
     MethodHandle HANDLE = Upcall.findTarget(GLFWDropFun.class, "invoke", DESCRIPTOR);
 
-    ///The interface target method of the upcall.
-    ///
-    ///Invoke
-    ///
-    ///@param window The window that received the event.
-    ///@param paths The UTF-8 encoded file and/or directory path names.
-    ///
-    ///@glfw.pointer_lifetime The path array and its strings are valid until the
-    ///callback function returns.
+    /// The interface target method of the upcall.
     void invoke(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, java.lang.String[] paths);
 
-    ///The target method of the upcall.
-    ///
-    ///Invoke
-    ///
-    ///@param window The window that received the event.
-    ///@param path_count The number of dropped paths.
-    ///@param paths The UTF-8 encoded file and/or directory path names.
-    ///
-    ///@glfw.pointer_lifetime The path array and its strings are valid until the
-    ///callback function returns.
+    /// The target method of the upcall.
     default void invoke(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("int") int path_count, java.lang.foreign.MemorySegment paths) {
         var a = new String[path_count];
         Unmarshal.copy(paths, a);
@@ -69,17 +43,8 @@ public interface GLFWDropFun extends Upcall {
     @Override
     default MemorySegment stub(Arena arena) { return Linker.nativeLinker().upcallStub(HANDLE.bindTo(this), DESCRIPTOR, arena); }
 
-    ///A static invoker of the target method.
-    ///
-    ///Invoke
-    ///
-    ///@param window The window that received the event.
-    ///@param path_count The number of dropped paths.
-    ///@param paths The UTF-8 encoded file and/or directory path names.
-    ///
-    ///@glfw.pointer_lifetime The path array and its strings are valid until the
-    ///callback function returns.
-    ///@param stub the upcall stub
+    /// A static invoker of the target method.
+    /// @param stub the upcall stub
     static void invoke(MemorySegment stub, @CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("int") int path_count, java.lang.foreign.MemorySegment paths) {
         try { HANDLE.invokeExact(stub, window, path_count, paths); }
         catch (Throwable e) { throw new RuntimeException("error in GLFWDropFun::invoke (static invoker)", e); }

--- a/modules/overrungl.glfw/src/main/java/overrungl/glfw/GLFWErrorFun.java
+++ b/modules/overrungl.glfw/src/main/java/overrungl/glfw/GLFWErrorFun.java
@@ -23,15 +23,6 @@ import overrungl.annotation.*;
 import overrungl.upcall.*;
 import overrungl.util.*;
 
-/// The function pointer type for error callbacks.
-/// 
-/// This is the function pointer type for error callbacks.  An error callback
-/// function has the following signature:
-/// ```java
-/// void callback_name(int error_code, String description)
-/// ```
-/// 
-/// @see GLFW#glfwSetErrorCallback(MemorySegment)
 @FunctionalInterface
 public interface GLFWErrorFun extends Upcall {
     /// The function descriptor.
@@ -39,28 +30,10 @@ public interface GLFWErrorFun extends Upcall {
     /// The method handle of the target method.
     MethodHandle HANDLE = Upcall.findTarget(GLFWErrorFun.class, "invoke", DESCRIPTOR);
 
-    ///The interface target method of the upcall.
-    ///
-    ///Invoke
-    ///
-    ///@param error_code An error code.  Future releases may add
-    ///more error codes.
-    ///@param description A UTF-8 encoded string describing the error.
-    ///
-    ///@glfw.pointer_lifetime The error description string is valid until the callback
-    ///function returns.
+    /// The interface target method of the upcall.
     void invoke(@CType("int") int error_code, @CType("const char*") java.lang.String description);
 
-    ///The target method of the upcall.
-    ///
-    ///Invoke
-    ///
-    ///@param error_code An error code.  Future releases may add
-    ///more error codes.
-    ///@param description A UTF-8 encoded string describing the error.
-    ///
-    ///@glfw.pointer_lifetime The error description string is valid until the callback
-    ///function returns.
+    /// The target method of the upcall.
     default void invoke(@CType("int") int error_code, @CType("const char*") java.lang.foreign.MemorySegment description) {
         invoke(error_code, Unmarshal.unmarshalAsString(description));
     }
@@ -68,17 +41,8 @@ public interface GLFWErrorFun extends Upcall {
     @Override
     default MemorySegment stub(Arena arena) { return Linker.nativeLinker().upcallStub(HANDLE.bindTo(this), DESCRIPTOR, arena); }
 
-    ///A static invoker of the target method.
-    ///
-    ///Invoke
-    ///
-    ///@param error_code An error code.  Future releases may add
-    ///more error codes.
-    ///@param description A UTF-8 encoded string describing the error.
-    ///
-    ///@glfw.pointer_lifetime The error description string is valid until the callback
-    ///function returns.
-    ///@param stub the upcall stub
+    /// A static invoker of the target method.
+    /// @param stub the upcall stub
     static void invoke(MemorySegment stub, @CType("int") int error_code, @CType("const char*") java.lang.foreign.MemorySegment description) {
         try { HANDLE.invokeExact(stub, error_code, description); }
         catch (Throwable e) { throw new RuntimeException("error in GLFWErrorFun::invoke (static invoker)", e); }

--- a/modules/overrungl.glfw/src/main/java/overrungl/glfw/GLFWFramebufferSizeFun.java
+++ b/modules/overrungl.glfw/src/main/java/overrungl/glfw/GLFWFramebufferSizeFun.java
@@ -23,15 +23,6 @@ import overrungl.annotation.*;
 import overrungl.upcall.*;
 import overrungl.util.*;
 
-/// The function pointer type for framebuffer size callbacks.
-/// 
-/// This is the function pointer type for framebuffer size callbacks.
-/// A framebuffer size callback function has the following signature:
-/// ```java
-/// void function_name(MemorySegment window, int width, int height)
-/// ```
-/// 
-/// @see GLFW#glfwSetFramebufferSizeCallback(MemorySegment, MemorySegment)
 @FunctionalInterface
 public interface GLFWFramebufferSizeFun extends Upcall {
     /// The function descriptor.
@@ -39,26 +30,14 @@ public interface GLFWFramebufferSizeFun extends Upcall {
     /// The method handle of the target method.
     MethodHandle HANDLE = Upcall.findTarget(GLFWFramebufferSizeFun.class, "invoke", DESCRIPTOR);
 
-    ///The target method of the upcall.
-    ///
-    ///Invoke
-    ///
-    ///@param window The window whose framebuffer was resized.
-    ///@param width The new width, in pixels, of the framebuffer.
-    ///@param height The new height, in pixels, of the framebuffer.
+    /// The target method of the upcall.
     void invoke(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("int") int width, @CType("int") int height);
 
     @Override
     default MemorySegment stub(Arena arena) { return Linker.nativeLinker().upcallStub(HANDLE.bindTo(this), DESCRIPTOR, arena); }
 
-    ///A static invoker of the target method.
-    ///
-    ///Invoke
-    ///
-    ///@param window The window whose framebuffer was resized.
-    ///@param width The new width, in pixels, of the framebuffer.
-    ///@param height The new height, in pixels, of the framebuffer.
-    ///@param stub the upcall stub
+    /// A static invoker of the target method.
+    /// @param stub the upcall stub
     static void invoke(MemorySegment stub, @CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("int") int width, @CType("int") int height) {
         try { HANDLE.invokeExact(stub, window, width, height); }
         catch (Throwable e) { throw new RuntimeException("error in GLFWFramebufferSizeFun::invoke (static invoker)", e); }

--- a/modules/overrungl.glfw/src/main/java/overrungl/glfw/GLFWGamepadState.java
+++ b/modules/overrungl.glfw/src/main/java/overrungl/glfw/GLFWGamepadState.java
@@ -24,26 +24,11 @@ import overrungl.annotation.*;
 import overrungl.struct.*;
 import overrungl.util.*;
 
-/// Gamepad input state
-/// 
-/// This describes the input state of a gamepad.
-/// 
-/// ## See Also
-/// - [glfwGetGamepadState][GLFW#glfwGetGamepadState(int, MemorySegment)]
-///
 /// ## Members
 /// ### buttons
 /// [Byte offset handle][#MH_buttons] - [Memory layout][#ML_buttons] - Getter - Setter
-///
-/// The states of each gamepad button, `GLFW_PRESS`
-/// or `GLFW_RELEASE`.
-///
 /// ### axes
 /// [Byte offset handle][#MH_axes] - [Memory layout][#ML_axes] - Getter - Setter
-///
-/// The states of each gamepad axis, in the range -1.0
-/// to 1.0 inclusive.
-///
 /// ## Layout
 /// [Java definition][#LAYOUT]
 /// ```c

--- a/modules/overrungl.glfw/src/main/java/overrungl/glfw/GLFWGammaRamp.java
+++ b/modules/overrungl.glfw/src/main/java/overrungl/glfw/GLFWGammaRamp.java
@@ -24,35 +24,15 @@ import overrungl.annotation.*;
 import overrungl.struct.*;
 import overrungl.util.*;
 
-/// Gamma ramp.
-/// 
-/// This describes the gamma ramp for a monitor.
-/// 
-/// ## See Also
-/// - [glfwGetGammaRamp][GLFW#glfwGetGammaRamp(MemorySegment)]
-/// - [glfwSetGammaRamp][GLFW#glfwSetGammaRamp(MemorySegment, MemorySegment)]
-///
 /// ## Members
 /// ### red
 /// [VarHandle][#VH_red] - [Getter][#red()] - [Setter][#red(java.lang.foreign.MemorySegment)]
-///
-/// An array of value describing the response of the red channel.
-///
 /// ### green
 /// [VarHandle][#VH_green] - [Getter][#green()] - [Setter][#green(java.lang.foreign.MemorySegment)]
-///
-/// An array of value describing the response of the green channel.
-///
 /// ### blue
 /// [VarHandle][#VH_blue] - [Getter][#blue()] - [Setter][#blue(java.lang.foreign.MemorySegment)]
-///
-/// An array of value describing the response of the blue channel.
-///
 /// ### size
 /// [VarHandle][#VH_size] - [Getter][#size()] - [Setter][#size(int)]
-///
-/// The number of elements in each array.
-///
 /// ## Layout
 /// [Java definition][#LAYOUT]
 /// ```c

--- a/modules/overrungl.glfw/src/main/java/overrungl/glfw/GLFWImage.java
+++ b/modules/overrungl.glfw/src/main/java/overrungl/glfw/GLFWImage.java
@@ -24,27 +24,13 @@ import overrungl.annotation.*;
 import overrungl.struct.*;
 import overrungl.util.*;
 
-/// Image data.
-/// 
-/// This describes a single 2D image.  See the documentation for each related
-/// function what the expected pixel format is.
-///
 /// ## Members
 /// ### width
 /// [VarHandle][#VH_width] - [Getter][#width()] - [Setter][#width(int)]
-///
-/// The width, in pixels, of this image.
-///
 /// ### height
 /// [VarHandle][#VH_height] - [Getter][#height()] - [Setter][#height(int)]
-///
-/// The height, in pixels, of this image.
-///
 /// ### pixels
 /// [VarHandle][#VH_pixels] - [Getter][#pixels()] - [Setter][#pixels(java.lang.foreign.MemorySegment)]
-///
-/// The pixel data of this image, arranged left-to-right, top-to-bottom.
-///
 /// ## Layout
 /// [Java definition][#LAYOUT]
 /// ```c

--- a/modules/overrungl.glfw/src/main/java/overrungl/glfw/GLFWJoystickFun.java
+++ b/modules/overrungl.glfw/src/main/java/overrungl/glfw/GLFWJoystickFun.java
@@ -23,15 +23,6 @@ import overrungl.annotation.*;
 import overrungl.upcall.*;
 import overrungl.util.*;
 
-/// The function pointer type for joystick configuration callbacks.
-/// 
-/// This is the function pointer type for joystick configuration callbacks.
-/// A joystick configuration callback function has the following signature:
-/// ```java
-/// void function_name(int jid, int event)
-/// ```
-/// 
-/// @see GLFW#glfwSetJoystickCallback(MemorySegment)
 @FunctionalInterface
 public interface GLFWJoystickFun extends Upcall {
     /// The function descriptor.
@@ -39,26 +30,14 @@ public interface GLFWJoystickFun extends Upcall {
     /// The method handle of the target method.
     MethodHandle HANDLE = Upcall.findTarget(GLFWJoystickFun.class, "invoke", DESCRIPTOR);
 
-    ///The target method of the upcall.
-    ///
-    ///Invoke
-    ///
-    ///@param jid The joystick that was connected or disconnected.
-    ///@param event One of `GLFW_CONNECTED` or `GLFW_DISCONNECTED`.  Future
-    ///releases may add more events.
+    /// The target method of the upcall.
     void invoke(@CType("int") int jid, @CType("int") int event);
 
     @Override
     default MemorySegment stub(Arena arena) { return Linker.nativeLinker().upcallStub(HANDLE.bindTo(this), DESCRIPTOR, arena); }
 
-    ///A static invoker of the target method.
-    ///
-    ///Invoke
-    ///
-    ///@param jid The joystick that was connected or disconnected.
-    ///@param event One of `GLFW_CONNECTED` or `GLFW_DISCONNECTED`.  Future
-    ///releases may add more events.
-    ///@param stub the upcall stub
+    /// A static invoker of the target method.
+    /// @param stub the upcall stub
     static void invoke(MemorySegment stub, @CType("int") int jid, @CType("int") int event) {
         try { HANDLE.invokeExact(stub, jid, event); }
         catch (Throwable e) { throw new RuntimeException("error in GLFWJoystickFun::invoke (static invoker)", e); }

--- a/modules/overrungl.glfw/src/main/java/overrungl/glfw/GLFWKeyFun.java
+++ b/modules/overrungl.glfw/src/main/java/overrungl/glfw/GLFWKeyFun.java
@@ -23,15 +23,6 @@ import overrungl.annotation.*;
 import overrungl.upcall.*;
 import overrungl.util.*;
 
-/// The function pointer type for keyboard key callbacks.
-/// 
-/// This is the function pointer type for keyboard key callbacks.  A keyboard
-/// key callback function has the following signature:
-/// ```java
-/// void function_name(MemorySegment window, int key, int scancode, int action, int mods)
-/// ```
-/// 
-/// @see GLFW#glfwSetKeyCallback(MemorySegment, MemorySegment)
 @FunctionalInterface
 public interface GLFWKeyFun extends Upcall {
     /// The function descriptor.
@@ -39,34 +30,14 @@ public interface GLFWKeyFun extends Upcall {
     /// The method handle of the target method.
     MethodHandle HANDLE = Upcall.findTarget(GLFWKeyFun.class, "invoke", DESCRIPTOR);
 
-    ///The target method of the upcall.
-    ///
-    ///Invoke
-    ///
-    ///@param window The window that received the event.
-    ///@param key The keyboard key that was pressed or released.
-    ///@param scancode The platform-specific scancode of the key.
-    ///@param action `GLFW_PRESS`, `GLFW_RELEASE` or `GLFW_REPEAT`.  Future
-    ///releases may add more actions.
-    ///@param mods Bit field describing which modifier keys were
-    ///held down.
+    /// The target method of the upcall.
     void invoke(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("int") int key, @CType("int") int scancode, @CType("int") int action, @CType("int") int mods);
 
     @Override
     default MemorySegment stub(Arena arena) { return Linker.nativeLinker().upcallStub(HANDLE.bindTo(this), DESCRIPTOR, arena); }
 
-    ///A static invoker of the target method.
-    ///
-    ///Invoke
-    ///
-    ///@param window The window that received the event.
-    ///@param key The keyboard key that was pressed or released.
-    ///@param scancode The platform-specific scancode of the key.
-    ///@param action `GLFW_PRESS`, `GLFW_RELEASE` or `GLFW_REPEAT`.  Future
-    ///releases may add more actions.
-    ///@param mods Bit field describing which modifier keys were
-    ///held down.
-    ///@param stub the upcall stub
+    /// A static invoker of the target method.
+    /// @param stub the upcall stub
     static void invoke(MemorySegment stub, @CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("int") int key, @CType("int") int scancode, @CType("int") int action, @CType("int") int mods) {
         try { HANDLE.invokeExact(stub, window, key, scancode, action, mods); }
         catch (Throwable e) { throw new RuntimeException("error in GLFWKeyFun::invoke (static invoker)", e); }

--- a/modules/overrungl.glfw/src/main/java/overrungl/glfw/GLFWMonitorFun.java
+++ b/modules/overrungl.glfw/src/main/java/overrungl/glfw/GLFWMonitorFun.java
@@ -23,15 +23,6 @@ import overrungl.annotation.*;
 import overrungl.upcall.*;
 import overrungl.util.*;
 
-/// The function pointer type for monitor configuration callbacks.
-/// 
-/// This is the function pointer type for monitor configuration callbacks.
-/// A monitor callback function has the following signature:
-/// ```java
-/// void function_name(MemorySegment monitor, int event)
-/// ```
-/// 
-/// @see GLFW#glfwSetMonitorCallback(MemorySegment)
 @FunctionalInterface
 public interface GLFWMonitorFun extends Upcall {
     /// The function descriptor.
@@ -39,26 +30,14 @@ public interface GLFWMonitorFun extends Upcall {
     /// The method handle of the target method.
     MethodHandle HANDLE = Upcall.findTarget(GLFWMonitorFun.class, "invoke", DESCRIPTOR);
 
-    ///The target method of the upcall.
-    ///
-    ///Invoke
-    ///
-    ///@param monitor The monitor that was connected or disconnected.
-    ///@param event One of `GLFW_CONNECTED` or `GLFW_DISCONNECTED`.  Future
-    ///releases may add more events.
+    /// The target method of the upcall.
     void invoke(@CType("GLFWmonitor*") java.lang.foreign.MemorySegment monitor, @CType("int") int event);
 
     @Override
     default MemorySegment stub(Arena arena) { return Linker.nativeLinker().upcallStub(HANDLE.bindTo(this), DESCRIPTOR, arena); }
 
-    ///A static invoker of the target method.
-    ///
-    ///Invoke
-    ///
-    ///@param monitor The monitor that was connected or disconnected.
-    ///@param event One of `GLFW_CONNECTED` or `GLFW_DISCONNECTED`.  Future
-    ///releases may add more events.
-    ///@param stub the upcall stub
+    /// A static invoker of the target method.
+    /// @param stub the upcall stub
     static void invoke(MemorySegment stub, @CType("GLFWmonitor*") java.lang.foreign.MemorySegment monitor, @CType("int") int event) {
         try { HANDLE.invokeExact(stub, monitor, event); }
         catch (Throwable e) { throw new RuntimeException("error in GLFWMonitorFun::invoke (static invoker)", e); }

--- a/modules/overrungl.glfw/src/main/java/overrungl/glfw/GLFWMouseButtonFun.java
+++ b/modules/overrungl.glfw/src/main/java/overrungl/glfw/GLFWMouseButtonFun.java
@@ -23,15 +23,6 @@ import overrungl.annotation.*;
 import overrungl.upcall.*;
 import overrungl.util.*;
 
-/// The function pointer type for mouse button callbacks.
-/// 
-/// This is the function pointer type for mouse button callback functions.
-/// A mouse button callback function has the following signature:
-/// ```java
-/// void function_name(MemorySegment window, int button, int action, int mods)
-/// ```
-/// 
-/// @see GLFW#glfwSetMouseButtonCallback(MemorySegment, MemorySegment)
 @FunctionalInterface
 public interface GLFWMouseButtonFun extends Upcall {
     /// The function descriptor.
@@ -39,34 +30,14 @@ public interface GLFWMouseButtonFun extends Upcall {
     /// The method handle of the target method.
     MethodHandle HANDLE = Upcall.findTarget(GLFWMouseButtonFun.class, "invoke", DESCRIPTOR);
 
-    ///The target method of the upcall.
-    ///
-    ///Invoke
-    ///
-    ///@param window The window that received the event.
-    ///@param button The mouse button that was pressed or
-    ///released.
-    ///@param action One of `GLFW_PRESS` or `GLFW_RELEASE`.  Future releases
-    ///may add more actions.
-    ///@param mods Bit field describing which modifier keys were
-    ///held down.
+    /// The target method of the upcall.
     void invoke(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("int") int button, @CType("int") int action, @CType("int") int mods);
 
     @Override
     default MemorySegment stub(Arena arena) { return Linker.nativeLinker().upcallStub(HANDLE.bindTo(this), DESCRIPTOR, arena); }
 
-    ///A static invoker of the target method.
-    ///
-    ///Invoke
-    ///
-    ///@param window The window that received the event.
-    ///@param button The mouse button that was pressed or
-    ///released.
-    ///@param action One of `GLFW_PRESS` or `GLFW_RELEASE`.  Future releases
-    ///may add more actions.
-    ///@param mods Bit field describing which modifier keys were
-    ///held down.
-    ///@param stub the upcall stub
+    /// A static invoker of the target method.
+    /// @param stub the upcall stub
     static void invoke(MemorySegment stub, @CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("int") int button, @CType("int") int action, @CType("int") int mods) {
         try { HANDLE.invokeExact(stub, window, button, action, mods); }
         catch (Throwable e) { throw new RuntimeException("error in GLFWMouseButtonFun::invoke (static invoker)", e); }

--- a/modules/overrungl.glfw/src/main/java/overrungl/glfw/GLFWNative.java
+++ b/modules/overrungl.glfw/src/main/java/overrungl/glfw/GLFWNative.java
@@ -29,18 +29,14 @@ import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodHandle;
 
-/**
- * This is the header file of the native access functions.
- * <h2>Native access</h2>
- * Functions related to accessing native handles.
- * <p>
- * <strong>By using the native access functions you assert that you know what you're
- * doing and how to fix problems caused by using them.  If you don't, you
- * shouldn't be using them.</strong>
- *
- * @author squid233
- * @since 0.1.0
- */
+/// GLFW native functions.
+///
+/// **By using the native access functions you assert that you know what you're
+/// doing and how to fix problems caused by using them.  If you don't, you
+/// shouldn't be using them.**
+///
+/// @author squid233
+/// @since 0.1.0
 public final class GLFWNative {
     //region ---[BEGIN GENERATOR BEGIN]---
     //@formatter:off
@@ -103,17 +99,6 @@ public final class GLFWNative {
     }
     //endregion
 
-    ///Returns the adapter device name of the specified monitor.
-    ///
-    ///@return The UTF-8 encoded adapter device name (for example `\\.\DISPLAY1`)
-    ///of the specified monitor, or `NULL` if an error
-    ///occurred.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][GLFW#GLFW_NOT_INITIALIZED] and
-    ///[GLFW_PLATFORM_UNAVAILABLE][GLFW#GLFW_PLATFORM_UNAVAILABLE].
-    ///
-    ///@glfw.thread_safety This function may be called from any thread.  Access is not
-    ///synchronized.
     public static @CType("const char*") java.lang.foreign.MemorySegment glfwGetWin32Adapter_(@CType("GLFWmonitor*") java.lang.foreign.MemorySegment monitor) {
         if (Handles.MH_glfwGetWin32Adapter != null) {
         try {
@@ -122,17 +107,6 @@ public final class GLFWNative {
         } else { throw new SymbolNotFoundError("Symbol not found: glfwGetWin32Adapter"); }
     }
 
-    ///Returns the adapter device name of the specified monitor.
-    ///
-    ///@return The UTF-8 encoded adapter device name (for example `\\.\DISPLAY1`)
-    ///of the specified monitor, or `NULL` if an error
-    ///occurred.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][GLFW#GLFW_NOT_INITIALIZED] and
-    ///[GLFW_PLATFORM_UNAVAILABLE][GLFW#GLFW_PLATFORM_UNAVAILABLE].
-    ///
-    ///@glfw.thread_safety This function may be called from any thread.  Access is not
-    ///synchronized.
     public static @CType("const char*") java.lang.String glfwGetWin32Adapter(@CType("GLFWmonitor*") java.lang.foreign.MemorySegment monitor) {
         if (Handles.MH_glfwGetWin32Adapter != null) {
         try {
@@ -141,17 +115,6 @@ public final class GLFWNative {
         } else { throw new SymbolNotFoundError("Symbol not found: glfwGetWin32Adapter"); }
     }
 
-    ///Returns the display device name of the specified monitor.
-    ///
-    ///@return The UTF-8 encoded display device name (for example
-    ///`\\.\DISPLAY1\Monitor0`) of the specified monitor, or `NULL` if an
-    ///error occurred.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][GLFW#GLFW_NOT_INITIALIZED] and
-    ///[GLFW_PLATFORM_UNAVAILABLE][GLFW#GLFW_PLATFORM_UNAVAILABLE].
-    ///
-    ///@glfw.thread_safety This function may be called from any thread.  Access is not
-    ///synchronized.
     public static @CType("const char*") java.lang.foreign.MemorySegment glfwGetWin32Monitor_(@CType("GLFWmonitor*") java.lang.foreign.MemorySegment monitor) {
         if (Handles.MH_glfwGetWin32Monitor != null) {
         try {
@@ -160,17 +123,6 @@ public final class GLFWNative {
         } else { throw new SymbolNotFoundError("Symbol not found: glfwGetWin32Monitor"); }
     }
 
-    ///Returns the display device name of the specified monitor.
-    ///
-    ///@return The UTF-8 encoded display device name (for example
-    ///`\\.\DISPLAY1\Monitor0`) of the specified monitor, or `NULL` if an
-    ///error occurred.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][GLFW#GLFW_NOT_INITIALIZED] and
-    ///[GLFW_PLATFORM_UNAVAILABLE][GLFW#GLFW_PLATFORM_UNAVAILABLE].
-    ///
-    ///@glfw.thread_safety This function may be called from any thread.  Access is not
-    ///synchronized.
     public static @CType("const char*") java.lang.String glfwGetWin32Monitor(@CType("GLFWmonitor*") java.lang.foreign.MemorySegment monitor) {
         if (Handles.MH_glfwGetWin32Monitor != null) {
         try {
@@ -179,23 +131,6 @@ public final class GLFWNative {
         } else { throw new SymbolNotFoundError("Symbol not found: glfwGetWin32Monitor"); }
     }
 
-    ///Returns the `HWND` of the specified window.
-    ///
-    ///@return The `HWND` of the specified window, or `NULL` if an
-    ///error occurred.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][GLFW#GLFW_NOT_INITIALIZED] and
-    ///[GLFW_PLATFORM_UNAVAILABLE][GLFW#GLFW_PLATFORM_UNAVAILABLE].
-    ///@glfw.remark The `HDC` associated with the window can be queried with the
-    ///[GetDC](https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getdc)
-    ///function.
-    ///```c
-    ///HDC dc = GetDC(glfwGetWin32Window(window));
-    ///```
-    ///This DC is private and does not need to be released.
-    ///
-    ///@glfw.thread_safety This function may be called from any thread.  Access is not
-    ///synchronized.
     public static @CType("HWND") java.lang.foreign.MemorySegment glfwGetWin32Window(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window) {
         if (Handles.MH_glfwGetWin32Window != null) {
         try {
@@ -204,24 +139,6 @@ public final class GLFWNative {
         } else { throw new SymbolNotFoundError("Symbol not found: glfwGetWin32Window"); }
     }
 
-    ///Returns the `HGLRC` of the specified window.
-    ///
-    ///@return The `HGLRC` of the specified window, or `NULL` if an
-    ///error occurred.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][GLFW#GLFW_NOT_INITIALIZED],
-    ///[GLFW_PLATFORM_UNAVAILABLE][GLFW#GLFW_PLATFORM_UNAVAILABLE] and [GLFW_NO_WINDOW_CONTEXT][GLFW#GLFW_NO_WINDOW_CONTEXT].
-    ///
-    ///@glfw.remark The `HDC` associated with the window can be queried with the
-    ///[GetDC](https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getdc)
-    ///function.
-    ///```c
-    ///HDC dc = GetDC(glfwGetWin32Window(window));
-    ///```
-    ///This DC is private and does not need to be released.
-    ///
-    ///@glfw.thread_safety This function may be called from any thread.  Access is not
-    ///synchronized.
     public static @CType("HGLRC") java.lang.foreign.MemorySegment glfwGetWGLContext(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window) {
         if (Handles.MH_glfwGetWGLContext != null) {
         try {
@@ -230,16 +147,6 @@ public final class GLFWNative {
         } else { throw new SymbolNotFoundError("Symbol not found: glfwGetWGLContext"); }
     }
 
-    ///Returns the `CGDirectDisplayID` of the specified monitor.
-    ///
-    ///@return The `CGDirectDisplayID` of the specified monitor, or
-    ///`kCGNullDirectDisplay` if an error occurred.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][GLFW#GLFW_NOT_INITIALIZED] and
-    ///[GLFW_PLATFORM_UNAVAILABLE][GLFW#GLFW_PLATFORM_UNAVAILABLE].
-    ///
-    ///@glfw.thread_safety This function may be called from any thread.  Access is not
-    ///synchronized.
     public static @CType("CGDirectDisplayID") int glfwGetCocoaMonitor(@CType("GLFWmonitor*") java.lang.foreign.MemorySegment monitor) {
         if (Handles.MH_glfwGetCocoaMonitor != null) {
         try {
@@ -248,16 +155,6 @@ public final class GLFWNative {
         } else { throw new SymbolNotFoundError("Symbol not found: glfwGetCocoaMonitor"); }
     }
 
-    ///Returns the `NSWindow` of the specified window.
-    ///
-    ///@return The `NSWindow` of the specified window, or `nil` if an
-    ///error occurred.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][GLFW#GLFW_NOT_INITIALIZED] and
-    ///[GLFW_PLATFORM_UNAVAILABLE][GLFW#GLFW_PLATFORM_UNAVAILABLE].
-    ///
-    ///@glfw.thread_safety This function may be called from any thread.  Access is not
-    ///synchronized.
     public static @CType("id") java.lang.foreign.MemorySegment glfwGetCocoaWindow(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window) {
         if (Handles.MH_glfwGetCocoaWindow != null) {
         try {
@@ -266,16 +163,6 @@ public final class GLFWNative {
         } else { throw new SymbolNotFoundError("Symbol not found: glfwGetCocoaWindow"); }
     }
 
-    ///Returns the `NSView` of the specified window.
-    ///
-    ///@return The `NSView` of the specified window, or `nil` if an
-    ///error occurred.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][GLFW#GLFW_NOT_INITIALIZED] and
-    ///[GLFW_PLATFORM_UNAVAILABLE][GLFW#GLFW_PLATFORM_UNAVAILABLE].
-    ///
-    ///@glfw.thread_safety This function may be called from any thread.  Access is not
-    ///synchronized.
     public static @CType("id") java.lang.foreign.MemorySegment glfwGetCocoaView(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window) {
         if (Handles.MH_glfwGetCocoaView != null) {
         try {
@@ -284,16 +171,6 @@ public final class GLFWNative {
         } else { throw new SymbolNotFoundError("Symbol not found: glfwGetCocoaView"); }
     }
 
-    ///Returns the `NSOpenGLContext` of the specified window.
-    ///
-    ///@return The `NSOpenGLContext` of the specified window, or `nil` if an
-    ///error occurred.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][GLFW#GLFW_NOT_INITIALIZED],
-    ///[GLFW_PLATFORM_UNAVAILABLE][GLFW#GLFW_PLATFORM_UNAVAILABLE] and [GLFW_NO_WINDOW_CONTEXT][GLFW#GLFW_NO_WINDOW_CONTEXT].
-    ///
-    ///@glfw.thread_safety This function may be called from any thread.  Access is not
-    ///synchronized.
     public static @CType("id") java.lang.foreign.MemorySegment glfwGetNSGLContext(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window) {
         if (Handles.MH_glfwGetNSGLContext != null) {
         try {
@@ -302,16 +179,6 @@ public final class GLFWNative {
         } else { throw new SymbolNotFoundError("Symbol not found: glfwGetNSGLContext"); }
     }
 
-    ///Returns the `Display` used by GLFW.
-    ///
-    ///@return The `Display` used by GLFW, or `NULL` if an
-    ///error occurred.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][GLFW#GLFW_NOT_INITIALIZED] and
-    ///[GLFW_PLATFORM_UNAVAILABLE][GLFW#GLFW_PLATFORM_UNAVAILABLE].
-    ///
-    ///@glfw.thread_safety This function may be called from any thread.  Access is not
-    ///synchronized.
     public static @CType("Display*") java.lang.foreign.MemorySegment glfwGetX11Display() {
         if (Handles.MH_glfwGetX11Display != null) {
         try {
@@ -320,16 +187,6 @@ public final class GLFWNative {
         } else { throw new SymbolNotFoundError("Symbol not found: glfwGetX11Display"); }
     }
 
-    ///Returns the `RRCrtc` of the specified monitor.
-    ///
-    ///@return The `RRCrtc` of the specified monitor, or `None` if an
-    ///error occurred.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][GLFW#GLFW_NOT_INITIALIZED] and
-    ///[GLFW_PLATFORM_UNAVAILABLE][GLFW#GLFW_PLATFORM_UNAVAILABLE].
-    ///
-    ///@glfw.thread_safety This function may be called from any thread.  Access is not
-    ///synchronized.
     public static @CType("RRCrtc") long glfwGetX11Adapter(@CType("GLFWmonitor*") java.lang.foreign.MemorySegment monitor) {
         if (Handles.MH_glfwGetX11Adapter != null) {
         try {
@@ -338,16 +195,6 @@ public final class GLFWNative {
         } else { throw new SymbolNotFoundError("Symbol not found: glfwGetX11Adapter"); }
     }
 
-    ///Returns the `RROutput` of the specified monitor.
-    ///
-    ///@return The `RROutput` of the specified monitor, or `None` if an
-    ///error occurred.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][GLFW#GLFW_NOT_INITIALIZED] and
-    ///[GLFW_PLATFORM_UNAVAILABLE][GLFW#GLFW_PLATFORM_UNAVAILABLE].
-    ///
-    ///@glfw.thread_safety This function may be called from any thread.  Access is not
-    ///synchronized.
     public static @CType("RROutput") long glfwGetX11Monitor(@CType("GLFWmonitor*") java.lang.foreign.MemorySegment monitor) {
         if (Handles.MH_glfwGetX11Monitor != null) {
         try {
@@ -356,16 +203,6 @@ public final class GLFWNative {
         } else { throw new SymbolNotFoundError("Symbol not found: glfwGetX11Monitor"); }
     }
 
-    ///Returns the `Window` of the specified window.
-    ///
-    ///@return The `Window` of the specified window, or `None` if an
-    ///error occurred.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][GLFW#GLFW_NOT_INITIALIZED] and
-    ///[GLFW_PLATFORM_UNAVAILABLE][GLFW#GLFW_PLATFORM_UNAVAILABLE].
-    ///
-    ///@glfw.thread_safety This function may be called from any thread.  Access is not
-    ///synchronized.
     public static @CType("RROutput") long glfwGetX11Window(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window) {
         if (Handles.MH_glfwGetX11Window != null) {
         try {
@@ -374,20 +211,6 @@ public final class GLFWNative {
         } else { throw new SymbolNotFoundError("Symbol not found: glfwGetX11Window"); }
     }
 
-    ///Sets the current primary selection to the specified string.
-    ///
-    ///@param string A UTF-8 encoded string.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][GLFW#GLFW_NOT_INITIALIZED],
-    ///[GLFW_PLATFORM_UNAVAILABLE][GLFW#GLFW_PLATFORM_UNAVAILABLE] and [GLFW_PLATFORM_ERROR][GLFW#GLFW_PLATFORM_ERROR].
-    ///
-    ///@glfw.pointer_lifetime The specified string is copied before this function
-    ///returns.
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
-    ///
-    ///@see #glfwGetX11SelectionString() glfwGetX11SelectionString
-    ///@see GLFW#glfwSetClipboardString(MemorySegment, MemorySegment) glfwSetClipboardString
     public static void glfwSetX11SelectionString(@CType("const char*") java.lang.foreign.MemorySegment string) {
         if (Handles.MH_glfwSetX11SelectionString != null) {
         try {
@@ -396,20 +219,6 @@ public final class GLFWNative {
         } else { throw new SymbolNotFoundError("Symbol not found: glfwSetX11SelectionString"); }
     }
 
-    ///Sets the current primary selection to the specified string.
-    ///
-    ///@param string A UTF-8 encoded string.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][GLFW#GLFW_NOT_INITIALIZED],
-    ///[GLFW_PLATFORM_UNAVAILABLE][GLFW#GLFW_PLATFORM_UNAVAILABLE] and [GLFW_PLATFORM_ERROR][GLFW#GLFW_PLATFORM_ERROR].
-    ///
-    ///@glfw.pointer_lifetime The specified string is copied before this function
-    ///returns.
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
-    ///
-    ///@see #glfwGetX11SelectionString() glfwGetX11SelectionString
-    ///@see GLFW#glfwSetClipboardString(MemorySegment, MemorySegment) glfwSetClipboardString
     public static void glfwSetX11SelectionString(@CType("const char*") java.lang.String string) {
         if (Handles.MH_glfwSetX11SelectionString != null) {
         try (var __overrungl_stack = MemoryStack.pushLocal()) {
@@ -418,26 +227,6 @@ public final class GLFWNative {
         } else { throw new SymbolNotFoundError("Symbol not found: glfwSetX11SelectionString"); }
     }
 
-    ///Returns the contents of the current primary selection as a string.
-    ///
-    ///If the selection is empty or if its contents cannot be converted, `NULL`
-    ///is returned and a [GLFW_FORMAT_UNAVAILABLE][GLFW#GLFW_FORMAT_UNAVAILABLE] error is generated.
-    ///
-    ///@return The contents of the selection as a UTF-8 encoded string, or `NULL`
-    ///if an error occurred.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][GLFW#GLFW_NOT_INITIALIZED],
-    ///[GLFW_PLATFORM_UNAVAILABLE][GLFW#GLFW_PLATFORM_UNAVAILABLE] and [GLFW_PLATFORM_ERROR][GLFW#GLFW_PLATFORM_ERROR].
-    ///
-    ///@glfw.pointer_lifetime The returned string is allocated and freed by GLFW. You
-    ///should not free it yourself. It is valid until the next call to
-    ///`glfwGetX11SelectionString` or [glfwSetX11SelectionString][#glfwSetX11SelectionString(MemorySegment)], or until the
-    ///library is terminated.
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
-    ///
-    ///@see #glfwSetX11SelectionString(MemorySegment) glfwSetX11SelectionString
-    ///@see GLFW#glfwGetClipboardString(MemorySegment) glfwGetClipboardString
     public static @CType("const char*") java.lang.foreign.MemorySegment glfwGetX11SelectionString_() {
         if (Handles.MH_glfwGetX11SelectionString != null) {
         try {
@@ -446,26 +235,6 @@ public final class GLFWNative {
         } else { throw new SymbolNotFoundError("Symbol not found: glfwGetX11SelectionString"); }
     }
 
-    ///Returns the contents of the current primary selection as a string.
-    ///
-    ///If the selection is empty or if its contents cannot be converted, `NULL`
-    ///is returned and a [GLFW_FORMAT_UNAVAILABLE][GLFW#GLFW_FORMAT_UNAVAILABLE] error is generated.
-    ///
-    ///@return The contents of the selection as a UTF-8 encoded string, or `NULL`
-    ///if an error occurred.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][GLFW#GLFW_NOT_INITIALIZED],
-    ///[GLFW_PLATFORM_UNAVAILABLE][GLFW#GLFW_PLATFORM_UNAVAILABLE] and [GLFW_PLATFORM_ERROR][GLFW#GLFW_PLATFORM_ERROR].
-    ///
-    ///@glfw.pointer_lifetime The returned string is allocated and freed by GLFW. You
-    ///should not free it yourself. It is valid until the next call to
-    ///`glfwGetX11SelectionString` or [glfwSetX11SelectionString][#glfwSetX11SelectionString(MemorySegment)], or until the
-    ///library is terminated.
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
-    ///
-    ///@see #glfwSetX11SelectionString(MemorySegment) glfwSetX11SelectionString
-    ///@see GLFW#glfwGetClipboardString(MemorySegment) glfwGetClipboardString
     public static @CType("const char*") java.lang.String glfwGetX11SelectionString() {
         if (Handles.MH_glfwGetX11SelectionString != null) {
         try {
@@ -474,16 +243,6 @@ public final class GLFWNative {
         } else { throw new SymbolNotFoundError("Symbol not found: glfwGetX11SelectionString"); }
     }
 
-    ///Returns the `GLXContext` of the specified window.
-    ///
-    ///@return The `GLXContext` of the specified window, or `NULL` if an
-    ///error occurred.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][GLFW#GLFW_NOT_INITIALIZED],
-    ///[GLFW_NO_WINDOW_CONTEXT][GLFW#GLFW_NO_WINDOW_CONTEXT] and [GLFW_PLATFORM_UNAVAILABLE][GLFW#GLFW_PLATFORM_UNAVAILABLE].
-    ///
-    ///@glfw.thread_safety This function may be called from any thread.  Access is not
-    ///synchronized.
     public static @CType("GLXContext") java.lang.foreign.MemorySegment glfwGetGLXContext(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window) {
         if (Handles.MH_glfwGetGLXContext != null) {
         try {
@@ -492,16 +251,6 @@ public final class GLFWNative {
         } else { throw new SymbolNotFoundError("Symbol not found: glfwGetGLXContext"); }
     }
 
-    ///Returns the `GLXWindow` of the specified window.
-    ///
-    ///@return The `GLXWindow` of the specified window, or `None` if an
-    ///error occurred.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][GLFW#GLFW_NOT_INITIALIZED],
-    ///[GLFW_NO_WINDOW_CONTEXT][GLFW#GLFW_NO_WINDOW_CONTEXT] and [GLFW_PLATFORM_UNAVAILABLE][GLFW#GLFW_PLATFORM_UNAVAILABLE].
-    ///
-    ///@glfw.thread_safety This function may be called from any thread.  Access is not
-    ///synchronized.
     public static @CType("GLXWindow") long glfwGetGLXWindow(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window) {
         if (Handles.MH_glfwGetGLXWindow != null) {
         try {
@@ -510,16 +259,6 @@ public final class GLFWNative {
         } else { throw new SymbolNotFoundError("Symbol not found: glfwGetGLXWindow"); }
     }
 
-    ///Returns the `struct wl_display*` used by GLFW.
-    ///
-    ///@return The `struct wl_display*` used by GLFW, or `NULL` if an
-    ///error occurred.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][GLFW#GLFW_NOT_INITIALIZED] and
-    ///[GLFW_PLATFORM_UNAVAILABLE][GLFW#GLFW_PLATFORM_UNAVAILABLE].
-    ///
-    ///@glfw.thread_safety This function may be called from any thread.  Access is not
-    ///synchronized.
     public static @CType("struct wl_display*") java.lang.foreign.MemorySegment glfwGetWaylandDisplay() {
         if (Handles.MH_glfwGetWaylandDisplay != null) {
         try {
@@ -528,16 +267,6 @@ public final class GLFWNative {
         } else { throw new SymbolNotFoundError("Symbol not found: glfwGetWaylandDisplay"); }
     }
 
-    ///Returns the `struct wl_output*` of the specified monitor.
-    ///
-    ///@return The `struct wl_output*` of the specified monitor, or `NULL` if an
-    ///error occurred.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][GLFW#GLFW_NOT_INITIALIZED] and
-    ///[GLFW_PLATFORM_UNAVAILABLE][GLFW#GLFW_PLATFORM_UNAVAILABLE].
-    ///
-    ///@glfw.thread_safety This function may be called from any thread.  Access is not
-    ///synchronized.
     public static @CType("struct wl_output*") java.lang.foreign.MemorySegment glfwGetWaylandMonitor(@CType("GLFWmonitor*") java.lang.foreign.MemorySegment monitor) {
         if (Handles.MH_glfwGetWaylandMonitor != null) {
         try {
@@ -546,16 +275,6 @@ public final class GLFWNative {
         } else { throw new SymbolNotFoundError("Symbol not found: glfwGetWaylandMonitor"); }
     }
 
-    ///Returns the main `struct wl_surface*` of the specified window.
-    ///
-    ///@return The main `struct wl_surface*` of the specified window, or `NULL` if
-    ///an error occurred.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][GLFW#GLFW_NOT_INITIALIZED] and
-    ///[GLFW_PLATFORM_UNAVAILABLE][GLFW#GLFW_PLATFORM_UNAVAILABLE].
-    ///
-    ///@glfw.thread_safety This function may be called from any thread.  Access is not
-    ///synchronized.
     public static @CType("struct wl_surface*") java.lang.foreign.MemorySegment glfwGetWaylandWindow(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window) {
         if (Handles.MH_glfwGetWaylandWindow != null) {
         try {
@@ -564,18 +283,6 @@ public final class GLFWNative {
         } else { throw new SymbolNotFoundError("Symbol not found: glfwGetWaylandWindow"); }
     }
 
-    ///Returns the `EGLDisplay` used by GLFW.
-    ///
-    ///@return The `EGLDisplay` used by GLFW, or `EGL_NO_DISPLAY` if an
-    ///error occurred.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][GLFW#GLFW_NOT_INITIALIZED].
-    ///
-    ///@glfw.remark Because EGL is initialized on demand, this function will return
-    ///`EGL_NO_DISPLAY` until the first context has been created via EGL.
-    ///
-    ///@glfw.thread_safety This function may be called from any thread.  Access is not
-    ///synchronized.
     public static @CType("EGLDisplay") java.lang.foreign.MemorySegment glfwGetEGLDisplay() {
         if (Handles.MH_glfwGetEGLDisplay != null) {
         try {
@@ -584,16 +291,6 @@ public final class GLFWNative {
         } else { throw new SymbolNotFoundError("Symbol not found: glfwGetEGLDisplay"); }
     }
 
-    ///Returns the `EGLContext` of the specified window.
-    ///
-    ///@return The `EGLContext` of the specified window, or `EGL_NO_CONTEXT` if an
-    ///error occurred.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][GLFW#GLFW_NOT_INITIALIZED] and
-    ///[GLFW_NO_WINDOW_CONTEXT][GLFW#GLFW_NO_WINDOW_CONTEXT].
-    ///
-    ///@glfw.thread_safety This function may be called from any thread.  Access is not
-    ///synchronized.
     public static @CType("EGLContext") java.lang.foreign.MemorySegment glfwGetEGLContext(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window) {
         if (Handles.MH_glfwGetEGLContext != null) {
         try {
@@ -602,16 +299,6 @@ public final class GLFWNative {
         } else { throw new SymbolNotFoundError("Symbol not found: glfwGetEGLContext"); }
     }
 
-    ///Returns the `EGLSurface` of the specified window.
-    ///
-    ///@return The `EGLSurface` of the specified window, or `EGL_NO_SURFACE` if an
-    ///error occurred.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][GLFW#GLFW_NOT_INITIALIZED] and
-    ///[GLFW_NO_WINDOW_CONTEXT][GLFW#GLFW_NO_WINDOW_CONTEXT].
-    ///
-    ///@glfw.thread_safety This function may be called from any thread.  Access is not
-    ///synchronized.
     public static @CType("EGLSurface") java.lang.foreign.MemorySegment glfwGetEGLSurface(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window) {
         if (Handles.MH_glfwGetEGLSurface != null) {
         try {
@@ -620,23 +307,6 @@ public final class GLFWNative {
         } else { throw new SymbolNotFoundError("Symbol not found: glfwGetEGLSurface"); }
     }
 
-    ///Retrieves the color buffer associated with the specified window.
-    ///
-    ///@param window The window whose color buffer to retrieve.
-    ///@param width Where to store the width of the color buffer, or `NULL`.
-    ///@param height Where to store the height of the color buffer, or `NULL`.
-    ///@param format Where to store the OSMesa pixel format of the color
-    ///buffer, or `NULL`.
-    ///@param buffer Where to store the address of the color buffer, or
-    ///`NULL`.
-    ///@return `GLFW_TRUE` if successful, or `GLFW_FALSE` if an
-    ///error occurred.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][GLFW#GLFW_NOT_INITIALIZED] and
-    ///[GLFW_NO_WINDOW_CONTEXT][GLFW#GLFW_NO_WINDOW_CONTEXT].
-    ///
-    ///@glfw.thread_safety This function may be called from any thread.  Access is not
-    ///synchronized.
     public static @CType("int") boolean glfwGetOSMesaColorBuffer(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @Out @CType("int*") java.lang.foreign.MemorySegment width, @Out @CType("int*") java.lang.foreign.MemorySegment height, @Out @CType("int*") java.lang.foreign.MemorySegment format, @Out @CType("void**") java.lang.foreign.MemorySegment buffer) {
         if (Handles.MH_glfwGetOSMesaColorBuffer != null) {
         try {
@@ -645,23 +315,6 @@ public final class GLFWNative {
         } else { throw new SymbolNotFoundError("Symbol not found: glfwGetOSMesaColorBuffer"); }
     }
 
-    ///Retrieves the depth buffer associated with the specified window.
-    ///
-    ///@param window The window whose depth buffer to retrieve.
-    ///@param width Where to store the width of the depth buffer, or `NULL`.
-    ///@param height Where to store the height of the depth buffer, or `NULL`.
-    ///@param bytesPerValue Where to store the number of bytes per depth
-    ///buffer element, or `NULL`.
-    ///@param buffer Where to store the address of the depth buffer, or
-    ///`NULL`.
-    ///@return `GLFW_TRUE` if successful, or `GLFW_FALSE` if an
-    ///error occurred.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][GLFW#GLFW_NOT_INITIALIZED] and
-    ///[GLFW_NO_WINDOW_CONTEXT][GLFW#GLFW_NO_WINDOW_CONTEXT].
-    ///
-    ///@glfw.thread_safety This function may be called from any thread.  Access is not
-    ///synchronized.
     public static @CType("int") boolean glfwGetOSMesaDepthBuffer(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @Out @CType("int*") java.lang.foreign.MemorySegment width, @Out @CType("int*") java.lang.foreign.MemorySegment height, @Out @CType("int*") java.lang.foreign.MemorySegment bytesPerValue, @Out @CType("void**") java.lang.foreign.MemorySegment buffer) {
         if (Handles.MH_glfwGetOSMesaDepthBuffer != null) {
         try {
@@ -670,16 +323,6 @@ public final class GLFWNative {
         } else { throw new SymbolNotFoundError("Symbol not found: glfwGetOSMesaDepthBuffer"); }
     }
 
-    ///Returns the `OSMesaContext` of the specified window.
-    ///
-    ///@return The `OSMesaContext` of the specified window, or `NULL` if an
-    ///error occurred.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][GLFW#GLFW_NOT_INITIALIZED] and
-    ///[GLFW_NO_WINDOW_CONTEXT][GLFW#GLFW_NO_WINDOW_CONTEXT].
-    ///
-    ///@glfw.thread_safety This function may be called from any thread.  Access is not
-    ///synchronized.
     public static @CType("OSMesaContext") java.lang.foreign.MemorySegment glfwGetOSMesaContext(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window) {
         if (Handles.MH_glfwGetOSMesaContext != null) {
         try {

--- a/modules/overrungl.glfw/src/main/java/overrungl/glfw/GLFWReallocateFun.java
+++ b/modules/overrungl.glfw/src/main/java/overrungl/glfw/GLFWReallocateFun.java
@@ -23,15 +23,6 @@ import overrungl.annotation.*;
 import overrungl.upcall.*;
 import overrungl.util.*;
 
-/// The function pointer type for memory reallocation callbacks.
-/// 
-/// This is the function pointer type for memory reallocation callbacks.
-/// A memory reallocation callback function has the following signature:
-/// ```java
-/// MemorySegment function_name(MemorySegment block, long size, MemorySegment user)
-/// ```
-/// 
-/// @see GLFWAllocator
 @FunctionalInterface
 public interface GLFWReallocateFun extends Upcall {
     /// The function descriptor.
@@ -39,92 +30,14 @@ public interface GLFWReallocateFun extends Upcall {
     /// The method handle of the target method.
     MethodHandle HANDLE = Upcall.findTarget(GLFWReallocateFun.class, "invoke", DESCRIPTOR);
 
-    ///The target method of the upcall.
-    ///
-    ///This function must return a memory block at least `size` bytes long, or
-    ///`NULL` if allocation failed.  Note that not all parts of GLFW handle allocation
-    ///failures gracefully yet.
-    ///
-    ///This function must support being called during [glfwInit][GLFW#glfwInit()] but before the library is
-    ///flagged as initialized, as well as during [glfwTerminate][GLFW#glfwTerminate()] after the library is no
-    ///longer flagged as initialized.
-    ///
-    ///Any memory allocated via this function will be deallocated via the same allocator
-    ///during library termination or earlier.
-    ///
-    ///Any memory allocated via this function must be suitably aligned for any object type.
-    ///If you are using C99 or earlier, this alignment is platform-dependent but will be the
-    ///same as what `realloc` provides.  If you are using C11 or later, this is the value of
-    ///`alignof(max_align_t)`.
-    ///
-    ///The block address will never be `NULL` and the size will always be greater than zero.
-    ///Reallocations of a block to size zero are converted into deallocations before reaching
-    ///the custom allocator.  Reallocations of `NULL` to a non-zero size are converted into
-    ///regular allocations before reaching the custom allocator.
-    ///
-    ///If this function returns `NULL`, GLFW will emit [GLFW_OUT_OF_MEMORY][GLFW#GLFW_OUT_OF_MEMORY].
-    ///
-    ///This function must not call any GLFW function.
-    ///
-    ///@param block The address of the memory block to reallocate.
-    ///@param size The new minimum size, in bytes, of the memory block.
-    ///@param user The user-defined pointer from the allocator.
-    ///@return The address of the newly allocated or resized memory block, or
-    ///`NULL` if an error occurred.
-    ///
-    ///@glfw.pointer_lifetime The returned memory block must be valid at least until it
-    ///is deallocated.
-    ///
-    ///@glfw.reentrancy This function should not call any GLFW function.
-    ///
-    ///@glfw.thread_safety This function must support being called from any thread that calls GLFW
-    ///functions.
+    /// The target method of the upcall.
     @CType("void*") java.lang.foreign.MemorySegment invoke(@CType("void*") java.lang.foreign.MemorySegment block, @CType("size_t") long size, @CType("void*") java.lang.foreign.MemorySegment user);
 
     @Override
     default MemorySegment stub(Arena arena) { return Linker.nativeLinker().upcallStub(HANDLE.bindTo(this), DESCRIPTOR, arena); }
 
-    ///A static invoker of the target method.
-    ///
-    ///This function must return a memory block at least `size` bytes long, or
-    ///`NULL` if allocation failed.  Note that not all parts of GLFW handle allocation
-    ///failures gracefully yet.
-    ///
-    ///This function must support being called during [glfwInit][GLFW#glfwInit()] but before the library is
-    ///flagged as initialized, as well as during [glfwTerminate][GLFW#glfwTerminate()] after the library is no
-    ///longer flagged as initialized.
-    ///
-    ///Any memory allocated via this function will be deallocated via the same allocator
-    ///during library termination or earlier.
-    ///
-    ///Any memory allocated via this function must be suitably aligned for any object type.
-    ///If you are using C99 or earlier, this alignment is platform-dependent but will be the
-    ///same as what `realloc` provides.  If you are using C11 or later, this is the value of
-    ///`alignof(max_align_t)`.
-    ///
-    ///The block address will never be `NULL` and the size will always be greater than zero.
-    ///Reallocations of a block to size zero are converted into deallocations before reaching
-    ///the custom allocator.  Reallocations of `NULL` to a non-zero size are converted into
-    ///regular allocations before reaching the custom allocator.
-    ///
-    ///If this function returns `NULL`, GLFW will emit [GLFW_OUT_OF_MEMORY][GLFW#GLFW_OUT_OF_MEMORY].
-    ///
-    ///This function must not call any GLFW function.
-    ///
-    ///@param block The address of the memory block to reallocate.
-    ///@param size The new minimum size, in bytes, of the memory block.
-    ///@param user The user-defined pointer from the allocator.
-    ///@return The address of the newly allocated or resized memory block, or
-    ///`NULL` if an error occurred.
-    ///
-    ///@glfw.pointer_lifetime The returned memory block must be valid at least until it
-    ///is deallocated.
-    ///
-    ///@glfw.reentrancy This function should not call any GLFW function.
-    ///
-    ///@glfw.thread_safety This function must support being called from any thread that calls GLFW
-    ///functions.
-    ///@param stub the upcall stub
+    /// A static invoker of the target method.
+    /// @param stub the upcall stub
     static @CType("void*") java.lang.foreign.MemorySegment invoke(MemorySegment stub, @CType("void*") java.lang.foreign.MemorySegment block, @CType("size_t") long size, @CType("void*") java.lang.foreign.MemorySegment user) {
         try { return (java.lang.foreign.MemorySegment) HANDLE.invokeExact(stub, block, size, user); }
         catch (Throwable e) { throw new RuntimeException("error in GLFWReallocateFun::invoke (static invoker)", e); }

--- a/modules/overrungl.glfw/src/main/java/overrungl/glfw/GLFWScrollFun.java
+++ b/modules/overrungl.glfw/src/main/java/overrungl/glfw/GLFWScrollFun.java
@@ -23,15 +23,6 @@ import overrungl.annotation.*;
 import overrungl.upcall.*;
 import overrungl.util.*;
 
-/// The function pointer type for scroll callbacks.
-/// 
-/// This is the function pointer type for scroll callbacks.  A scroll callback
-/// function has the following signature:
-/// ```java
-/// void function_name(MemorySegment window, double xoffset, double yoffset)
-/// ```
-/// 
-/// @see GLFW#glfwSetScrollCallback(MemorySegment, MemorySegment)
 @FunctionalInterface
 public interface GLFWScrollFun extends Upcall {
     /// The function descriptor.
@@ -39,26 +30,14 @@ public interface GLFWScrollFun extends Upcall {
     /// The method handle of the target method.
     MethodHandle HANDLE = Upcall.findTarget(GLFWScrollFun.class, "invoke", DESCRIPTOR);
 
-    ///The target method of the upcall.
-    ///
-    ///Invoke
-    ///
-    ///@param window The window that received the event.
-    ///@param xoffset The scroll offset along the x-axis.
-    ///@param yoffset The scroll offset along the y-axis.
+    /// The target method of the upcall.
     void invoke(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("double") double xoffset, @CType("double") double yoffset);
 
     @Override
     default MemorySegment stub(Arena arena) { return Linker.nativeLinker().upcallStub(HANDLE.bindTo(this), DESCRIPTOR, arena); }
 
-    ///A static invoker of the target method.
-    ///
-    ///Invoke
-    ///
-    ///@param window The window that received the event.
-    ///@param xoffset The scroll offset along the x-axis.
-    ///@param yoffset The scroll offset along the y-axis.
-    ///@param stub the upcall stub
+    /// A static invoker of the target method.
+    /// @param stub the upcall stub
     static void invoke(MemorySegment stub, @CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("double") double xoffset, @CType("double") double yoffset) {
         try { HANDLE.invokeExact(stub, window, xoffset, yoffset); }
         catch (Throwable e) { throw new RuntimeException("error in GLFWScrollFun::invoke (static invoker)", e); }

--- a/modules/overrungl.glfw/src/main/java/overrungl/glfw/GLFWVidMode.java
+++ b/modules/overrungl.glfw/src/main/java/overrungl/glfw/GLFWVidMode.java
@@ -24,45 +24,19 @@ import overrungl.annotation.*;
 import overrungl.struct.*;
 import overrungl.util.*;
 
-/// Video mode type.
-/// 
-/// This describes a single video mode.
-/// 
-/// ## See Also
-/// - [glfwGetVideoMode][GLFW#glfwGetVideoMode(MemorySegment)]
-/// - [glfwGetVideoModes][GLFW#glfwGetVideoModes(MemorySegment, MemorySegment)]
-///
 /// ## Members
 /// ### width
 /// [VarHandle][#VH_width] - [Getter][#width()] - [Setter][#width(int)]
-///
-/// The width, in screen coordinates, of the video mode.
-///
 /// ### height
 /// [VarHandle][#VH_height] - [Getter][#height()] - [Setter][#height(int)]
-///
-/// The height, in screen coordinates, of the video mode.
-///
 /// ### redBits
 /// [VarHandle][#VH_redBits] - [Getter][#redBits()] - [Setter][#redBits(int)]
-///
-/// The bit depth of the red channel of the video mode.
-///
 /// ### greenBits
 /// [VarHandle][#VH_greenBits] - [Getter][#greenBits()] - [Setter][#greenBits(int)]
-///
-/// The bit depth of the green channel of the video mode.
-///
 /// ### blueBits
 /// [VarHandle][#VH_blueBits] - [Getter][#blueBits()] - [Setter][#blueBits(int)]
-///
-/// The bit depth of the blue channel of the video mode.
-///
 /// ### refreshRate
 /// [VarHandle][#VH_refreshRate] - [Getter][#refreshRate()] - [Setter][#refreshRate(int)]
-///
-/// The refresh rate, in Hz, of the video mode.
-///
 /// ## Layout
 /// [Java definition][#LAYOUT]
 /// ```c

--- a/modules/overrungl.glfw/src/main/java/overrungl/glfw/GLFWVulkan.java
+++ b/modules/overrungl.glfw/src/main/java/overrungl/glfw/GLFWVulkan.java
@@ -29,7 +29,7 @@ import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodHandle;
 
 /**
- * The GLFW Vulkan binding.
+ * GLFW Vulkan functions.
  *
  * @author squid233
  * @since 0.1.0
@@ -54,216 +54,30 @@ public final class GLFWVulkan {
     }
     //endregion
 
-    ///Sets the desired Vulkan `vkGetInstanceProcAddr` function.
-    ///
-    ///This function sets the `vkGetInstanceProcAddr` function that GLFW will use for all
-    ///Vulkan related entry point queries.
-    ///
-    ///This feature is mostly useful on macOS, if your copy of the Vulkan loader is in
-    ///a location where GLFW cannot find it through dynamic loading, or if you are still
-    ///using the static library version of the loader.
-    ///
-    ///If set to `NULL`, GLFW will try to load the Vulkan loader dynamically by its standard
-    ///name and get this function from there.  This is the default behavior.
-    ///
-    ///The standard name of the loader is `vulkan-1.dll` on Windows, `libvulkan.so.1` on
-    ///Linux and other Unix-like systems and `libvulkan.1.dylib` on macOS.  If your code is
-    ///also loading it via these names then you probably don't need to use this function.
-    ///
-    ///The function address you set is never reset by GLFW, but it only takes effect during
-    ///initialization.  Once GLFW has been initialized, any updates will be ignored until the
-    ///library is terminated and initialized again.
-    ///
-    ///@param loader The address of the function to use, or `NULL`.
-    ///
-    ///Loader function signature
-    ///```c
-    ///PFN_vkVoidFunction vkGetInstanceProcAddr(VkInstance instance, const char* name)
-    ///```
-    ///For more information about this function, see the
-    ///[Vulkan Registry](https://www.khronos.org/registry/vulkan/).
-    ///
-    ///@glfw.errors None.
-    ///
-    ///@glfw.remark This function may be called before [glfwInit][GLFW#glfwInit()].
-    ///
-    ///@glfw.thread_safety This function must only be called from the main thread.
-    ///
-    ///@see GLFW#glfwInit() glfwInit
     public static void glfwInitVulkanLoader(@CType("PFN_vkGetInstanceProcAddr") java.lang.foreign.MemorySegment loader) {
         try {
             Handles.MH_glfwInitVulkanLoader.invokeExact(loader);
         } catch (Throwable e) { throw new RuntimeException("error in glfwInitVulkanLoader", e); }
     }
 
-    ///Returns the address of the specified Vulkan instance function.
-    ///
-    ///This function returns the address of the specified Vulkan core or extension
-    ///function for the specified instance.  If instance is set to `NULL` it can
-    ///return any function exported from the Vulkan loader, including at least the
-    ///following functions:
-    ///- `vkEnumerateInstanceExtensionProperties`
-    ///- `vkEnumerateInstanceLayerProperties`
-    ///- `vkCreateInstance`
-    ///- `vkGetInstanceProcAddr`
-    ///
-    ///If Vulkan is not available on the machine, this function returns `NULL` and
-    ///generates a [GLFW_API_UNAVAILABLE][GLFW#GLFW_API_UNAVAILABLE] error.  Call [glfwVulkanSupported][GLFW#glfwVulkanSupported()]
-    ///to check whether Vulkan is at least minimally available.
-    ///
-    ///This function is equivalent to calling `vkGetInstanceProcAddr` with
-    ///a platform-specific query of the Vulkan loader as a fallback.
-    ///
-    ///@param instance The Vulkan instance to query, or `NULL` to retrieve
-    ///functions related to instance creation.
-    ///@param procname The ASCII encoded name of the function.
-    ///@return The address of the function, or `NULL` if an
-    ///error occurred.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][GLFW#GLFW_NOT_INITIALIZED] and
-    ///[GLFW_API_UNAVAILABLE][GLFW#GLFW_API_UNAVAILABLE].
-    ///
-    ///@glfw.pointer_lifetime The returned function pointer is valid until the library
-    ///is terminated.
-    ///
-    ///@glfw.thread_safety This function may be called from any thread.
     public static @CType("GLFWvkproc") java.lang.foreign.MemorySegment glfwGetInstanceProcAddress(@CType("VkInstance") java.lang.foreign.MemorySegment instance, @CType("const char*") java.lang.foreign.MemorySegment procname) {
         try {
             return (java.lang.foreign.MemorySegment) Handles.MH_glfwGetInstanceProcAddress.invokeExact(instance, procname);
         } catch (Throwable e) { throw new RuntimeException("error in glfwGetInstanceProcAddress", e); }
     }
 
-    ///Returns the address of the specified Vulkan instance function.
-    ///
-    ///This function returns the address of the specified Vulkan core or extension
-    ///function for the specified instance.  If instance is set to `NULL` it can
-    ///return any function exported from the Vulkan loader, including at least the
-    ///following functions:
-    ///- `vkEnumerateInstanceExtensionProperties`
-    ///- `vkEnumerateInstanceLayerProperties`
-    ///- `vkCreateInstance`
-    ///- `vkGetInstanceProcAddr`
-    ///
-    ///If Vulkan is not available on the machine, this function returns `NULL` and
-    ///generates a [GLFW_API_UNAVAILABLE][GLFW#GLFW_API_UNAVAILABLE] error.  Call [glfwVulkanSupported][GLFW#glfwVulkanSupported()]
-    ///to check whether Vulkan is at least minimally available.
-    ///
-    ///This function is equivalent to calling `vkGetInstanceProcAddr` with
-    ///a platform-specific query of the Vulkan loader as a fallback.
-    ///
-    ///@param instance The Vulkan instance to query, or `NULL` to retrieve
-    ///functions related to instance creation.
-    ///@param procname The ASCII encoded name of the function.
-    ///@return The address of the function, or `NULL` if an
-    ///error occurred.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][GLFW#GLFW_NOT_INITIALIZED] and
-    ///[GLFW_API_UNAVAILABLE][GLFW#GLFW_API_UNAVAILABLE].
-    ///
-    ///@glfw.pointer_lifetime The returned function pointer is valid until the library
-    ///is terminated.
-    ///
-    ///@glfw.thread_safety This function may be called from any thread.
     public static @CType("GLFWvkproc") java.lang.foreign.MemorySegment glfwGetInstanceProcAddress(@CType("VkInstance") java.lang.foreign.MemorySegment instance, @CType("const char*") java.lang.String procname) {
         try (var __overrungl_stack = MemoryStack.pushLocal()) {
             return (java.lang.foreign.MemorySegment) Handles.MH_glfwGetInstanceProcAddress.invokeExact(instance, Marshal.marshal(__overrungl_stack, procname));
         } catch (Throwable e) { throw new RuntimeException("error in glfwGetInstanceProcAddress", e); }
     }
 
-    ///Returns whether the specified queue family can present images.
-    ///
-    ///This function returns whether the specified queue family of the specified
-    ///physical device supports presentation to the platform GLFW was built for.
-    ///
-    ///If Vulkan or the required window surface creation instance extensions are
-    ///not available on the machine, or if the specified instance was not created
-    ///with the required extensions, this function returns `GLFW_FALSE` and
-    ///generates a [GLFW_API_UNAVAILABLE][GLFW#GLFW_API_UNAVAILABLE] error.  Call [glfwVulkanSupported][GLFW#glfwVulkanSupported()]
-    ///to check whether Vulkan is at least minimally available and
-    ///[glfwGetRequiredInstanceExtensions][GLFW#glfwGetRequiredInstanceExtensions(MemorySegment)] to check what instance extensions are
-    ///required.
-    ///
-    ///@param instance The instance that the physical device belongs to.
-    ///@param device The physical device that the queue family belongs to.
-    ///@param queuefamily The index of the queue family to query.
-    ///@return `GLFW_TRUE` if the queue family supports presentation, or
-    ///`GLFW_FALSE` otherwise.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][GLFW#GLFW_NOT_INITIALIZED],
-    ///[GLFW_API_UNAVAILABLE][GLFW#GLFW_API_UNAVAILABLE] and [GLFW_PLATFORM_ERROR][GLFW#GLFW_PLATFORM_ERROR].
-    ///
-    ///@glfw.remark __macOS:__ This function currently always returns `GLFW_TRUE`, as the
-    ///`VK_MVK_macos_surface` and `VK_EXT_metal_surface` extensions do not provide
-    ///a `vkGetPhysicalDevice*PresentationSupport` type function.
-    ///
-    ///@glfw.thread_safety This function may be called from any thread.  For
-    ///synchronization details of Vulkan objects, see the Vulkan specification.
     public static @CType("int") boolean glfwGetPhysicalDevicePresentationSupport(@CType("VkInstance") java.lang.foreign.MemorySegment instance, @CType("VkPhysicalDevice") java.lang.foreign.MemorySegment device, @CType("uint32_t") int queuefamily) {
         try {
             return (int) Handles.MH_glfwGetPhysicalDevicePresentationSupport.invokeExact(instance, device, queuefamily) != GLFW.GLFW_FALSE;
         } catch (Throwable e) { throw new RuntimeException("error in glfwGetPhysicalDevicePresentationSupport", e); }
     }
 
-    ///Creates a Vulkan surface for the specified window.
-    ///
-    ///This function creates a Vulkan surface for the specified window.
-    ///
-    ///If the Vulkan loader or at least one minimally functional ICD were not found,
-    ///this function returns `VK_ERROR_INITIALIZATION_FAILED` and generates a
-    ///[GLFW_API_UNAVAILABLE][GLFW#GLFW_API_UNAVAILABLE] error.  Call [glfwVulkanSupported][GLFW#glfwVulkanSupported()] to check whether
-    ///Vulkan is at least minimally available.
-    ///
-    ///If the required window surface creation instance extensions are not
-    ///available or if the specified instance was not created with these extensions
-    ///enabled, this function returns `VK_ERROR_EXTENSION_NOT_PRESENT` and
-    ///generates a [GLFW_API_UNAVAILABLE][GLFW#GLFW_API_UNAVAILABLE] error.  Call
-    ///[glfwGetRequiredInstanceExtensions][GLFW#glfwGetRequiredInstanceExtensions(MemorySegment)] to check what instance extensions are
-    ///required.
-    ///
-    ///The window surface cannot be shared with another API so the window must
-    ///have been created with the client api hint
-    ///set to `GLFW_NO_API` otherwise it generates a [GLFW_INVALID_VALUE][GLFW#GLFW_INVALID_VALUE] error
-    ///and returns `VK_ERROR_NATIVE_WINDOW_IN_USE_KHR`.
-    ///
-    ///The window surface must be destroyed before the specified Vulkan instance.
-    ///It is the responsibility of the caller to destroy the window surface.  GLFW
-    ///does not destroy it for you.  Call `vkDestroySurfaceKHR` to destroy the
-    ///surface.
-    ///
-    ///@param instance The Vulkan instance to create the surface in.
-    ///@param window The window to create the surface for.
-    ///@param allocator The allocator to use, or `NULL` to use the default
-    ///allocator.
-    ///@param surface Where to store the handle of the surface.  This is set
-    ///to `VK_NULL_HANDLE` if an error occurred.
-    ///@return `VK_SUCCESS` if successful, or a Vulkan error code if an
-    ///error occurred.
-    ///
-    ///@glfw.errors Possible errors include [GLFW_NOT_INITIALIZED][GLFW#GLFW_NOT_INITIALIZED],
-    ///[GLFW_API_UNAVAILABLE][GLFW#GLFW_API_UNAVAILABLE], [GLFW_PLATFORM_ERROR][GLFW#GLFW_PLATFORM_ERROR] and [GLFW_INVALID_VALUE][GLFW#GLFW_INVALID_VALUE]
-    ///
-    ///@glfw.remark If an error occurs before the creation call is made, GLFW returns
-    ///the Vulkan error code most appropriate for the error.  Appropriate use of
-    ///[glfwVulkanSupported][GLFW#glfwVulkanSupported()] and [glfwGetRequiredInstanceExtensions][GLFW#glfwGetRequiredInstanceExtensions(MemorySegment)] should
-    ///eliminate almost all occurrences of these errors.
-    ///- __macOS:__ GLFW prefers the `VK_EXT_metal_surface` extension, with the
-    ///    `VK_MVK_macos_surface` extension as a fallback.  The name of the selected
-    ///    extension, if any, is included in the array returned by
-    ///    [glfwGetRequiredInstanceExtensions][GLFW#glfwGetRequiredInstanceExtensions(MemorySegment)].
-    ///
-    ///    This function creates and sets a `CAMetalLayer` instance for
-    ///    the window content view, which is required for MoltenVK to function.
-    ///- __X11:__ By default GLFW prefers the `VK_KHR_xcb_surface` extension,
-    ///    with the `VK_KHR_xlib_surface` extension as a fallback.  You can make
-    ///    `VK_KHR_xlib_surface` the preferred extension by setting the
-    ///    [GLFW_X11_XCB_VULKAN_SURFACE][GLFW#GLFW_X11_XCB_VULKAN_SURFACE] init
-    ///    hint.  The name of the selected extension, if any, is included in the array
-    ///    returned by [glfwGetRequiredInstanceExtensions][GLFW#glfwGetRequiredInstanceExtensions(MemorySegment)].
-    ///
-    ///@glfw.thread_safety This function may be called from any thread.  For
-    ///synchronization details of Vulkan objects, see the Vulkan specification.
-    ///
-    ///@see GLFW#glfwGetRequiredInstanceExtensions(MemorySegment) glfwGetRequiredInstanceExtensions
     public static @CType("VkResult") int glfwCreateWindowSurface(@CType("VkInstance") java.lang.foreign.MemorySegment instance, @CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("const VkAllocationCallbacks*") java.lang.foreign.MemorySegment allocator, @Out @CType("VkSurfaceKHR*") java.lang.foreign.MemorySegment surface) {
         try {
             return (int) Handles.MH_glfwCreateWindowSurface.invokeExact(instance, window, allocator, surface);

--- a/modules/overrungl.glfw/src/main/java/overrungl/glfw/GLFWWindowCloseFun.java
+++ b/modules/overrungl.glfw/src/main/java/overrungl/glfw/GLFWWindowCloseFun.java
@@ -23,15 +23,6 @@ import overrungl.annotation.*;
 import overrungl.upcall.*;
 import overrungl.util.*;
 
-/// The function pointer type for window close callbacks.
-/// 
-/// This is the function pointer type for window close callbacks.  A window
-/// close callback function has the following signature:
-/// ```java
-/// void function_name(MemorySegment window)
-/// ```
-/// 
-/// @see GLFW#glfwSetWindowCloseCallback(MemorySegment, MemorySegment)
 @FunctionalInterface
 public interface GLFWWindowCloseFun extends Upcall {
     /// The function descriptor.
@@ -39,22 +30,14 @@ public interface GLFWWindowCloseFun extends Upcall {
     /// The method handle of the target method.
     MethodHandle HANDLE = Upcall.findTarget(GLFWWindowCloseFun.class, "invoke", DESCRIPTOR);
 
-    ///The target method of the upcall.
-    ///
-    ///Invoke
-    ///
-    ///@param window The window that the user attempted to close.
+    /// The target method of the upcall.
     void invoke(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window);
 
     @Override
     default MemorySegment stub(Arena arena) { return Linker.nativeLinker().upcallStub(HANDLE.bindTo(this), DESCRIPTOR, arena); }
 
-    ///A static invoker of the target method.
-    ///
-    ///Invoke
-    ///
-    ///@param window The window that the user attempted to close.
-    ///@param stub the upcall stub
+    /// A static invoker of the target method.
+    /// @param stub the upcall stub
     static void invoke(MemorySegment stub, @CType("GLFWwindow*") java.lang.foreign.MemorySegment window) {
         try { HANDLE.invokeExact(stub, window); }
         catch (Throwable e) { throw new RuntimeException("error in GLFWWindowCloseFun::invoke (static invoker)", e); }

--- a/modules/overrungl.glfw/src/main/java/overrungl/glfw/GLFWWindowContentScaleFun.java
+++ b/modules/overrungl.glfw/src/main/java/overrungl/glfw/GLFWWindowContentScaleFun.java
@@ -23,15 +23,6 @@ import overrungl.annotation.*;
 import overrungl.upcall.*;
 import overrungl.util.*;
 
-/// The function pointer type for window content scale callbacks.
-/// 
-/// This is the function pointer type for window content scale callbacks.
-/// A window content scale callback function has the following signature:
-/// ```java
-/// void function_name(MemorySegment window, float xscale, float yscale)
-/// ```
-/// 
-/// @see GLFW#glfwSetWindowContentScaleCallback(MemorySegment, MemorySegment)
 @FunctionalInterface
 public interface GLFWWindowContentScaleFun extends Upcall {
     /// The function descriptor.
@@ -39,26 +30,14 @@ public interface GLFWWindowContentScaleFun extends Upcall {
     /// The method handle of the target method.
     MethodHandle HANDLE = Upcall.findTarget(GLFWWindowContentScaleFun.class, "invoke", DESCRIPTOR);
 
-    ///The target method of the upcall.
-    ///
-    ///Invoke
-    ///
-    ///@param window The window whose content scale changed.
-    ///@param xscale The new x-axis content scale of the window.
-    ///@param yscale The new y-axis content scale of the window.
+    /// The target method of the upcall.
     void invoke(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("float") float xscale, @CType("float") float yscale);
 
     @Override
     default MemorySegment stub(Arena arena) { return Linker.nativeLinker().upcallStub(HANDLE.bindTo(this), DESCRIPTOR, arena); }
 
-    ///A static invoker of the target method.
-    ///
-    ///Invoke
-    ///
-    ///@param window The window whose content scale changed.
-    ///@param xscale The new x-axis content scale of the window.
-    ///@param yscale The new y-axis content scale of the window.
-    ///@param stub the upcall stub
+    /// A static invoker of the target method.
+    /// @param stub the upcall stub
     static void invoke(MemorySegment stub, @CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("float") float xscale, @CType("float") float yscale) {
         try { HANDLE.invokeExact(stub, window, xscale, yscale); }
         catch (Throwable e) { throw new RuntimeException("error in GLFWWindowContentScaleFun::invoke (static invoker)", e); }

--- a/modules/overrungl.glfw/src/main/java/overrungl/glfw/GLFWWindowFocusFun.java
+++ b/modules/overrungl.glfw/src/main/java/overrungl/glfw/GLFWWindowFocusFun.java
@@ -23,15 +23,6 @@ import overrungl.annotation.*;
 import overrungl.upcall.*;
 import overrungl.util.*;
 
-/// The function pointer type for window focus callbacks.
-/// 
-/// This is the function pointer type for window focus callbacks.  A window
-/// focus callback function has the following signature:
-/// ```java
-/// void function_name(MemorySegment window, boolean focused)
-/// ```
-/// 
-/// @see GLFW#glfwSetWindowFocusCallback(MemorySegment, MemorySegment)
 @FunctionalInterface
 public interface GLFWWindowFocusFun extends Upcall {
     /// The function descriptor.
@@ -39,22 +30,10 @@ public interface GLFWWindowFocusFun extends Upcall {
     /// The method handle of the target method.
     MethodHandle HANDLE = Upcall.findTarget(GLFWWindowFocusFun.class, "invoke", DESCRIPTOR);
 
-    ///The interface target method of the upcall.
-    ///
-    ///Invoke
-    ///
-    ///@param window The window that gained or lost input focus.
-    ///@param focused `true` if the window was given input focus, or
-    ///`false` if it lost it.
+    /// The interface target method of the upcall.
     void invoke(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("int") boolean focused);
 
-    ///The target method of the upcall.
-    ///
-    ///Invoke
-    ///
-    ///@param window The window that gained or lost input focus.
-    ///@param focused `GLFW_TRUE` if the window was given input focus, or
-    ///`GLFW_FALSE` if it lost it.
+    /// The target method of the upcall.
     default void invoke(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("int") int focused) {
         invoke(window, focused != GLFW.GLFW_FALSE);
     }
@@ -62,14 +41,8 @@ public interface GLFWWindowFocusFun extends Upcall {
     @Override
     default MemorySegment stub(Arena arena) { return Linker.nativeLinker().upcallStub(HANDLE.bindTo(this), DESCRIPTOR, arena); }
 
-    ///A static invoker of the target method.
-    ///
-    ///Invoke
-    ///
-    ///@param window The window that gained or lost input focus.
-    ///@param focused `GLFW_TRUE` if the window was given input focus, or
-    ///`GLFW_FALSE` if it lost it.
-    ///@param stub the upcall stub
+    /// A static invoker of the target method.
+    /// @param stub the upcall stub
     static void invoke(MemorySegment stub, @CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("int") int focused) {
         try { HANDLE.invokeExact(stub, window, focused); }
         catch (Throwable e) { throw new RuntimeException("error in GLFWWindowFocusFun::invoke (static invoker)", e); }

--- a/modules/overrungl.glfw/src/main/java/overrungl/glfw/GLFWWindowIconifyFun.java
+++ b/modules/overrungl.glfw/src/main/java/overrungl/glfw/GLFWWindowIconifyFun.java
@@ -23,15 +23,6 @@ import overrungl.annotation.*;
 import overrungl.upcall.*;
 import overrungl.util.*;
 
-/// The function pointer type for window iconify callbacks.
-/// 
-/// This is the function pointer type for window iconify callbacks.  A window
-/// iconify callback function has the following signature:
-/// ```java
-/// void function_name(MemorySegment window, boolean iconified)
-/// ```
-/// 
-/// @see GLFW#glfwSetWindowIconifyCallback(MemorySegment, MemorySegment)
 @FunctionalInterface
 public interface GLFWWindowIconifyFun extends Upcall {
     /// The function descriptor.
@@ -39,22 +30,10 @@ public interface GLFWWindowIconifyFun extends Upcall {
     /// The method handle of the target method.
     MethodHandle HANDLE = Upcall.findTarget(GLFWWindowIconifyFun.class, "invoke", DESCRIPTOR);
 
-    ///The interface target method of the upcall.
-    ///
-    ///Invoke
-    ///
-    ///@param window The window that was iconified or restored.
-    ///@param iconified `true` if the window was iconified, or
-    ///`false` if it was restored.
+    /// The interface target method of the upcall.
     void invoke(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("int") boolean iconified);
 
-    ///The target method of the upcall.
-    ///
-    ///Invoke
-    ///
-    ///@param window The window that was iconified or restored.
-    ///@param iconified `GLFW_TRUE` if the window was iconified, or
-    ///`GLFW_FALSE` if it was restored.
+    /// The target method of the upcall.
     default void invoke(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("int") int iconified) {
         invoke(window, iconified != GLFW.GLFW_FALSE);
     }
@@ -62,14 +41,8 @@ public interface GLFWWindowIconifyFun extends Upcall {
     @Override
     default MemorySegment stub(Arena arena) { return Linker.nativeLinker().upcallStub(HANDLE.bindTo(this), DESCRIPTOR, arena); }
 
-    ///A static invoker of the target method.
-    ///
-    ///Invoke
-    ///
-    ///@param window The window that was iconified or restored.
-    ///@param iconified `GLFW_TRUE` if the window was iconified, or
-    ///`GLFW_FALSE` if it was restored.
-    ///@param stub the upcall stub
+    /// A static invoker of the target method.
+    /// @param stub the upcall stub
     static void invoke(MemorySegment stub, @CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("int") int iconified) {
         try { HANDLE.invokeExact(stub, window, iconified); }
         catch (Throwable e) { throw new RuntimeException("error in GLFWWindowIconifyFun::invoke (static invoker)", e); }

--- a/modules/overrungl.glfw/src/main/java/overrungl/glfw/GLFWWindowMaximizeFun.java
+++ b/modules/overrungl.glfw/src/main/java/overrungl/glfw/GLFWWindowMaximizeFun.java
@@ -23,15 +23,6 @@ import overrungl.annotation.*;
 import overrungl.upcall.*;
 import overrungl.util.*;
 
-/// The function pointer type for window maximize callbacks.
-/// 
-/// This is the function pointer type for window maximize callbacks.  A window
-/// maximize callback function has the following signature:
-/// ```java
-/// void function_name(MemorySegment window, boolean maximized)
-/// ```
-/// 
-/// @see GLFW#glfwSetWindowMaximizeCallback(MemorySegment, MemorySegment)
 @FunctionalInterface
 public interface GLFWWindowMaximizeFun extends Upcall {
     /// The function descriptor.
@@ -39,22 +30,10 @@ public interface GLFWWindowMaximizeFun extends Upcall {
     /// The method handle of the target method.
     MethodHandle HANDLE = Upcall.findTarget(GLFWWindowMaximizeFun.class, "invoke", DESCRIPTOR);
 
-    ///The interface target method of the upcall.
-    ///
-    ///Invoke
-    ///
-    ///@param window The window that was maximized or restored.
-    ///@param maximized `true` if the window was maximized, or
-    ///`false` if it was restored.
+    /// The interface target method of the upcall.
     void invoke(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("int") boolean maximized);
 
-    ///The target method of the upcall.
-    ///
-    ///Invoke
-    ///
-    ///@param window The window that was maximized or restored.
-    ///@param maximized `GLFW_TRUE` if the window was maximized, or
-    ///`GLFW_FALSE` if it was restored.
+    /// The target method of the upcall.
     default void invoke(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("int") int maximized) {
         invoke(window, maximized != GLFW.GLFW_FALSE);
     }
@@ -62,14 +41,8 @@ public interface GLFWWindowMaximizeFun extends Upcall {
     @Override
     default MemorySegment stub(Arena arena) { return Linker.nativeLinker().upcallStub(HANDLE.bindTo(this), DESCRIPTOR, arena); }
 
-    ///A static invoker of the target method.
-    ///
-    ///Invoke
-    ///
-    ///@param window The window that was maximized or restored.
-    ///@param maximized `GLFW_TRUE` if the window was maximized, or
-    ///`GLFW_FALSE` if it was restored.
-    ///@param stub the upcall stub
+    /// A static invoker of the target method.
+    /// @param stub the upcall stub
     static void invoke(MemorySegment stub, @CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("int") int maximized) {
         try { HANDLE.invokeExact(stub, window, maximized); }
         catch (Throwable e) { throw new RuntimeException("error in GLFWWindowMaximizeFun::invoke (static invoker)", e); }

--- a/modules/overrungl.glfw/src/main/java/overrungl/glfw/GLFWWindowPosFun.java
+++ b/modules/overrungl.glfw/src/main/java/overrungl/glfw/GLFWWindowPosFun.java
@@ -23,15 +23,6 @@ import overrungl.annotation.*;
 import overrungl.upcall.*;
 import overrungl.util.*;
 
-/// The function pointer type for window position callbacks.
-/// 
-/// This is the function pointer type for window position callbacks.  A window
-/// position callback function has the following signature:
-/// ```java
-/// void callback_name(MemorySegment window, int xpos, int ypos)
-/// ```
-/// 
-/// @see GLFW#glfwSetWindowPosCallback(MemorySegment, MemorySegment)
 @FunctionalInterface
 public interface GLFWWindowPosFun extends Upcall {
     /// The function descriptor.
@@ -39,30 +30,14 @@ public interface GLFWWindowPosFun extends Upcall {
     /// The method handle of the target method.
     MethodHandle HANDLE = Upcall.findTarget(GLFWWindowPosFun.class, "invoke", DESCRIPTOR);
 
-    ///The target method of the upcall.
-    ///
-    ///Invoke
-    ///
-    ///@param window The window that was moved.
-    ///@param xpos The new x-coordinate, in screen coordinates, of the
-    ///upper-left corner of the content area of the window.
-    ///@param ypos The new y-coordinate, in screen coordinates, of the
-    ///upper-left corner of the content area of the window.
+    /// The target method of the upcall.
     void invoke(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("int") int xpos, @CType("int") int ypos);
 
     @Override
     default MemorySegment stub(Arena arena) { return Linker.nativeLinker().upcallStub(HANDLE.bindTo(this), DESCRIPTOR, arena); }
 
-    ///A static invoker of the target method.
-    ///
-    ///Invoke
-    ///
-    ///@param window The window that was moved.
-    ///@param xpos The new x-coordinate, in screen coordinates, of the
-    ///upper-left corner of the content area of the window.
-    ///@param ypos The new y-coordinate, in screen coordinates, of the
-    ///upper-left corner of the content area of the window.
-    ///@param stub the upcall stub
+    /// A static invoker of the target method.
+    /// @param stub the upcall stub
     static void invoke(MemorySegment stub, @CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("int") int xpos, @CType("int") int ypos) {
         try { HANDLE.invokeExact(stub, window, xpos, ypos); }
         catch (Throwable e) { throw new RuntimeException("error in GLFWWindowPosFun::invoke (static invoker)", e); }

--- a/modules/overrungl.glfw/src/main/java/overrungl/glfw/GLFWWindowRefreshFun.java
+++ b/modules/overrungl.glfw/src/main/java/overrungl/glfw/GLFWWindowRefreshFun.java
@@ -23,15 +23,6 @@ import overrungl.annotation.*;
 import overrungl.upcall.*;
 import overrungl.util.*;
 
-/// The function pointer type for window content refresh callbacks.
-/// 
-/// This is the function pointer type for window content refresh callbacks.
-/// A window content refresh callback function has the following signature:
-/// ```java
-/// void function_name(MemorySegment window);
-/// ```
-/// 
-/// @see GLFW#glfwSetWindowRefreshCallback(MemorySegment, MemorySegment)
 @FunctionalInterface
 public interface GLFWWindowRefreshFun extends Upcall {
     /// The function descriptor.
@@ -39,22 +30,14 @@ public interface GLFWWindowRefreshFun extends Upcall {
     /// The method handle of the target method.
     MethodHandle HANDLE = Upcall.findTarget(GLFWWindowRefreshFun.class, "invoke", DESCRIPTOR);
 
-    ///The target method of the upcall.
-    ///
-    ///Invoke
-    ///
-    ///@param window The window whose content needs to be refreshed.
+    /// The target method of the upcall.
     void invoke(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window);
 
     @Override
     default MemorySegment stub(Arena arena) { return Linker.nativeLinker().upcallStub(HANDLE.bindTo(this), DESCRIPTOR, arena); }
 
-    ///A static invoker of the target method.
-    ///
-    ///Invoke
-    ///
-    ///@param window The window whose content needs to be refreshed.
-    ///@param stub the upcall stub
+    /// A static invoker of the target method.
+    /// @param stub the upcall stub
     static void invoke(MemorySegment stub, @CType("GLFWwindow*") java.lang.foreign.MemorySegment window) {
         try { HANDLE.invokeExact(stub, window); }
         catch (Throwable e) { throw new RuntimeException("error in GLFWWindowRefreshFun::invoke (static invoker)", e); }

--- a/modules/overrungl.glfw/src/main/java/overrungl/glfw/GLFWWindowSizeFun.java
+++ b/modules/overrungl.glfw/src/main/java/overrungl/glfw/GLFWWindowSizeFun.java
@@ -23,15 +23,6 @@ import overrungl.annotation.*;
 import overrungl.upcall.*;
 import overrungl.util.*;
 
-/// The function pointer type for window size callbacks.
-/// 
-/// This is the function pointer type for window size callbacks.  A window size
-/// callback function has the following signature:
-/// ```java
-/// void callback_name(MemorySegment window, int width, int height)
-/// ```
-/// 
-/// @see GLFW#glfwSetWindowSizeCallback(MemorySegment, MemorySegment)
 @FunctionalInterface
 public interface GLFWWindowSizeFun extends Upcall {
     /// The function descriptor.
@@ -39,26 +30,14 @@ public interface GLFWWindowSizeFun extends Upcall {
     /// The method handle of the target method.
     MethodHandle HANDLE = Upcall.findTarget(GLFWWindowSizeFun.class, "invoke", DESCRIPTOR);
 
-    ///The target method of the upcall.
-    ///
-    ///Invoke
-    ///
-    ///@param window The window that was resized.
-    ///@param width The new width, in screen coordinates, of the window.
-    ///@param height The new height, in screen coordinates, of the window.
+    /// The target method of the upcall.
     void invoke(@CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("int") int width, @CType("int") int height);
 
     @Override
     default MemorySegment stub(Arena arena) { return Linker.nativeLinker().upcallStub(HANDLE.bindTo(this), DESCRIPTOR, arena); }
 
-    ///A static invoker of the target method.
-    ///
-    ///Invoke
-    ///
-    ///@param window The window that was resized.
-    ///@param width The new width, in screen coordinates, of the window.
-    ///@param height The new height, in screen coordinates, of the window.
-    ///@param stub the upcall stub
+    /// A static invoker of the target method.
+    /// @param stub the upcall stub
     static void invoke(MemorySegment stub, @CType("GLFWwindow*") java.lang.foreign.MemorySegment window, @CType("int") int width, @CType("int") int height) {
         try { HANDLE.invokeExact(stub, window, width, height); }
         catch (Throwable e) { throw new RuntimeException("error in GLFWWindowSizeFun::invoke (static invoker)", e); }

--- a/modules/overrungl.glfw/src/main/java/overrungl/glfw/package-info.java
+++ b/modules/overrungl.glfw/src/main/java/overrungl/glfw/package-info.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023-2025 Overrun Organization
+ * Copyright (c) 2025 Overrun Organization
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -16,11 +16,10 @@
 
 /// The GLFW binding.
 ///
+/// - [Website](https://www.glfw.org/)
+/// - [Documentation](https://www.glfw.org/docs/latest/)
+/// - [Source](https://github.com/glfw/glfw)
+///
 /// @author squid233
 /// @since 0.1.0
-module overrungl.glfw {
-    exports overrungl.glfw;
-
-    requires transitive overrungl.core;
-    requires static org.jetbrains.annotations;
-}
+package overrungl.glfw;

--- a/modules/overrungl.nfd/src/main/java/module-info.java
+++ b/modules/overrungl.nfd/src/main/java/module-info.java
@@ -14,12 +14,12 @@
  * copies or substantial portions of the Software.
  */
 
-/**
- * The NFD binding.
- *
- * @author squid233
- * @since 0.1.0
- */
+/// The NFD binding.
+///
+/// - [Source](https://github.com/btzy/nativefiledialog-extended)
+///
+/// @author squid233
+/// @since 0.1.0
 module overrungl.nfd {
     exports overrungl.nfd;
 

--- a/modules/overrungl.nfd/src/main/java/module-info.java
+++ b/modules/overrungl.nfd/src/main/java/module-info.java
@@ -16,8 +16,6 @@
 
 /// The NFD binding.
 ///
-/// - [Source](https://github.com/btzy/nativefiledialog-extended)
-///
 /// @author squid233
 /// @since 0.1.0
 module overrungl.nfd {

--- a/modules/overrungl.nfd/src/main/java/overrungl/nfd/NFD.java
+++ b/modules/overrungl.nfd/src/main/java/overrungl/nfd/NFD.java
@@ -29,125 +29,25 @@ import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodHandle;
 
-/**
- * <h2>Native File Dialog Extended</h2>
- * <p>
- * A small C library that portably invokes native file open, folder select and file save dialogs.
- * Write dialog code once and have it pop up native dialogs on all supported platforms.
- * Avoid linking large dependencies like wxWidgets and Qt.
- * <p>
- * Features:
- * <ul>
- *     <li>Supports Windows, MacOS, and Linux</li>
- *     <li>Friendly names for filters (e.g. {@code Java Source files (*.java;*.kt)} instead of {@code (*.java;*.kt)}) on platforms that support it</li>
- *     <li>Automatically append file extension on platforms where users expect it</li>
- *     <li>Support for setting a default folder path</li>
- *     <li>Support for setting a default file name (e.g. {@code Untitled.java})</li>
- *     <li>Consistent UTF-8 support on all platforms</li>
- *     <li>Native character set (UTF-16LE) support on Windows</li>
- *     <li>Initialization and de-initialization of platform library (e.g. COM (Windows) / GTK (Linux GTK) / D-Bus (Linux portal)) decoupled from dialog functions, so applications can choose when to initialize/de-initialize</li>
- *     <li>Multiple file selection support (for file open dialog)</li>
- *     <li>No third party dependencies</li>
- * </ul>
- *
- * <h3>Basic Usages</h3>
- * {@snippet lang = java:
- * void main() {
- *     NFD_Init();
- *
- *     try (MemoryStack stack = MemoryStack.pushLocal()) {
- *         String[] outPath = new String[1];
- *         var filterItem = NFDFilterItem.create(stack,
- *             Map.entry("Source code", "java"),
- *             Map.entry("Image file", "png,jpg"));
- *         var result = NFD_OpenDialog(outPath, filterItem, null);
- *         switch (result) {
- *             case NFD_ERROR -> println("Error: " + NFD_GetError());
- *             case NFD_OKAY -> println("Success! " + outPath[0]);
- *             case NFD_CANCEL -> println("User pressed cancel.");
- *         }
- *     }
- *
- *     NFD_Quit();
- * }}
- *
- * <h3>File Filter Syntax</h3>
- * Files can be filtered by file extension groups:
- * {@snippet lang = java:
- * var filterItem = NFDFilterItem.create(allocator,
- *     Map.entry("Source code", "java"),
- *     Map.entry("Image file", "png,jpg"));
- *}
- * <p>
- * A file filter is a pair of strings comprising the friendly name and the specification
- * (multiple file extensions are comma-separated).
- * <p>
- * A list of file filters can be passed as an argument when invoking the library.
- * <p>
- * A wildcard filter is always added to every dialog.
- * <p>
- * <i>Note: On MacOS, the file dialogs do not have friendly names and there is no way to switch between filters, so the filter specifications are combined (e.g. "java,kt,png,jpg"). The filter specification is also never explicitly shown to the user. This is usual MacOS behaviour and users expect it.</i>
- * <p>
- * <i>Note 2: You must ensure that the specification string is non-empty and that every file extension has at least one character. Otherwise, bad things might ensue (i.e. undefined behaviour).</i>
- * <p>
- * <i>Note 3: On Linux, the file extension is appended (if missing) when the user presses down the "Save" button. The appended file extension will remain visible to the user, even if an overwrite prompt is shown and the user then presses "Cancel".</i>
- * <p>
- * <i>Note 4: On Windows, the default folder parameter is only used if there is no recently used folder available. Otherwise, the default folder will be the folder that was last used. Internally, the Windows implementation calls <a href="https://docs.microsoft.com/en-us/windows/desktop/api/shobjidl_core/nf-shobjidl_core-ifiledialog-setdefaultfolder">IFileDialog::SetDefaultFolder(IShellItem)</a>. This is usual Windows behaviour and users expect it.</i>
- *
- * <h3>Iterating Over PathSets</h3>
- * A file open dialog that supports multiple selection produces a PathSet,
- * which is a thin abstraction over the platform-specific collection.
- * There are two ways to iterate over a PathSet:
- *
- * <h4>Accessing by index</h4>
- * This method does array-like access on the PathSet, and is the easiest to use.
- * However, on certain platforms (Linux, and possibly Windows),
- * it takes O(N²) time in total to iterate the entire PathSet,
- * because the underlying platform-specific implementation uses a linked list.
- *
- * <h4>Using an enumerator (experimental)</h4>
- * This method uses an enumerator object to iterate the paths in the PathSet.
- * It is guaranteed to take O(N) time in total to iterate the entire PathSet.
- * <p>
- * See {@link NFDEnumerator}.
- * <p>
- * This API is experimental, and subject to change.
- *
- * @author squid233
- * @since 0.1.0
- */
+/// Native File Dialog Extended binding.
+///
+/// See the [source repository](https://github.com/btzy/nativefiledialog-extended) for basic usages.
+///
+/// @author squid233
+/// @since 0.1.0
 public final class NFD {
     //region ---[BEGIN GENERATOR BEGIN]---
     //@formatter:off
     //region Fields
-    ///#### Documentation of fields
-    ///##### NFD_ERROR
-    ///Programmatic error
-    ///##### NFD_OKAY
-    ///User pressed okay, or successful return
-    ///##### NFD_CANCEL
-    ///User pressed cancel
     public static final int
         NFD_ERROR = 0,
         NFD_OKAY = 1,
         NFD_CANCEL = 2;
-    ///The native window handle type.
-    ///Wayland support will be implemented separately in the future
-    ///#### Documentation of fields
-    ///##### NFD_WINDOW_HANDLE_TYPE_WINDOWS
-    ///Windows: handle is HWND (the Windows API typedefs this to void*)
-    ///##### NFD_WINDOW_HANDLE_TYPE_COCOA
-    ///Cocoa: handle is NSWindow*
-    ///##### NFD_WINDOW_HANDLE_TYPE_X11
-    ///X11: handle is Window
     public static final int
         NFD_WINDOW_HANDLE_TYPE_UNSET = 0,
         NFD_WINDOW_HANDLE_TYPE_WINDOWS = 1,
         NFD_WINDOW_HANDLE_TYPE_COCOA = 2,
         NFD_WINDOW_HANDLE_TYPE_X11 = 3;
-    ///This is a unique identifier tagged to all the NFD_*With() function calls, for backward
-    ///compatibility purposes. <p>There is usually no need to use this directly, unless you want to use
-    ///NFD differently depending on the version you're building with.
     public static final int NFD_INTERFACE_VERSION = 1;
     //endregion
     //region Method handles
@@ -201,211 +101,128 @@ public final class NFD {
     }
     //endregion
 
-    ///Free a file path that was returned by the dialogs.
-    ///
-    ///Note: use NFD_PathSet_FreePath() to free path from pathset instead of this function.
     public static void NFD_FreePath(@CType("nfdnchar_t*") java.lang.foreign.MemorySegment filePath) {
         try {
             Handles.MH_NFD_FreePathN.invokeExact(filePath);
         } catch (Throwable e) { throw new RuntimeException("error in NFD_FreePathN", e); }
     }
 
-    ///Initialize NFD. Call this for every thread that might use NFD, before calling any other NFD
-    ///functions on that thread.
     public static @CType("nfdresult_t") int NFD_Init() {
         try {
             return (int) Handles.MH_NFD_Init.invokeExact();
         } catch (Throwable e) { throw new RuntimeException("error in NFD_Init", e); }
     }
 
-    ///Call this to de-initialize NFD, if [NFD_Init][#NFD_Init()] returned NFD_OKAY.
     public static void NFD_Quit() {
         try {
             Handles.MH_NFD_Quit.invokeExact();
         } catch (Throwable e) { throw new RuntimeException("error in NFD_Quit", e); }
     }
 
-    ///Single file open dialog
-    ///
-    ///It's the caller's responsibility to free `outPath` via NFD_FreePath() if this function returns
-    ///NFD_OKAY.
-    ///@param filterCount If zero, filterList is ignored (you can use null).
-    ///@param defaultPath If null, the operating system will decide.
     public static @CType("nfdresult_t") int NFD_OpenDialog(@CType("nfdnchar_t**") java.lang.foreign.MemorySegment outPath, @CType("const nfdnfilteritem_t*") java.lang.foreign.MemorySegment filterList, @CType("nfdfiltersize_t") int filterCount, @CType("const nfdnchar_t*") java.lang.foreign.MemorySegment defaultPath) {
         try {
             return (int) Handles.MH_NFD_OpenDialogN.invokeExact(outPath, filterList, filterCount, defaultPath);
         } catch (Throwable e) { throw new RuntimeException("error in NFD_OpenDialogN", e); }
     }
 
-    ///This function is a library implementation detail.  Please use NFD_OpenDialog_With() instead.
     public static @CType("nfdresult_t") int NFD_OpenDialog_With_Impl(@CType("nfdversion_t") int version, @CType("nfdnchar_t**") java.lang.foreign.MemorySegment outPath, @CType("const nfdopendialognargs_t*") java.lang.foreign.MemorySegment args) {
         try {
             return (int) Handles.MH_NFD_OpenDialogN_With_Impl.invokeExact(version, outPath, args);
         } catch (Throwable e) { throw new RuntimeException("error in NFD_OpenDialogN_With_Impl", e); }
     }
 
-    ///Single file open dialog, with additional parameters.
-    ///
-    ///It is the caller's responsibility to free `outPath` via NFD_FreePath() if this function
-    ///returns NFD_OKAY.  See documentation of [NFDOpenDialogArgs] for details.
     public static @CType("nfdresult_t") int NFD_OpenDialog_With(@CType("nfdnchar_t**") java.lang.foreign.MemorySegment outPath, @CType("const nfdopendialognargs_t*") java.lang.foreign.MemorySegment args) {
         return NFD_OpenDialog_With_Impl(NFD_INTERFACE_VERSION, outPath, args);
     }
 
-    ///Multiple file open dialog
-    ///
-    ///It is the caller's responsibility to free `outPaths` via NFD_PathSet_Free() if this function
-    ///returns NFD_OKAY.
-    ///@param filterCount If zero, filterList is ignored (you can use null).
-    ///@param defaultPath If null, the operating system will decide.
     public static @CType("nfdresult_t") int NFD_OpenDialogMultiple(@CType("const nfdpathset_t**") java.lang.foreign.MemorySegment outPaths, @CType("const nfdnfilteritem_t*") java.lang.foreign.MemorySegment filterList, @CType("nfdfiltersize_t") int filterCount, @CType("const nfdnchar_t*") java.lang.foreign.MemorySegment defaultPath) {
         try {
             return (int) Handles.MH_NFD_OpenDialogMultipleN.invokeExact(outPaths, filterList, filterCount, defaultPath);
         } catch (Throwable e) { throw new RuntimeException("error in NFD_OpenDialogMultipleN", e); }
     }
 
-    ///This function is a library implementation detail.  Please use NFD_OpenDialogMultiple_With()
-    ///instead.
     public static @CType("nfdresult_t") int NFD_OpenDialogMultiple_With_Impl(@CType("nfdversion_t") int version, @CType("const nfdpathset_t**") java.lang.foreign.MemorySegment outPaths, @CType("const nfdopendialognargs_t*") java.lang.foreign.MemorySegment args) {
         try {
             return (int) Handles.MH_NFD_OpenDialogMultipleN_With_Impl.invokeExact(version, outPaths, args);
         } catch (Throwable e) { throw new RuntimeException("error in NFD_OpenDialogMultipleN_With_Impl", e); }
     }
 
-    ///Multiple file open dialog, with additional parameters.
-    ///
-    ///It is the caller's responsibility to free `outPaths` via NFD_PathSet_Free() if this function
-    ///returns NFD_OKAY.  See documentation of [NFDOpenDialogArgs] for details.
     public static @CType("nfdresult_t") int NFD_OpenDialogMultiple_With(@CType("const nfdpathset_t**") java.lang.foreign.MemorySegment outPaths, @CType("const nfdopendialognargs_t*") java.lang.foreign.MemorySegment args) {
         return NFD_OpenDialogMultiple_With_Impl(NFD_INTERFACE_VERSION, outPaths, args);
     }
 
-    ///Save dialog
-    ///
-    ///It is the caller's responsibility to free `outPath` via NFD_FreePath() if this function returns
-    ///NFD_OKAY.
-    ///@param filterCount If zero, filterList is ignored (you can use null).
-    ///@param defaultPath If null, the operating system will decide.
     public static @CType("nfdresult_t") int NFD_SaveDialog(@CType("nfdnchar_t**") java.lang.foreign.MemorySegment outPath, @CType("const nfdnfilteritem_t*") java.lang.foreign.MemorySegment filterList, @CType("nfdfiltersize_t") int filterCount, @CType("const nfdnchar_t*") java.lang.foreign.MemorySegment defaultPath, @CType("const nfdnchar_t*") java.lang.foreign.MemorySegment defaultName) {
         try {
             return (int) Handles.MH_NFD_SaveDialogN.invokeExact(outPath, filterList, filterCount, defaultPath, defaultName);
         } catch (Throwable e) { throw new RuntimeException("error in NFD_SaveDialogN", e); }
     }
 
-    ///This function is a library implementation detail.  Please use NFD_SaveDialog_With() instead.
     public static @CType("nfdresult_t") int NFD_SaveDialog_With_Impl(@CType("nfdversion_t") int version, @CType("nfdnchar_t**") java.lang.foreign.MemorySegment outPath, @CType("const nfdsavedialognargs_t*") java.lang.foreign.MemorySegment args) {
         try {
             return (int) Handles.MH_NFD_SaveDialogN_With_Impl.invokeExact(version, outPath, args);
         } catch (Throwable e) { throw new RuntimeException("error in NFD_SaveDialogN_With_Impl", e); }
     }
 
-    ///Single file save dialog, with additional parameters.
-    ///
-    ///It is the caller's responsibility to free `outPath` via NFD_FreePath() if this function
-    ///returns NFD_OKAY.  See documentation of [NFDSaveDialogArgs] for details.
     public static @CType("nfdresult_t") int NFD_SaveDialog_With(@CType("nfdnchar_t**") java.lang.foreign.MemorySegment outPath, @CType("const nfdsavedialognargs_t*") java.lang.foreign.MemorySegment args) {
         return NFD_SaveDialog_With_Impl(NFD_INTERFACE_VERSION, outPath, args);
     }
 
-    ///Select single folder dialog
-    ///
-    ///It is the caller's responsibility to free `outPath` via NFD_FreePath() if this function returns
-    ///NFD_OKAY.
-    ///@param defaultPath If null, the operating system will decide.
     public static @CType("nfdresult_t") int NFD_PickFolder(@CType("nfdnchar_t**") java.lang.foreign.MemorySegment outPath, @CType("const nfdnchar_t*") java.lang.foreign.MemorySegment defaultPath) {
         try {
             return (int) Handles.MH_NFD_PickFolderN.invokeExact(outPath, defaultPath);
         } catch (Throwable e) { throw new RuntimeException("error in NFD_PickFolderN", e); }
     }
 
-    ///This function is a library implementation detail.  Please use NFD_PickFolder_With() instead.
     public static @CType("nfdresult_t") int NFD_PickFolder_With_Impl(@CType("nfdversion_t") int version, @CType("nfdnchar_t**") java.lang.foreign.MemorySegment outPath, @CType("const nfdpickfoldernargs_t*") java.lang.foreign.MemorySegment args) {
         try {
             return (int) Handles.MH_NFD_PickFolderN_With_Impl.invokeExact(version, outPath, args);
         } catch (Throwable e) { throw new RuntimeException("error in NFD_PickFolderN_With_Impl", e); }
     }
 
-    ///Select single folder dialog, with additional parameters.
-    ///
-    ///It is the caller's responsibility to free `outPath` via NFD_FreePath() if this function
-    ///returns NFD_OKAY.  See documentation of [NFDPickFolderArgs] for details.
     public static @CType("nfdresult_t") int NFD_PickFolder_With(@CType("nfdnchar_t**") java.lang.foreign.MemorySegment outPath, @CType("const nfdpickfoldernargs_t*") java.lang.foreign.MemorySegment args) {
         return NFD_PickFolder_With_Impl(NFD_INTERFACE_VERSION, outPath, args);
     }
 
-    ///Select multiple folder dialog
-    ///
-    ///It is the caller's responsibility to free `outPaths` via NFD_PathSet_Free() if this function
-    ///NFD_OKAY.
-    ///@param defaultPath If null, the operating system will decide.
     public static @CType("nfdresult_t") int NFD_PickFolderMultiple(@CType("const nfdpathset_t**") java.lang.foreign.MemorySegment outPaths, @CType("const nfdnchar_t*") java.lang.foreign.MemorySegment defaultPath) {
         try {
             return (int) Handles.MH_NFD_PickFolderMultipleN.invokeExact(outPaths, defaultPath);
         } catch (Throwable e) { throw new RuntimeException("error in NFD_PickFolderMultipleN", e); }
     }
 
-    ///This function is a library implementation detail.  Please use NFD_PickFolderMultiple_With() instead.
     public static @CType("nfdresult_t") int NFD_PickFolderMultiple_With_Impl(@CType("nfdversion_t") int version, @CType("const nfdpathset_t**") java.lang.foreign.MemorySegment outPaths, @CType("const nfdpickfoldernargs_t*") java.lang.foreign.MemorySegment args) {
         try {
             return (int) Handles.MH_NFD_PickFolderMultipleN_With_Impl.invokeExact(version, outPaths, args);
         } catch (Throwable e) { throw new RuntimeException("error in NFD_PickFolderMultipleN_With_Impl", e); }
     }
 
-    ///Select multiple folder dialog, with additional parameters.
-    ///
-    ///It is the caller's responsibility to free `outPaths` via NFD_PathSet_Free() if this function
-    ///returns NFD_OKAY.  See documentation of [NFDPickFolderArgs] for details.
     public static @CType("nfdresult_t") int NFD_PickFolderMultiple_With(@CType("const nfdpathset_t**") java.lang.foreign.MemorySegment outPaths, @CType("const nfdpickfoldernargs_t*") java.lang.foreign.MemorySegment args) {
         return NFD_PickFolderMultiple_With_Impl(NFD_INTERFACE_VERSION, outPaths, args);
     }
 
-    ///Get the last error
-    ///
-    ///This is set when a function returns NFD_ERROR.
-    ///The memory is owned by NFD and should not be freed by user code.
-    ///This is *always* ASCII printable characters, so it can be interpreted as UTF-8 without any
-    ///conversion.
-    ///@return The last error that was set, or null if there is no error.
     public static @CType("const char*") java.lang.foreign.MemorySegment NFD_GetError_() {
         try {
             return (java.lang.foreign.MemorySegment) Handles.MH_NFD_GetError.invokeExact();
         } catch (Throwable e) { throw new RuntimeException("error in NFD_GetError", e); }
     }
 
-    ///Get the last error
-    ///
-    ///This is set when a function returns NFD_ERROR.
-    ///The memory is owned by NFD and should not be freed by user code.
-    ///This is *always* ASCII printable characters, so it can be interpreted as UTF-8 without any
-    ///conversion.
-    ///@return The last error that was set, or null if there is no error.
     public static @CType("const char*") java.lang.String NFD_GetError() {
         try {
             return Unmarshal.unmarshalAsString((java.lang.foreign.MemorySegment) Handles.MH_NFD_GetError.invokeExact());
         } catch (Throwable e) { throw new RuntimeException("error in NFD_GetError", e); }
     }
 
-    ///Clear the error.
     public static void NFD_ClearError() {
         try {
             Handles.MH_NFD_ClearError.invokeExact();
         } catch (Throwable e) { throw new RuntimeException("error in NFD_ClearError", e); }
     }
 
-    ///Get the number of entries stored in pathSet.
-    ///
-    ///Note: some paths might be invalid (NFD_ERROR will be returned by NFD_PathSet_GetPath),
-    ///so we might not actually have this number of usable paths.
     public static @CType("nfdresult_t") int NFD_PathSet_GetCount(@CType("const nfdpathset_t*") java.lang.foreign.MemorySegment pathSet, @Out @CType("nfdpathsetsize_t*") java.lang.foreign.MemorySegment count) {
         try {
             return (int) Handles.MH_NFD_PathSet_GetCount.invokeExact(pathSet, count);
         } catch (Throwable e) { throw new RuntimeException("error in NFD_PathSet_GetCount", e); }
     }
 
-    ///Get the number of entries stored in pathSet.
-    ///
-    ///Note: some paths might be invalid (NFD_ERROR will be returned by NFD_PathSet_GetPath),
-    ///so we might not actually have this number of usable paths.
     public static @CType("nfdresult_t") int NFD_PathSet_GetCount(@CType("const nfdpathset_t*") java.lang.foreign.MemorySegment pathSet, @Out long[] count) {
         try (var __overrungl_stack = MemoryStack.pushLocal()) {
             var __overrungl_ref_count = Marshal.marshal(__overrungl_stack, count);
@@ -415,52 +232,36 @@ public final class NFD {
         } catch (Throwable e) { throw new RuntimeException("error in NFD_PathSet_GetCount", e); }
     }
 
-    ///Get the native path at offset index.
-    ///<p>
-    ///It is the caller's responsibility to free `outPath` via NFD_PathSet_FreePath() if this function
-    ///returns NFD_OKAY.
     public static @CType("nfdresult_t") int NFD_PathSet_GetPath(@CType("const nfdpathset_t*") java.lang.foreign.MemorySegment pathSet, @CType("nfdpathsetsize_t") long index, @CType("nfdnchar_t**") java.lang.foreign.MemorySegment outPath) {
         try {
             return (int) Handles.MH_NFD_PathSet_GetPathN.invokeExact(pathSet, index, outPath);
         } catch (Throwable e) { throw new RuntimeException("error in NFD_PathSet_GetPathN", e); }
     }
 
-    ///Free the path gotten by NFD_PathSet_GetPath().
     public static void NFD_PathSet_FreePath(@CType("const nfdnchar_t*") java.lang.foreign.MemorySegment filePath) {
         try {
             Handles.MH_NFD_PathSet_FreePathN.invokeExact(filePath);
         } catch (Throwable e) { throw new RuntimeException("error in NFD_PathSet_FreePathN", e); }
     }
 
-    ///Gets an enumerator of the path set.
-    ///
-    ///It is the caller's responsibility to free `enumerator` via NFD_PathSet_FreeEnum()
-    ///if this function returns NFD_OKAY, and it should be freed before freeing the pathset.
     public static @CType("nfdresult_t") int NFD_PathSet_GetEnum(@CType("const nfdpathset_t*") java.lang.foreign.MemorySegment pathSet, @CType("nfdpathsetenum_t*") java.lang.foreign.MemorySegment outEnumerator) {
         try {
             return (int) Handles.MH_NFD_PathSet_GetEnum.invokeExact(pathSet, outEnumerator);
         } catch (Throwable e) { throw new RuntimeException("error in NFD_PathSet_GetEnum", e); }
     }
 
-    ///Frees an enumerator of the path set.
     public static void NFD_PathSet_FreeEnum(@CType("nfdpathsetenum_t*") java.lang.foreign.MemorySegment enumerator) {
         try {
             Handles.MH_NFD_PathSet_FreeEnum.invokeExact(enumerator);
         } catch (Throwable e) { throw new RuntimeException("error in NFD_PathSet_FreeEnum", e); }
     }
 
-    ///Gets the next item from the path set enumerator.
-    ///
-    ///If there are no more items, then *outPaths will be set to null.
-    ///It is the caller's responsibility to free `*outPath` via NFD_PathSet_FreePath()
-    ///if this function returns NFD_OKAY and `*outPath` is not null.
     public static @CType("nfdresult_t") int NFD_PathSet_EnumNext(@CType("nfdpathsetenum_t*") java.lang.foreign.MemorySegment enumerator, @CType("nfdnchar_t**") java.lang.foreign.MemorySegment outPath) {
         try {
             return (int) Handles.MH_NFD_PathSet_EnumNextN.invokeExact(enumerator, outPath);
         } catch (Throwable e) { throw new RuntimeException("error in NFD_PathSet_EnumNextN", e); }
     }
 
-    ///Free the pathSet
     public static void NFD_PathSet_Free(@CType("const nfdpathset_t*") java.lang.foreign.MemorySegment pathSet) {
         try {
             Handles.MH_NFD_PathSet_Free.invokeExact(pathSet);
@@ -473,7 +274,6 @@ public final class NFD {
     private NFD() {
     }
 
-    /// Overloads [NFD_OpenDialog][#NFD_OpenDialog(MemorySegment, MemorySegment, int, MemorySegment)]
     public static int NFD_OpenDialog(String[] outPath, NFDFilterItem filterList, String defaultPath) {
         try (MemoryStack stack = MemoryStack.pushLocal()) {
             var seg = NFDInternal.marshalString(stack, outPath);
@@ -485,7 +285,6 @@ public final class NFD {
         }
     }
 
-    /// Overloads [NFD_OpenDialog_With][#NFD_OpenDialog_With(MemorySegment, MemorySegment)]
     public static int NFD_OpenDialog_With(String[] outPath, NFDOpenDialogArgs args) {
         try (MemoryStack stack = MemoryStack.pushLocal()) {
             var seg = NFDInternal.marshalString(stack, outPath);
@@ -497,19 +296,16 @@ public final class NFD {
         }
     }
 
-    /// Overloads [NFD_OpenDialogMultiple][#NFD_OpenDialogMultiple(MemorySegment, MemorySegment, int, MemorySegment)]
     public static int NFD_OpenDialogMultiple(MemorySegment outPaths, NFDFilterItem filterList, String defaultPath) {
         try (MemoryStack stack = MemoryStack.pushLocal()) {
             return NFD_OpenDialogMultiple(outPaths, Marshal.marshal(filterList), filterItemCount(filterList), NFDInternal.marshalString(stack, defaultPath));
         }
     }
 
-    /// Overloads [NFD_OpenDialogMultiple_With][#NFD_OpenDialogMultiple_With(MemorySegment, MemorySegment)]
     public static int NFD_OpenDialogMultiple_With(MemorySegment outPaths, NFDOpenDialogArgs args) {
         return NFD_OpenDialogMultiple_With(outPaths, Marshal.marshal(args));
     }
 
-    /// Overloads [NFD_SaveDialog][#NFD_SaveDialog(MemorySegment, MemorySegment, int, MemorySegment, MemorySegment)]
     public static int NFD_SaveDialog(String[] outPath, NFDFilterItem filterList, String defaultPath, String defaultName) {
         try (MemoryStack stack = MemoryStack.pushLocal()) {
             var seg = NFDInternal.marshalString(stack, outPath);
@@ -521,7 +317,6 @@ public final class NFD {
         }
     }
 
-    /// Overloads [NFD_SaveDialog_With][#NFD_SaveDialog_With(MemorySegment, MemorySegment)]
     public static int NFD_SaveDialog_With(String[] outPath, NFDSaveDialogArgs args) {
         try (MemoryStack stack = MemoryStack.pushLocal()) {
             var seg = NFDInternal.marshalString(stack, outPath);
@@ -533,7 +328,6 @@ public final class NFD {
         }
     }
 
-    /// Overloads [NFD_PickFolder][#NFD_PickFolder(MemorySegment, MemorySegment)]
     public static int NFD_PickFolder(String[] outPath, String defaultPath) {
         try (MemoryStack stack = MemoryStack.pushLocal()) {
             var seg = NFDInternal.marshalString(stack, outPath);
@@ -545,7 +339,6 @@ public final class NFD {
         }
     }
 
-    /// Overloads [NFD_PickFolder_With][#NFD_PickFolder_With(MemorySegment, MemorySegment)]
     public static int NFD_PickFolder_With(String[] outPath, NFDPickFolderArgs args) {
         try (MemoryStack stack = MemoryStack.pushLocal()) {
             var seg = NFDInternal.marshalString(stack, outPath);
@@ -557,19 +350,16 @@ public final class NFD {
         }
     }
 
-    /// Overloads [NFD_PickFolderMultiple][#NFD_PickFolderMultiple(MemorySegment, MemorySegment)]
     public static int NFD_PickFolderMultiple(MemorySegment outPaths, String defaultPath) {
         try (MemoryStack stack = MemoryStack.pushLocal()) {
             return NFD_PickFolderMultiple(outPaths, NFDInternal.marshalString(stack, defaultPath));
         }
     }
 
-    /// Overloads [NFD_PickFolderMultiple_With][#NFD_PickFolderMultiple_With(MemorySegment, MemorySegment)]
     public static int NFD_PickFolderMultiple_With(MemorySegment outPaths, NFDPickFolderArgs args) {
         return NFD_PickFolderMultiple_With(outPaths, Marshal.marshal(args));
     }
 
-    /// Overloads [NFD_PathSet_GetPath][#NFD_PathSet_GetPath(MemorySegment, long, MemorySegment)]
     public static int NFD_PathSet_GetPath(MemorySegment pathSet, long index, String[] outPath) {
         try (MemoryStack stack = MemoryStack.pushLocal()) {
             var seg = NFDInternal.marshalString(stack, outPath);
@@ -581,7 +371,6 @@ public final class NFD {
         }
     }
 
-    /// Overloads [NFD_PathSet_EnumNext][#NFD_PathSet_EnumNext(MemorySegment, MemorySegment)]
     public static int NFD_PathSet_EnumNext(MemorySegment enumerator, String[] outPath) {
         try (MemoryStack stack = MemoryStack.pushLocal()) {
             var seg = NFDInternal.marshalString(stack, outPath);

--- a/modules/overrungl.nfd/src/main/java/overrungl/nfd/NFDFilterItem.java
+++ b/modules/overrungl.nfd/src/main/java/overrungl/nfd/NFDFilterItem.java
@@ -24,8 +24,6 @@ import overrungl.annotation.*;
 import overrungl.struct.*;
 import overrungl.util.*;
 
-/// UTF-16 Filter Item on Windows, UTF-8 Filter Item on others
-///
 /// ## Members
 /// ### name
 /// [VarHandle][#VH_name] - [Getter][#name()] - [Setter][#name(java.lang.foreign.MemorySegment)]

--- a/modules/overrungl.nfd/src/main/java/overrungl/nfd/NFDWindowHandle.java
+++ b/modules/overrungl.nfd/src/main/java/overrungl/nfd/NFDWindowHandle.java
@@ -24,11 +24,6 @@ import overrungl.annotation.*;
 import overrungl.struct.*;
 import overrungl.util.*;
 
-/// The native window handle.
-/// 
-/// If using a platform abstraction framework (e.g. SDL2), this should be
-/// obtained using the corresponding NFD glue header (e.g. nfd_sdl2.h).
-///
 /// ## Members
 /// ### type
 /// [VarHandle][#VH_type] - [Getter][#type()] - [Setter][#type(long)]

--- a/modules/overrungl.nfd/src/main/java/overrungl/nfd/package-info.java
+++ b/modules/overrungl.nfd/src/main/java/overrungl/nfd/package-info.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023-2025 Overrun Organization
+ * Copyright (c) 2025 Overrun Organization
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -14,13 +14,10 @@
  * copies or substantial portions of the Software.
  */
 
-/// The GLFW binding.
+/// The NFD binding.
+///
+/// - [Source](https://github.com/btzy/nativefiledialog-extended)
 ///
 /// @author squid233
 /// @since 0.1.0
-module overrungl.glfw {
-    exports overrungl.glfw;
-
-    requires transitive overrungl.core;
-    requires static org.jetbrains.annotations;
-}
+package overrungl.nfd;

--- a/modules/overrungl.openal/src/main/java/module-info.java
+++ b/modules/overrungl.openal/src/main/java/module-info.java
@@ -14,10 +14,11 @@
  * copies or substantial portions of the Software.
  */
 
-/// The [OpenAL](https://www.openal.org/) binding.
+/// The OpenAL binding.
 ///
 /// OverrunGL uses [openal-soft](https://openal-soft.org/).
 ///
+/// - [Website](https://www.openal.org/)
 /// - [Source](https://github.com/kcat/openal-soft)
 ///
 /// @author squid233

--- a/modules/overrungl.openal/src/main/java/module-info.java
+++ b/modules/overrungl.openal/src/main/java/module-info.java
@@ -16,11 +16,6 @@
 
 /// The OpenAL binding.
 ///
-/// OverrunGL uses [openal-soft](https://openal-soft.org/).
-///
-/// - [Website](https://www.openal.org/)
-/// - [Source](https://github.com/kcat/openal-soft)
-///
 /// @author squid233
 /// @since 0.1.0
 module overrungl.openal {

--- a/modules/overrungl.openal/src/main/java/overrungl/openal/AL.java
+++ b/modules/overrungl.openal/src/main/java/overrungl/openal/AL.java
@@ -24,7 +24,6 @@ import overrungl.util.MemoryStack;
 import overrungl.util.Unmarshal;
 
 import java.lang.foreign.FunctionDescriptor;
-import java.lang.foreign.SymbolLookup;
 import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodHandle;
 
@@ -100,7 +99,6 @@ public final class AL {
     public static final int AL_DOPPLER_VELOCITY = 0xC001;
     public static final int AL_SPEED_OF_SOUND = 0xC003;
     public static final int AL_DISTANCE_MODEL = 0xD000;
-    ///Distance model values.
     public static final int
         AL_INVERSE_DISTANCE = 0xD001,
         AL_INVERSE_DISTANCE_CLAMPED = 0xD002,

--- a/modules/overrungl.openal/src/main/java/overrungl/openal/ALBufferCallbackTypeSOFT.java
+++ b/modules/overrungl.openal/src/main/java/overrungl/openal/ALBufferCallbackTypeSOFT.java
@@ -30,14 +30,14 @@ public interface ALBufferCallbackTypeSOFT extends Upcall {
     /// The method handle of the target method.
     MethodHandle HANDLE = Upcall.findTarget(ALBufferCallbackTypeSOFT.class, "invoke", DESCRIPTOR);
 
-    ///The target method of the upcall.
+    /// The target method of the upcall.
     @CType("ALsizei") int invoke(@CType("ALvoid *") java.lang.foreign.MemorySegment userptr, @CType("ALvoid *") java.lang.foreign.MemorySegment sampledata, @CType("ALsizei") int numbytes);
 
     @Override
     default MemorySegment stub(Arena arena) { return Linker.nativeLinker().upcallStub(HANDLE.bindTo(this), DESCRIPTOR, arena); }
 
-    ///A static invoker of the target method.
-    ///@param stub the upcall stub
+    /// A static invoker of the target method.
+    /// @param stub the upcall stub
     static @CType("ALsizei") int invoke(MemorySegment stub, @CType("ALvoid *") java.lang.foreign.MemorySegment userptr, @CType("ALvoid *") java.lang.foreign.MemorySegment sampledata, @CType("ALsizei") int numbytes) {
         try { return (int) HANDLE.invokeExact(stub, userptr, sampledata, numbytes); }
         catch (Throwable e) { throw new RuntimeException("error in ALBufferCallbackTypeSOFT::invoke (static invoker)", e); }

--- a/modules/overrungl.openal/src/main/java/overrungl/openal/ALC.java
+++ b/modules/overrungl.openal/src/main/java/overrungl/openal/ALC.java
@@ -27,7 +27,7 @@ import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodHandle;
 
 /**
- * The OpenAL context binding.
+ * The OpenAL context related functions.
  *
  * @author squid233
  * @since 0.1.0
@@ -56,7 +56,6 @@ public final class ALC {
     public static final int ALC_DEFAULT_DEVICE_SPECIFIER = 0x1004;
     public static final int ALC_DEVICE_SPECIFIER = 0x1005;
     public static final int ALC_EXTENSIONS = 0x1006;
-    ///Capture extension
     public static final int ALC_EXT_CAPTURE = 1;
     public static final int ALC_CAPTURE_DEVICE_SPECIFIER = 0x310;
     public static final int ALC_CAPTURE_DEFAULT_DEVICE_SPECIFIER = 0x311;

--- a/modules/overrungl.openal/src/main/java/overrungl/openal/ALCEventProcTypeSOFT.java
+++ b/modules/overrungl.openal/src/main/java/overrungl/openal/ALCEventProcTypeSOFT.java
@@ -30,14 +30,14 @@ public interface ALCEventProcTypeSOFT extends Upcall {
     /// The method handle of the target method.
     MethodHandle HANDLE = Upcall.findTarget(ALCEventProcTypeSOFT.class, "invoke", DESCRIPTOR);
 
-    ///The target method of the upcall.
+    /// The target method of the upcall.
     void invoke(@CType("ALCenum") int eventType, @CType("ALCenum") int deviceType, @CType("ALCdevice *") java.lang.foreign.MemorySegment device, @CType("ALCsizei") int length, @CType("const ALCchar*") java.lang.foreign.MemorySegment message, @CType("void*") java.lang.foreign.MemorySegment userParam);
 
     @Override
     default MemorySegment stub(Arena arena) { return Linker.nativeLinker().upcallStub(HANDLE.bindTo(this), DESCRIPTOR, arena); }
 
-    ///A static invoker of the target method.
-    ///@param stub the upcall stub
+    /// A static invoker of the target method.
+    /// @param stub the upcall stub
     static void invoke(MemorySegment stub, @CType("ALCenum") int eventType, @CType("ALCenum") int deviceType, @CType("ALCdevice *") java.lang.foreign.MemorySegment device, @CType("ALCsizei") int length, @CType("const ALCchar*") java.lang.foreign.MemorySegment message, @CType("void*") java.lang.foreign.MemorySegment userParam) {
         try { HANDLE.invokeExact(stub, eventType, deviceType, device, length, message, userParam); }
         catch (Throwable e) { throw new RuntimeException("error in ALCEventProcTypeSOFT::invoke (static invoker)", e); }

--- a/modules/overrungl.openal/src/main/java/overrungl/openal/ALDebugProcEXT.java
+++ b/modules/overrungl.openal/src/main/java/overrungl/openal/ALDebugProcEXT.java
@@ -30,14 +30,14 @@ public interface ALDebugProcEXT extends Upcall {
     /// The method handle of the target method.
     MethodHandle HANDLE = Upcall.findTarget(ALDebugProcEXT.class, "invoke", DESCRIPTOR);
 
-    ///The target method of the upcall.
+    /// The target method of the upcall.
     void invoke(@CType("ALenum") int source, @CType("ALenum") int type, @CType("ALuint") int id, @CType("ALenum") int severity, @CType("ALsizei") int length, @CType("const ALchar*") java.lang.foreign.MemorySegment message, @CType("void*") java.lang.foreign.MemorySegment userParam);
 
     @Override
     default MemorySegment stub(Arena arena) { return Linker.nativeLinker().upcallStub(HANDLE.bindTo(this), DESCRIPTOR, arena); }
 
-    ///A static invoker of the target method.
-    ///@param stub the upcall stub
+    /// A static invoker of the target method.
+    /// @param stub the upcall stub
     static void invoke(MemorySegment stub, @CType("ALenum") int source, @CType("ALenum") int type, @CType("ALuint") int id, @CType("ALenum") int severity, @CType("ALsizei") int length, @CType("const ALchar*") java.lang.foreign.MemorySegment message, @CType("void*") java.lang.foreign.MemorySegment userParam) {
         try { HANDLE.invokeExact(stub, source, type, id, severity, length, message, userParam); }
         catch (Throwable e) { throw new RuntimeException("error in ALDebugProcEXT::invoke (static invoker)", e); }

--- a/modules/overrungl.openal/src/main/java/overrungl/openal/ALEventProcSOFT.java
+++ b/modules/overrungl.openal/src/main/java/overrungl/openal/ALEventProcSOFT.java
@@ -30,14 +30,14 @@ public interface ALEventProcSOFT extends Upcall {
     /// The method handle of the target method.
     MethodHandle HANDLE = Upcall.findTarget(ALEventProcSOFT.class, "invoke", DESCRIPTOR);
 
-    ///The target method of the upcall.
+    /// The target method of the upcall.
     void invoke(@CType("ALenum") int eventType, @CType("ALuint") int object, @CType("ALuint") int param, @CType("ALsizei") int length, @CType("const ALchar*") java.lang.foreign.MemorySegment message, @CType("void*") java.lang.foreign.MemorySegment userParam);
 
     @Override
     default MemorySegment stub(Arena arena) { return Linker.nativeLinker().upcallStub(HANDLE.bindTo(this), DESCRIPTOR, arena); }
 
-    ///A static invoker of the target method.
-    ///@param stub the upcall stub
+    /// A static invoker of the target method.
+    /// @param stub the upcall stub
     static void invoke(MemorySegment stub, @CType("ALenum") int eventType, @CType("ALuint") int object, @CType("ALuint") int param, @CType("ALsizei") int length, @CType("const ALchar*") java.lang.foreign.MemorySegment message, @CType("void*") java.lang.foreign.MemorySegment userParam) {
         try { HANDLE.invokeExact(stub, eventType, object, param, length, message, userParam); }
         catch (Throwable e) { throw new RuntimeException("error in ALEventProcSOFT::invoke (static invoker)", e); }

--- a/modules/overrungl.openal/src/main/java/overrungl/openal/ALFoldbackCallback.java
+++ b/modules/overrungl.openal/src/main/java/overrungl/openal/ALFoldbackCallback.java
@@ -30,14 +30,14 @@ public interface ALFoldbackCallback extends Upcall {
     /// The method handle of the target method.
     MethodHandle HANDLE = Upcall.findTarget(ALFoldbackCallback.class, "invoke", DESCRIPTOR);
 
-    ///The target method of the upcall.
+    /// The target method of the upcall.
     void invoke(@CType("ALenum") int mode, @CType("ALsizei") int count);
 
     @Override
     default MemorySegment stub(Arena arena) { return Linker.nativeLinker().upcallStub(HANDLE.bindTo(this), DESCRIPTOR, arena); }
 
-    ///A static invoker of the target method.
-    ///@param stub the upcall stub
+    /// A static invoker of the target method.
+    /// @param stub the upcall stub
     static void invoke(MemorySegment stub, @CType("ALenum") int mode, @CType("ALsizei") int count) {
         try { HANDLE.invokeExact(stub, mode, count); }
         catch (Throwable e) { throw new RuntimeException("error in ALFoldbackCallback::invoke (static invoker)", e); }

--- a/modules/overrungl.openal/src/main/java/overrungl/openal/package-info.java
+++ b/modules/overrungl.openal/src/main/java/overrungl/openal/package-info.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023-2025 Overrun Organization
+ * Copyright (c) 2025 Overrun Organization
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -14,13 +14,13 @@
  * copies or substantial portions of the Software.
  */
 
-/// The GLFW binding.
+/// The OpenAL binding.
+///
+/// OverrunGL uses [openal-soft](https://openal-soft.org/).
+///
+/// - [Website](https://www.openal.org/)
+/// - [Source](https://github.com/kcat/openal-soft)
 ///
 /// @author squid233
 /// @since 0.1.0
-module overrungl.glfw {
-    exports overrungl.glfw;
-
-    requires transitive overrungl.core;
-    requires static org.jetbrains.annotations;
-}
+package overrungl.openal;

--- a/modules/overrungl.opengl/src/main/java/module-info.java
+++ b/modules/overrungl.opengl/src/main/java/module-info.java
@@ -16,9 +16,6 @@
 
 // This file is auto-generated. DO NOT EDIT!
 /// The OpenGL binding.
-///
-/// - [References](https://registry.khronos.org/OpenGL-Refpages/gl4/)
-/// - [Registry](https://github.com/KhronosGroup/OpenGL-Registry)
 module overrungl.opengl {
     exports overrungl.opengl;
     exports overrungl.opengl.threedfx;

--- a/modules/overrungl.opengl/src/main/java/module-info.java
+++ b/modules/overrungl.opengl/src/main/java/module-info.java
@@ -16,6 +16,9 @@
 
 // This file is auto-generated. DO NOT EDIT!
 /// The OpenGL binding.
+///
+/// - [References](https://registry.khronos.org/OpenGL-Refpages/gl4/)
+/// - [Registry](https://github.com/KhronosGroup/OpenGL-Registry)
 module overrungl.opengl {
     exports overrungl.opengl;
     exports overrungl.opengl.threedfx;

--- a/modules/overrungl.opengl/src/main/java/overrungl/opengl/GLDebugProc.java
+++ b/modules/overrungl.opengl/src/main/java/overrungl/opengl/GLDebugProc.java
@@ -30,10 +30,10 @@ public interface GLDebugProc extends Upcall {
     /// The method handle of the target method.
     MethodHandle HANDLE = Upcall.findTarget(GLDebugProc.class, "invoke", DESCRIPTOR);
 
-    ///The interface target method of the upcall.
+    /// The interface target method of the upcall.
     void invoke(@CType("GLenum") int source, @CType("GLenum") int type, @CType("GLuint") int id, @CType("GLenum") int severity, @CType("const GLchar *") java.lang.String message, @CType("const void *") java.lang.foreign.MemorySegment userParam);
 
-    ///The target method of the upcall.
+    /// The target method of the upcall.
     default void invoke(@CType("GLenum") int source, @CType("GLenum") int type, @CType("GLuint") int id, @CType("GLenum") int severity, @CType("GLsizei") int length, @CType("const GLchar *") java.lang.foreign.MemorySegment message, @CType("const void *") java.lang.foreign.MemorySegment userParam) {
         invoke(source, type, id, severity, Unmarshal.unmarshalAsString(message), userParam);
     }
@@ -41,8 +41,8 @@ public interface GLDebugProc extends Upcall {
     @Override
     default MemorySegment stub(Arena arena) { return Linker.nativeLinker().upcallStub(HANDLE.bindTo(this), DESCRIPTOR, arena); }
 
-    ///A static invoker of the target method.
-    ///@param stub the upcall stub
+    /// A static invoker of the target method.
+    /// @param stub the upcall stub
     static void invoke(MemorySegment stub, @CType("GLenum") int source, @CType("GLenum") int type, @CType("GLuint") int id, @CType("GLenum") int severity, @CType("GLsizei") int length, @CType("const GLchar *") java.lang.foreign.MemorySegment message, @CType("const void *") java.lang.foreign.MemorySegment userParam) {
         try { HANDLE.invokeExact(stub, source, type, id, severity, length, message, userParam); }
         catch (Throwable e) { throw new RuntimeException("error in GLDebugProc::invoke (static invoker)", e); }

--- a/modules/overrungl.opengl/src/main/java/overrungl/opengl/amd/GLDebugProcAMD.java
+++ b/modules/overrungl.opengl/src/main/java/overrungl/opengl/amd/GLDebugProcAMD.java
@@ -30,10 +30,10 @@ public interface GLDebugProcAMD extends Upcall {
     /// The method handle of the target method.
     MethodHandle HANDLE = Upcall.findTarget(GLDebugProcAMD.class, "invoke", DESCRIPTOR);
 
-    ///The interface target method of the upcall.
+    /// The interface target method of the upcall.
     void invoke(@CType("GLuint") int id, @CType("GLenum") int category, @CType("GLenum") int severity, @CType("const GLchar *") java.lang.String message, @CType("void*") java.lang.foreign.MemorySegment userParam);
 
-    ///The target method of the upcall.
+    /// The target method of the upcall.
     default void invoke(@CType("GLuint") int id, @CType("GLenum") int category, @CType("GLenum") int severity, @CType("GLsizei") int length, @CType("const GLchar *") java.lang.foreign.MemorySegment message, @CType("void*") java.lang.foreign.MemorySegment userParam) {
         invoke(id, category, severity, Unmarshal.unmarshalAsString(message), userParam);
     }
@@ -41,8 +41,8 @@ public interface GLDebugProcAMD extends Upcall {
     @Override
     default MemorySegment stub(Arena arena) { return Linker.nativeLinker().upcallStub(HANDLE.bindTo(this), DESCRIPTOR, arena); }
 
-    ///A static invoker of the target method.
-    ///@param stub the upcall stub
+    /// A static invoker of the target method.
+    /// @param stub the upcall stub
     static void invoke(MemorySegment stub, @CType("GLuint") int id, @CType("GLenum") int category, @CType("GLenum") int severity, @CType("GLsizei") int length, @CType("const GLchar *") java.lang.foreign.MemorySegment message, @CType("void*") java.lang.foreign.MemorySegment userParam) {
         try { HANDLE.invokeExact(stub, id, category, severity, length, message, userParam); }
         catch (Throwable e) { throw new RuntimeException("error in GLDebugProcAMD::invoke (static invoker)", e); }

--- a/modules/overrungl.opengl/src/main/java/overrungl/opengl/nv/GLVulkanProcNV.java
+++ b/modules/overrungl.opengl/src/main/java/overrungl/opengl/nv/GLVulkanProcNV.java
@@ -30,14 +30,14 @@ public interface GLVulkanProcNV extends Upcall {
     /// The method handle of the target method.
     MethodHandle HANDLE = Upcall.findTarget(GLVulkanProcNV.class, "invoke", DESCRIPTOR);
 
-    ///The target method of the upcall.
+    /// The target method of the upcall.
     void invoke();
 
     @Override
     default MemorySegment stub(Arena arena) { return Linker.nativeLinker().upcallStub(HANDLE.bindTo(this), DESCRIPTOR, arena); }
 
-    ///A static invoker of the target method.
-    ///@param stub the upcall stub
+    /// A static invoker of the target method.
+    /// @param stub the upcall stub
     static void invoke(MemorySegment stub) {
         try { HANDLE.invokeExact(stub); }
         catch (Throwable e) { throw new RuntimeException("error in GLVulkanProcNV::invoke (static invoker)", e); }

--- a/modules/overrungl.opengl/src/main/java/overrungl/opengl/package-info.java
+++ b/modules/overrungl.opengl/src/main/java/overrungl/opengl/package-info.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023-2025 Overrun Organization
+ * Copyright (c) 2025 Overrun Organization
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -14,13 +14,11 @@
  * copies or substantial portions of the Software.
  */
 
-/// The GLFW binding.
+/// The OpenGL binding.
+///
+/// - [References](https://registry.khronos.org/OpenGL-Refpages/gl4/)
+/// - [Registry](https://github.com/KhronosGroup/OpenGL-Registry)
 ///
 /// @author squid233
 /// @since 0.1.0
-module overrungl.glfw {
-    exports overrungl.glfw;
-
-    requires transitive overrungl.core;
-    requires static org.jetbrains.annotations;
-}
+package overrungl.opengl;

--- a/modules/overrungl.stb/src/main/java/module-info.java
+++ b/modules/overrungl.stb/src/main/java/module-info.java
@@ -16,8 +16,6 @@
 
 /// The stb binding.
 ///
-/// - [Source](https://github.com/nothings/stb)
-///
 /// @author squid233
 /// @since 0.1.0
 module overrungl.stb {

--- a/modules/overrungl.stb/src/main/java/module-info.java
+++ b/modules/overrungl.stb/src/main/java/module-info.java
@@ -14,12 +14,12 @@
  * copies or substantial portions of the Software.
  */
 
-/**
- * The STB binding.
- *
- * @author squid233
- * @since 0.1.0
- */
+/// The stb binding.
+///
+/// - [Source](https://github.com/nothings/stb)
+///
+/// @author squid233
+/// @since 0.1.0
 module overrungl.stb {
     exports overrungl.stb;
 

--- a/modules/overrungl.stb/src/main/java/overrungl/stb/STBEasyFont.java
+++ b/modules/overrungl.stb/src/main/java/overrungl/stb/STBEasyFont.java
@@ -28,37 +28,10 @@ import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodHandle;
 
-/**
- * Easy-to-deploy,
- * reasonably compact,
- * extremely inefficient performance-wise,
- * crappy-looking,
- * ASCII-only,
- * bitmap font for use in 3D APIs.
- * <p>
- * Intended for when you just want to get some text displaying
- * in a 3D app as quickly as possible.
- * <p>
- * Doesn't use any textures, instead builds characters out of quads.
- * <h2>Sample Code</h2>
- * Here's sample code for old OpenGL; it's a lot more complicated
- * to make work on modern APIs, and that's your problem.
- * {@snippet lang = java:
- * import java.lang.foreign.Arena;
- * static MemorySegment buffer = Arena.ofAuto().allocate(99999); // ~500 chars
- * void printString(GL gl, float x, float y, String text, float r, float g, float b) {
- *     int numQuads = stb_easy_font_print(x, y, text, MemorySegment.NULL, buffer, (int) buffer.byteSize());
- *     gl.Color3f(r, g, b);
- *     gl.EnableClientState(GL_VERTEX_ARRAY);
- *     gl.VertexPointer(2, GL_FLOAT, 16, buffer);
- *     gl.DrawArrays(GL_QUADS, 0, numQuads * 4);
- *     gl.DisableClientState(GL_VERTEX_ARRAY);
- * }
- *}
- *
- * @author squid233
- * @since 0.1.0
- */
+/// [stb_easy_font.h](https://github.com/nothings/stb/blob/master/stb_easy_font.h)
+///
+/// @author squid233
+/// @since 0.1.0
 public final class STBEasyFont {
     //region ---[BEGIN GENERATOR BEGIN]---
     //@formatter:off
@@ -81,92 +54,42 @@ public final class STBEasyFont {
     }
     //endregion
 
-    ///{@return `stb_easy_font_spacing_val`}
     public static @CType("float") float stb_easy_font_get_spacing() {
         try {
             return (float) Handles.MH_stb_easy_font_get_spacing.invokeExact();
         } catch (Throwable e) { throw new RuntimeException("error in stb_easy_font_get_spacing", e); }
     }
 
-    ///Use positive values to expand the space between characters,
-    ///and small negative values (no smaller than -1.5) to contract
-    ///the space between characters.
-    ///
-    ///E.g. spacing = 1 adds one "pixel" of spacing between the
-    ///characters. spacing = -1 is reasonable but feels a bit too
-    ///compact to me; -0.5 is a reasonable compromise as long as
-    ///you're scaling the font up.
-    ///@param spacing value
     public static void stb_easy_font_spacing(@CType("float") float spacing) {
         try {
             Handles.MH_stb_easy_font_spacing.invokeExact(spacing);
         } catch (Throwable e) { throw new RuntimeException("error in stb_easy_font_spacing", e); }
     }
 
-    ///Takes a string (which can contain '\n') and fills out a
-    ///vertex buffer with renderable data to draw the string.
-    ///Output data assumes increasing x is rightwards, increasing y
-    ///is downwards.
-    ///
-    ///The vertex data is divided into quads, i.e. there are four
-    ///vertices in the vertex buffer for each quad.
-    ///
-    ///The vertices are stored in an interleaved format:
-    ///
-    ///- x:`float`
-    ///- y:`float`
-    ///- z:`float`
-    ///- color:`uint8[4]`
-    ///
-    ///You can ignore z and color if you get them from elsewhere
-    ///This format was chosen in the hopes it would make it
-    ///easier for you to reuse existing vertex-buffer-drawing code.
-    ///
-    ///If you pass in NULL for color, it becomes 255,255,255,255.
-    ///
-    ///If the buffer isn't large enough, it will truncate.
-    ///Expect it to use an average of ~270 bytes per character.
-    ///
-    ///If your API doesn't draw quads, build a reusable index
-    ///list that allows you to render quads as indexed triangles.
-    ///
-    ///@return the number of quads.
     public static @CType("int") int stb_easy_font_print(@CType("float") float x, @CType("float") float y, @CType("char *") java.lang.foreign.MemorySegment text, @CType("unsigned char[4]") java.lang.foreign.MemorySegment color, @CType("void*") java.lang.foreign.MemorySegment vertex_buffer, @CType("int") int vbuf_size) {
         try {
             return (int) Handles.MH_stb_easy_font_print.invokeExact(x, y, text, color, vertex_buffer, vbuf_size);
         } catch (Throwable e) { throw new RuntimeException("error in stb_easy_font_print", e); }
     }
 
-    ///Takes a string and returns the horizontal size and the
-    ///vertical size (which can vary if 'text' has newlines).
-    ///@return the horizontal size
     public static @CType("int") int stb_easy_font_width(@CType("char *") java.lang.foreign.MemorySegment width) {
         try {
             return (int) Handles.MH_stb_easy_font_width.invokeExact(width);
         } catch (Throwable e) { throw new RuntimeException("error in stb_easy_font_width", e); }
     }
 
-    ///Takes a string and returns the horizontal size and the
-    ///vertical size (which can vary if 'text' has newlines).
-    ///@return the horizontal size
     public static @CType("int") int stb_easy_font_width(java.lang.String width) {
         try (var __overrungl_stack = MemoryStack.pushLocal()) {
             return (int) Handles.MH_stb_easy_font_width.invokeExact(Marshal.marshal(__overrungl_stack, width));
         } catch (Throwable e) { throw new RuntimeException("error in stb_easy_font_width", e); }
     }
 
-    ///Takes a string and returns the horizontal size and the
-    ///vertical size (which can vary if 'text' has newlines).
-    ///@return the vertical size
     public static @CType("int") int stb_easy_font_height(@CType("char *") java.lang.foreign.MemorySegment height) {
         try {
             return (int) Handles.MH_stb_easy_font_height.invokeExact(height);
         } catch (Throwable e) { throw new RuntimeException("error in stb_easy_font_height", e); }
     }
 
-    ///Takes a string and returns the horizontal size and the
-    ///vertical size (which can vary if 'text' has newlines).
-    ///@return the vertical size
     public static @CType("int") int stb_easy_font_height(java.lang.String height) {
         try (var __overrungl_stack = MemoryStack.pushLocal()) {
             return (int) Handles.MH_stb_easy_font_height.invokeExact(Marshal.marshal(__overrungl_stack, height));

--- a/modules/overrungl.stb/src/main/java/overrungl/stb/STBIIOEof.java
+++ b/modules/overrungl.stb/src/main/java/overrungl/stb/STBIIOEof.java
@@ -23,7 +23,6 @@ import overrungl.annotation.*;
 import overrungl.upcall.*;
 import overrungl.util.*;
 
-/// The eof callback
 @FunctionalInterface
 public interface STBIIOEof extends Upcall {
     /// The function descriptor.
@@ -31,14 +30,10 @@ public interface STBIIOEof extends Upcall {
     /// The method handle of the target method.
     MethodHandle HANDLE = Upcall.findTarget(STBIIOEof.class, "invoke_", DESCRIPTOR);
 
-    ///The interface target method of the upcall.
-    ///
-    ///@return nonzero if we are at end of file/data
+    /// The interface target method of the upcall.
     boolean invoke(@CType("void*") java.lang.foreign.MemorySegment user);
 
-    ///The target method of the upcall.
-    ///
-    ///@return nonzero if we are at end of file/data
+    /// The target method of the upcall.
     default @CType("int") int invoke_(@CType("void*") java.lang.foreign.MemorySegment user) {
         return invoke(user) ? 1 : 0;
     }
@@ -46,10 +41,8 @@ public interface STBIIOEof extends Upcall {
     @Override
     default MemorySegment stub(Arena arena) { return Linker.nativeLinker().upcallStub(HANDLE.bindTo(this), DESCRIPTOR, arena); }
 
-    ///A static invoker of the target method.
-    ///
-    ///@return nonzero if we are at end of file/data
-    ///@param stub the upcall stub
+    /// A static invoker of the target method.
+    /// @param stub the upcall stub
     static @CType("int") int invoke(MemorySegment stub, @CType("void*") java.lang.foreign.MemorySegment user) {
         try { return (int) HANDLE.invokeExact(stub, user); }
         catch (Throwable e) { throw new RuntimeException("error in STBIIOEof::invoke (static invoker)", e); }

--- a/modules/overrungl.stb/src/main/java/overrungl/stb/STBIIORead.java
+++ b/modules/overrungl.stb/src/main/java/overrungl/stb/STBIIORead.java
@@ -23,7 +23,6 @@ import overrungl.annotation.*;
 import overrungl.upcall.*;
 import overrungl.util.*;
 
-/// The read callback
 @FunctionalInterface
 public interface STBIIORead extends Upcall {
     /// The function descriptor.
@@ -31,20 +30,14 @@ public interface STBIIORead extends Upcall {
     /// The method handle of the target method.
     MethodHandle HANDLE = Upcall.findTarget(STBIIORead.class, "invoke", DESCRIPTOR);
 
-    ///The target method of the upcall.
-    ///
-    ///fill 'data' with 'size' bytes.
-    ///@return number of bytes actually read
+    /// The target method of the upcall.
     @CType("int") int invoke(@CType("void*") java.lang.foreign.MemorySegment user, @CType("char *") java.lang.foreign.MemorySegment data, @CType("int") int size);
 
     @Override
     default MemorySegment stub(Arena arena) { return Linker.nativeLinker().upcallStub(HANDLE.bindTo(this), DESCRIPTOR, arena); }
 
-    ///A static invoker of the target method.
-    ///
-    ///fill 'data' with 'size' bytes.
-    ///@return number of bytes actually read
-    ///@param stub the upcall stub
+    /// A static invoker of the target method.
+    /// @param stub the upcall stub
     static @CType("int") int invoke(MemorySegment stub, @CType("void*") java.lang.foreign.MemorySegment user, @CType("char *") java.lang.foreign.MemorySegment data, @CType("int") int size) {
         try { return (int) HANDLE.invokeExact(stub, user, data, size); }
         catch (Throwable e) { throw new RuntimeException("error in STBIIORead::invoke (static invoker)", e); }

--- a/modules/overrungl.stb/src/main/java/overrungl/stb/STBIIOSkip.java
+++ b/modules/overrungl.stb/src/main/java/overrungl/stb/STBIIOSkip.java
@@ -23,7 +23,6 @@ import overrungl.annotation.*;
 import overrungl.upcall.*;
 import overrungl.util.*;
 
-/// The skip callback
 @FunctionalInterface
 public interface STBIIOSkip extends Upcall {
     /// The function descriptor.
@@ -31,18 +30,14 @@ public interface STBIIOSkip extends Upcall {
     /// The method handle of the target method.
     MethodHandle HANDLE = Upcall.findTarget(STBIIOSkip.class, "invoke", DESCRIPTOR);
 
-    ///The target method of the upcall.
-    ///
-    ///skip the next 'n' bytes, or 'unget' the last -n bytes if negative
+    /// The target method of the upcall.
     void invoke(@CType("void*") java.lang.foreign.MemorySegment user, @CType("int") int n);
 
     @Override
     default MemorySegment stub(Arena arena) { return Linker.nativeLinker().upcallStub(HANDLE.bindTo(this), DESCRIPTOR, arena); }
 
-    ///A static invoker of the target method.
-    ///
-    ///skip the next 'n' bytes, or 'unget' the last -n bytes if negative
-    ///@param stub the upcall stub
+    /// A static invoker of the target method.
+    /// @param stub the upcall stub
     static void invoke(MemorySegment stub, @CType("void*") java.lang.foreign.MemorySegment user, @CType("int") int n) {
         try { HANDLE.invokeExact(stub, user, n); }
         catch (Throwable e) { throw new RuntimeException("error in STBIIOSkip::invoke (static invoker)", e); }

--- a/modules/overrungl.stb/src/main/java/overrungl/stb/STBIRInputCallback.java
+++ b/modules/overrungl.stb/src/main/java/overrungl/stb/STBIRInputCallback.java
@@ -23,7 +23,6 @@ import overrungl.annotation.*;
 import overrungl.upcall.*;
 import overrungl.util.*;
 
-/// INPUT CALLBACK: this callback is used for input scanlines
 @FunctionalInterface
 public interface STBIRInputCallback extends Upcall {
     /// The function descriptor.
@@ -31,14 +30,14 @@ public interface STBIRInputCallback extends Upcall {
     /// The method handle of the target method.
     MethodHandle HANDLE = Upcall.findTarget(STBIRInputCallback.class, "invoke", DESCRIPTOR);
 
-    ///The target method of the upcall.
+    /// The target method of the upcall.
     @CType("void const *") java.lang.foreign.MemorySegment invoke(@CType("void*") java.lang.foreign.MemorySegment optional_output, @CType("void const *") java.lang.foreign.MemorySegment input_ptr, @CType("int") int num_pixels, @CType("int") int x, @CType("int") int y, @CType("void*") java.lang.foreign.MemorySegment context);
 
     @Override
     default MemorySegment stub(Arena arena) { return Linker.nativeLinker().upcallStub(HANDLE.bindTo(this), DESCRIPTOR, arena); }
 
-    ///A static invoker of the target method.
-    ///@param stub the upcall stub
+    /// A static invoker of the target method.
+    /// @param stub the upcall stub
     static @CType("void const *") java.lang.foreign.MemorySegment invoke(MemorySegment stub, @CType("void*") java.lang.foreign.MemorySegment optional_output, @CType("void const *") java.lang.foreign.MemorySegment input_ptr, @CType("int") int num_pixels, @CType("int") int x, @CType("int") int y, @CType("void*") java.lang.foreign.MemorySegment context) {
         try { return (java.lang.foreign.MemorySegment) HANDLE.invokeExact(stub, optional_output, input_ptr, num_pixels, x, y, context); }
         catch (Throwable e) { throw new RuntimeException("error in STBIRInputCallback::invoke (static invoker)", e); }

--- a/modules/overrungl.stb/src/main/java/overrungl/stb/STBIRKernelCallback.java
+++ b/modules/overrungl.stb/src/main/java/overrungl/stb/STBIRKernelCallback.java
@@ -23,7 +23,6 @@ import overrungl.annotation.*;
 import overrungl.upcall.*;
 import overrungl.util.*;
 
-/// callbacks for user installed filters
 @FunctionalInterface
 public interface STBIRKernelCallback extends Upcall {
     /// The function descriptor.
@@ -31,14 +30,14 @@ public interface STBIRKernelCallback extends Upcall {
     /// The method handle of the target method.
     MethodHandle HANDLE = Upcall.findTarget(STBIRKernelCallback.class, "invoke", DESCRIPTOR);
 
-    ///The target method of the upcall.
+    /// The target method of the upcall.
     @CType("float") float invoke(@CType("float") float x, @CType("float") float scale, @CType("void*") java.lang.foreign.MemorySegment user_data);
 
     @Override
     default MemorySegment stub(Arena arena) { return Linker.nativeLinker().upcallStub(HANDLE.bindTo(this), DESCRIPTOR, arena); }
 
-    ///A static invoker of the target method.
-    ///@param stub the upcall stub
+    /// A static invoker of the target method.
+    /// @param stub the upcall stub
     static @CType("float") float invoke(MemorySegment stub, @CType("float") float x, @CType("float") float scale, @CType("void*") java.lang.foreign.MemorySegment user_data) {
         try { return (float) HANDLE.invokeExact(stub, x, scale, user_data); }
         catch (Throwable e) { throw new RuntimeException("error in STBIRKernelCallback::invoke (static invoker)", e); }

--- a/modules/overrungl.stb/src/main/java/overrungl/stb/STBIROutputCallback.java
+++ b/modules/overrungl.stb/src/main/java/overrungl/stb/STBIROutputCallback.java
@@ -23,7 +23,6 @@ import overrungl.annotation.*;
 import overrungl.upcall.*;
 import overrungl.util.*;
 
-/// OUTPUT CALLBACK: this callback is used for output scanlines
 @FunctionalInterface
 public interface STBIROutputCallback extends Upcall {
     /// The function descriptor.
@@ -31,14 +30,14 @@ public interface STBIROutputCallback extends Upcall {
     /// The method handle of the target method.
     MethodHandle HANDLE = Upcall.findTarget(STBIROutputCallback.class, "invoke", DESCRIPTOR);
 
-    ///The target method of the upcall.
+    /// The target method of the upcall.
     void invoke(@CType("void const *") java.lang.foreign.MemorySegment output_ptr, @CType("int") int num_pixels, @CType("int") int y, @CType("void*") java.lang.foreign.MemorySegment context);
 
     @Override
     default MemorySegment stub(Arena arena) { return Linker.nativeLinker().upcallStub(HANDLE.bindTo(this), DESCRIPTOR, arena); }
 
-    ///A static invoker of the target method.
-    ///@param stub the upcall stub
+    /// A static invoker of the target method.
+    /// @param stub the upcall stub
     static void invoke(MemorySegment stub, @CType("void const *") java.lang.foreign.MemorySegment output_ptr, @CType("int") int num_pixels, @CType("int") int y, @CType("void*") java.lang.foreign.MemorySegment context) {
         try { HANDLE.invokeExact(stub, output_ptr, num_pixels, y, context); }
         catch (Throwable e) { throw new RuntimeException("error in STBIROutputCallback::invoke (static invoker)", e); }

--- a/modules/overrungl.stb/src/main/java/overrungl/stb/STBIRSupportCallback.java
+++ b/modules/overrungl.stb/src/main/java/overrungl/stb/STBIRSupportCallback.java
@@ -23,7 +23,6 @@ import overrungl.annotation.*;
 import overrungl.upcall.*;
 import overrungl.util.*;
 
-/// callbacks for user installed filters
 @FunctionalInterface
 public interface STBIRSupportCallback extends Upcall {
     /// The function descriptor.
@@ -31,14 +30,14 @@ public interface STBIRSupportCallback extends Upcall {
     /// The method handle of the target method.
     MethodHandle HANDLE = Upcall.findTarget(STBIRSupportCallback.class, "invoke", DESCRIPTOR);
 
-    ///The target method of the upcall.
+    /// The target method of the upcall.
     @CType("float") float invoke(@CType("float") float scale, @CType("void*") java.lang.foreign.MemorySegment user_data);
 
     @Override
     default MemorySegment stub(Arena arena) { return Linker.nativeLinker().upcallStub(HANDLE.bindTo(this), DESCRIPTOR, arena); }
 
-    ///A static invoker of the target method.
-    ///@param stub the upcall stub
+    /// A static invoker of the target method.
+    /// @param stub the upcall stub
     static @CType("float") float invoke(MemorySegment stub, @CType("float") float scale, @CType("void*") java.lang.foreign.MemorySegment user_data) {
         try { return (float) HANDLE.invokeExact(stub, scale, user_data); }
         catch (Throwable e) { throw new RuntimeException("error in STBIRSupportCallback::invoke (static invoker)", e); }

--- a/modules/overrungl.stb/src/main/java/overrungl/stb/STBIWriteFunc.java
+++ b/modules/overrungl.stb/src/main/java/overrungl/stb/STBIWriteFunc.java
@@ -30,14 +30,14 @@ public interface STBIWriteFunc extends Upcall {
     /// The method handle of the target method.
     MethodHandle HANDLE = Upcall.findTarget(STBIWriteFunc.class, "invoke", DESCRIPTOR);
 
-    ///The target method of the upcall.
+    /// The target method of the upcall.
     void invoke(@CType("void*") java.lang.foreign.MemorySegment context, @CType("void*") java.lang.foreign.MemorySegment data, @CType("int") int size);
 
     @Override
     default MemorySegment stub(Arena arena) { return Linker.nativeLinker().upcallStub(HANDLE.bindTo(this), DESCRIPTOR, arena); }
 
-    ///A static invoker of the target method.
-    ///@param stub the upcall stub
+    /// A static invoker of the target method.
+    /// @param stub the upcall stub
     static void invoke(MemorySegment stub, @CType("void*") java.lang.foreign.MemorySegment context, @CType("void*") java.lang.foreign.MemorySegment data, @CType("int") int size) {
         try { HANDLE.invokeExact(stub, context, data, size); }
         catch (Throwable e) { throw new RuntimeException("error in STBIWriteFunc::invoke (static invoker)", e); }

--- a/modules/overrungl.stb/src/main/java/overrungl/stb/STBImage.java
+++ b/modules/overrungl.stb/src/main/java/overrungl/stb/STBImage.java
@@ -26,17 +26,14 @@ import overrungl.util.Unmarshal;
 import java.lang.foreign.*;
 import java.lang.invoke.MethodHandle;
 
-/**
- * The STB image reader.
- *
- * @author squid233
- * @since 0.1.0
- */
+/// [stb_image.h](https://github.com/nothings/stb/blob/master/stb_image.h)
+///
+/// @author squid233
+/// @since 0.1.0
 public final class STBImage {
     //region ---[BEGIN GENERATOR BEGIN]---
     //@formatter:off
     //region Fields
-    ///only used for desired_channels
     public static final int STBI_default = 0;
     public static final int STBI_grey = 1;
     public static final int STBI_grey_alpha = 2;
@@ -310,25 +307,18 @@ public final class STBImage {
         } catch (Throwable e) { throw new RuntimeException("error in stbi_is_hdr", e); }
     }
 
-    ///get a VERY brief reason for failure
-    ///
-    ///on most compilers (and ALL modern mainstream compilers) this is threadsafe
     public static @CType("const char*") java.lang.foreign.MemorySegment stbi_failure_reason_() {
         try {
             return (java.lang.foreign.MemorySegment) Handles.MH_stbi_failure_reason.invokeExact();
         } catch (Throwable e) { throw new RuntimeException("error in stbi_failure_reason", e); }
     }
 
-    ///get a VERY brief reason for failure
-    ///
-    ///on most compilers (and ALL modern mainstream compilers) this is threadsafe
     public static @CType("const char*") java.lang.String stbi_failure_reason() {
         try {
             return Unmarshal.unmarshalAsString((java.lang.foreign.MemorySegment) Handles.MH_stbi_failure_reason.invokeExact());
         } catch (Throwable e) { throw new RuntimeException("error in stbi_failure_reason", e); }
     }
 
-    ///free the loaded image -- this is just free()
     public static void stbi_image_free(@CType("void*") java.lang.foreign.MemorySegment retval_from_stbi_load) {
         try {
             Handles.MH_stbi_image_free.invokeExact(retval_from_stbi_load);
@@ -403,24 +393,18 @@ public final class STBImage {
         } catch (Throwable e) { throw new RuntimeException("error in stbi_is_16_bit", e); }
     }
 
-    ///for image formats that explicitly notate that they have premultiplied alpha,
-    ///we just return the colors as stored in the file. set this flag to force
-    ///unpremultiplication. results are undefined if the unpremultiply overflow.
     public static void stbi_set_unpremultiply_on_load(@CType("int") boolean flag_true_if_should_unpremultiply) {
         try {
             Handles.MH_stbi_set_unpremultiply_on_load.invokeExact(flag_true_if_should_unpremultiply);
         } catch (Throwable e) { throw new RuntimeException("error in stbi_set_unpremultiply_on_load", e); }
     }
 
-    ///indicate whether we should process iphone images back to canonical format,
-    ///or just pass them through "as-is"
     public static void stbi_convert_iphone_png_to_rgb(@CType("int") boolean flag_true_if_should_convert) {
         try {
             Handles.MH_stbi_convert_iphone_png_to_rgb.invokeExact(flag_true_if_should_convert);
         } catch (Throwable e) { throw new RuntimeException("error in stbi_convert_iphone_png_to_rgb", e); }
     }
 
-    ///flip the image vertically, so the first pixel in the output array is the bottom left
     public static void stbi_set_flip_vertically_on_load(@CType("int") boolean flag_true_if_should_flip) {
         try {
             Handles.MH_stbi_set_flip_vertically_on_load.invokeExact(flag_true_if_should_flip);

--- a/modules/overrungl.stb/src/main/java/overrungl/stb/STBImageResize2.java
+++ b/modules/overrungl.stb/src/main/java/overrungl/stb/STBImageResize2.java
@@ -23,35 +23,14 @@ import java.lang.foreign.FunctionDescriptor;
 import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodHandle;
 
-/**
- * The STB image resizer.
- *
- * @author squid233
- * @since 0.1.0
- */
+/// [stb_image_resize2.h](https://github.com/nothings/stb/blob/master/stb_image_resize2.h)
+///
+/// @author squid233
+/// @since 0.1.0
 public final class STBImageResize2 {
     //region ---[BEGIN GENERATOR BEGIN]---
     //@formatter:off
     //region Fields
-    ///stbir_pixel_layout specifies:
-    ///- number of channels
-    ///- order of channels
-    ///- whether color is premultiplied by alpha
-    ///for back compatibility, you can cast the old channel count to an stbir_pixel_layout
-    ///#### Documentation of fields
-    ///##### STBIR_RGB
-    ///3-chan, with order specified (for channel flipping)
-    ///##### STBIR_BGR
-    ///3-chan, with order specified (for channel flipping)
-    ///##### STBIR_RGBA
-    ///alpha formats, where alpha is NOT premultiplied into color channels
-    ///##### STBIR_RGBA_PM
-    ///alpha formats, where alpha is premultiplied into color channels
-    ///##### STBIR_RGBA_NO_AW
-    ///alpha formats, where NO alpha weighting is applied at all!
-    ///these are just synonyms for the _PM flags (which also do
-    ///no alpha weighting). These names just make it more clear
-    ///for some folks).
     public static final int
         STBIR_1CHANNEL = 1,
         STBIR_2CHANNEL = 2,
@@ -76,33 +55,11 @@ public final class STBImageResize2 {
         STBIR_ABGR_NO_AW = 14,
         STBIR_RA_NO_AW = 15,
         STBIR_AR_NO_AW = 16;
-    ///stbir_edge
-    ///#### Documentation of fields
-    ///##### STBIR_EDGE_WRAP
-    ///this edge mode is slower and uses more memory
     public static final int
         STBIR_EDGE_CLAMP = 0,
         STBIR_EDGE_REFLECT = 1,
         STBIR_EDGE_WRAP = 2,
         STBIR_EDGE_ZERO = 3;
-    ///stbir_filter
-    ///#### Documentation of fields
-    ///##### STBIR_FILTER_DEFAULT
-    ///use same filter type that easy-to-use API chooses
-    ///##### STBIR_FILTER_BOX
-    ///A trapezoid w/1-pixel wide ramps, same result as box for integer scale ratios
-    ///##### STBIR_FILTER_TRIANGLE
-    ///On upsampling, produces same results as bilinear texture filtering
-    ///##### STBIR_FILTER_CUBICBSPLINE
-    ///The cubic b-spline (aka Mitchell-Netrevalli with B=1,C=0), gaussian-esque
-    ///##### STBIR_FILTER_CATMULLROM
-    ///An interpolating cubic spline
-    ///##### STBIR_FILTER_MITCHELL
-    ///Mitchell-Netrevalli filter with B=1/3, C=1/3
-    ///##### STBIR_FILTER_POINT_SAMPLE
-    ///Simple point sampling
-    ///##### STBIR_FILTER_OTHER
-    ///User callback specified
     public static final int
         STBIR_FILTER_DEFAULT = 0,
         STBIR_FILTER_BOX = 1,
@@ -112,10 +69,6 @@ public final class STBImageResize2 {
         STBIR_FILTER_MITCHELL = 5,
         STBIR_FILTER_POINT_SAMPLE = 6,
         STBIR_FILTER_OTHER = 7;
-    ///stbir_datatype
-    ///#### Documentation of fields
-    ///##### STBIR_TYPE_UINT8_SRGB_ALPHA
-    ///alpha channel, when present, should also be SRGB (this is very unusual)
     public static final int
         STBIR_TYPE_UINT8 = 0,
         STBIR_TYPE_UINT8_SRGB = 1,
@@ -267,57 +220,36 @@ public final class STBImageResize2 {
         } catch (Throwable e) { throw new RuntimeException("error in stbir_set_output_pixel_subrect", e); }
     }
 
-    ///when inputting AND outputting non-premultiplied alpha pixels, we use a slower but higher quality technique
-    ///that fills the zero alpha pixel's RGB values with something plausible.  If you don't care about areas of
-    ///zero alpha, you can call this function to get about a 25% speed improvement for STBIR_RGBA to STBIR_RGBA
-    ///types of resizes.
     public static @CType("int") boolean stbir_set_non_pm_alpha_speed_over_quality(@CType("STBIR_RESIZE *") java.lang.foreign.MemorySegment resize, @CType("int") int non_pma_alpha_speed_over_quality) {
         try {
             return (boolean) Handles.MH_stbir_set_non_pm_alpha_speed_over_quality.invokeExact(resize, non_pma_alpha_speed_over_quality);
         } catch (Throwable e) { throw new RuntimeException("error in stbir_set_non_pm_alpha_speed_over_quality", e); }
     }
 
-    ///This builds the samplers and does one allocation
     public static @CType("int") boolean stbir_build_samplers(@CType("STBIR_RESIZE *") java.lang.foreign.MemorySegment resize) {
         try {
             return (boolean) Handles.MH_stbir_build_samplers.invokeExact(resize);
         } catch (Throwable e) { throw new RuntimeException("error in stbir_build_samplers", e); }
     }
 
-    ///You MUST call this, if you call stbir_build_samplers or stbir_build_samplers_with_splits
     public static void stbir_free_samplers(@CType("STBIR_RESIZE *") java.lang.foreign.MemorySegment resize) {
         try {
             Handles.MH_stbir_free_samplers.invokeExact(resize);
         } catch (Throwable e) { throw new RuntimeException("error in stbir_free_samplers", e); }
     }
 
-    ///And this is the main function to perform the resize synchronously on one thread.
     public static @CType("int") boolean stbir_resize_extended(@CType("STBIR_RESIZE *") java.lang.foreign.MemorySegment resize) {
         try {
             return (boolean) Handles.MH_stbir_resize_extended.invokeExact(resize);
         } catch (Throwable e) { throw new RuntimeException("error in stbir_resize_extended", e); }
     }
 
-    ///This will build samplers for threading.
-    ///You can pass in the number of threads you'd like to use (try_splits).
-    ///It returns the number of splits (threads) that you can call it with.
-    ///It might be less if the image resize can't be split up that many ways.
     public static @CType("int") boolean stbir_build_samplers_with_splits(@CType("STBIR_RESIZE *") java.lang.foreign.MemorySegment resize, @CType("int") int try_splits) {
         try {
             return (boolean) Handles.MH_stbir_build_samplers_with_splits.invokeExact(resize, try_splits);
         } catch (Throwable e) { throw new RuntimeException("error in stbir_build_samplers_with_splits", e); }
     }
 
-    ///This function does a split of the resizing (you call this fuction for each
-    ///split, on multiple threads). A split is a piece of the output resize pixel space.
-    ///
-    ///Note that you MUST call stbir_build_samplers_with_splits before stbir_resize_extended_split!
-    ///
-    ///Usually, you will always call stbir_resize_split with split_start as the thread_index
-    ///and "1" for the split_count.
-    ///But, if you have a weird situation where you MIGHT want 8 threads, but sometimes
-    ///only 4 threads, you can use 0,2,4,6 for the split_start's and use "2" for the
-    ///split_count each time to turn in into a 4 thread resize. (This is unusual).
     public static @CType("int") boolean stbir_resize_extended_split(@CType("STBIR_RESIZE *") java.lang.foreign.MemorySegment resize, @CType("int") int split_start, @CType("int") int split_count) {
         try {
             return (boolean) Handles.MH_stbir_resize_extended_splits.invokeExact(resize, split_start, split_count);

--- a/modules/overrungl.stb/src/main/java/overrungl/stb/STBImageWrite.java
+++ b/modules/overrungl.stb/src/main/java/overrungl/stb/STBImageWrite.java
@@ -25,12 +25,10 @@ import overrungl.util.Unmarshal;
 import java.lang.foreign.*;
 import java.lang.invoke.MethodHandle;
 
-/**
- * The STB image writer.
- *
- * @author squid233
- * @since 0.1.0
- */
+/// [stb_image_write.h](https://github.com/nothings/stb/blob/master/stb_image_write.h)
+///
+/// @author squid233
+/// @since 0.1.0
 public final class STBImageWrite {
     //region ---[BEGIN GENERATOR BEGIN]---
     //@formatter:off

--- a/modules/overrungl.stb/src/main/java/overrungl/stb/STBPerlin.java
+++ b/modules/overrungl.stb/src/main/java/overrungl/stb/STBPerlin.java
@@ -23,24 +23,7 @@ import java.lang.foreign.FunctionDescriptor;
 import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodHandle;
 
-/// perlin noise
-///
-/// Fractal Noise:
-///
-/// Three common fractal noise functions are included, which produce
-/// a wide variety of nice effects depending on the parameters
-/// provided. Note that each function will call stb_perlin_noise3
-/// 'octaves' times, so this parameter will affect runtime.
-///
-/// - [stb_perlin_ridge_noise3][#stb_perlin_ridge_noise3(float, float, float, float, float, float, int)]
-/// - [stb_perlin_fbm_noise3][#stb_perlin_fbm_noise3(float, float, float, float, float, int)]
-/// - [stb_perlin_turbulence_noise3][#stb_perlin_turbulence_noise3(float, float, float, float, float, int)]
-///
-/// Typical values to start playing with:
-/// - octaves    =   6     -- number of "octaves" of noise3() to sum
-/// - lacunarity = ~ 2.0   -- spacing between successive octaves (use exactly 2.0 for wrapping output)
-/// - gain       =   0.5   -- relative weighting applied to each successive octave
-/// - offset     =   1.0?  -- used to invert the ridges, may need to be larger, not sure
+/// [stb_perlin.h](https://github.com/nothings/stb/blob/master/stb_perlin.h)
 ///
 /// @author squid233
 /// @since 0.1.0
@@ -68,26 +51,12 @@ public final class STBPerlin {
     }
     //endregion
 
-    ///This function computes a random value at the coordinate (x,y,z).
-    ///Adjacent random values are continuous but the noise fluctuates
-    ///its randomness with period 1, i.e. takes on wholly unrelated values
-    ///at integer points. Specifically, this implements Ken Perlin's
-    ///revised noise function from 2002.
-    ///
-    ///The "wrap" parameters can be used to create wraparound noise that
-    ///wraps at powers of two. The numbers MUST be powers of two. Specify
-    ///0 to mean "don't care". (The noise always wraps every 256 due
-    ///details of the implementation, even if you ask for larger or no
-    ///wrapping.)
     public static @CType("float") float stb_perlin_noise3(@CType("float") float x, @CType("float") float y, @CType("float") float z, @CType("int") int x_wrap, @CType("int") int y_wrap, @CType("int") int z_wrap) {
         try {
             return (float) Handles.MH_stb_perlin_noise3.invokeExact(x, y, z, x_wrap, y_wrap, z_wrap);
         } catch (Throwable e) { throw new RuntimeException("error in stb_perlin_noise3", e); }
     }
 
-    ///As above, but 'seed' selects from multiple different variations of the
-    ///noise function. The current implementation only uses the bottom 8 bits
-    /// of 'seed', but possibly in the future more bits will be used.
     public static @CType("float") float stb_perlin_noise3_seed(@CType("float") float x, @CType("float") float y, @CType("float") float z, @CType("int") int x_wrap, @CType("int") int y_wrap, @CType("int") int z_wrap, @CType("int") int seed) {
         try {
             return (float) Handles.MH_stb_perlin_noise3_seed.invokeExact(x, y, z, x_wrap, y_wrap, z_wrap, seed);

--- a/modules/overrungl.stb/src/main/java/overrungl/stb/STBRPContext.java
+++ b/modules/overrungl.stb/src/main/java/overrungl/stb/STBRPContext.java
@@ -24,9 +24,6 @@ import overrungl.annotation.*;
 import overrungl.struct.*;
 import overrungl.util.*;
 
-/// the details of the following structures don't matter to you, but they must
-/// be visible so you can handle the memory allocations for them
-///
 /// ## Members
 /// ### width
 /// ### height
@@ -37,9 +34,6 @@ import overrungl.util.*;
 /// ### active_head
 /// ### free_head
 /// ### extra
-///
-/// we allocate two extra nodes so optimal user-node-count is 'width' not 'width+2'
-///
 /// ## Layout
 /// [Java definition][#LAYOUT]
 /// ```c

--- a/modules/overrungl.stb/src/main/java/overrungl/stb/STBRPNode.java
+++ b/modules/overrungl.stb/src/main/java/overrungl/stb/STBRPNode.java
@@ -24,9 +24,6 @@ import overrungl.annotation.*;
 import overrungl.struct.*;
 import overrungl.util.*;
 
-/// the details of the following structures don't matter to you, but they must
-/// be visible so you can handle the memory allocations for them
-///
 /// ## Members
 /// ### x
 /// ### y

--- a/modules/overrungl.stb/src/main/java/overrungl/stb/STBRPRect.java
+++ b/modules/overrungl.stb/src/main/java/overrungl/stb/STBRPRect.java
@@ -24,39 +24,19 @@ import overrungl.annotation.*;
 import overrungl.struct.*;
 import overrungl.util.*;
 
-/// 16 bytes, nominally
-///
 /// ## Members
 /// ### id
 /// [VarHandle][#VH_id] - [Getter][#id()] - [Setter][#id(int)]
-///
-/// reserved for your use
-///
 /// ### w
 /// [VarHandle][#VH_w] - [Getter][#w()] - [Setter][#w(int)]
-///
-/// input
-///
 /// ### h
 /// [VarHandle][#VH_h] - [Getter][#h()] - [Setter][#h(int)]
-///
-/// input
-///
 /// ### x
 /// [VarHandle][#VH_x] - [Getter][#x()] - [Setter][#x(int)]
-///
-/// output
-///
 /// ### y
 /// [VarHandle][#VH_y] - [Getter][#y()] - [Setter][#y(int)]
-///
-/// output
-///
 /// ### was_packed
 /// [VarHandle][#VH_was_packed] - [Getter][#was_packed()] - [Setter][#was_packed(int)]
-///
-/// non-zero if valid packing
-///
 /// ## Layout
 /// [Java definition][#LAYOUT]
 /// ```c

--- a/modules/overrungl.stb/src/main/java/overrungl/stb/STBRectPack.java
+++ b/modules/overrungl.stb/src/main/java/overrungl/stb/STBRectPack.java
@@ -24,20 +24,14 @@ import java.lang.foreign.FunctionDescriptor;
 import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodHandle;
 
-/**
- * Useful for e.g. packing rectangular textures into an atlas.
- * Does not do rotation.
- * <p>
- * This library currently uses the Skyline Bottom-Left algorithm.
- *
- * @author squid233
- * @since 0.1.0
- */
+/// [stb_rect_pack.h](https://github.com/nothings/stb/blob/master/stb_rect_pack.h)
+///
+/// @author squid233
+/// @since 0.1.0
 public final class STBRectPack {
     //region ---[BEGIN GENERATOR BEGIN]---
     //@formatter:off
     //region Fields
-    ///Mostly for internal use, but this is the maximum supported coordinate value.
     public static final int STBRP__MAXVAL = 0x7fffffff;
     public static final int STBRP_HEURISTIC_Skyline_default = 0;
     public static final int STBRP_HEURISTIC_Skyline_BL_sortHeight = STBRP_HEURISTIC_Skyline_default;
@@ -58,144 +52,48 @@ public final class STBRectPack {
     }
     //endregion
 
-    ///Assign packed locations to rectangles. The rectangles are of type
-    ///'stbrp_rect' defined below, stored in the array 'rects', and there
-    ///are 'num_rects' many of them.
-    ///
-    ///Rectangles which are successfully packed have the 'was_packed' flag
-    ///set to a non-zero value and 'x' and 'y' store the minimum location
-    ///on each axis (i.e. bottom-left in cartesian coordinates, top-left
-    ///if you imagine y increasing downwards). Rectangles which do not fit
-    ///have the 'was_packed' flag set to 0.
-    ///
-    ///You should not try to access the 'rects' array from another thread
-    ///while this function is running, as the function temporarily reorders
-    ///the array while it executes.
-    ///
-    ///To pack into another rectangle, you need to call stbrp_init_target
-    ///again. To continue packing into the same rectangle, you can call
-    ///this function again. Calling this multiple times with multiple rect
-    ///arrays will probably produce worse packing results than calling it
-    ///a single time with the full rectangle array, but the option is
-    ///available.
-    ///
-    ///@return 1 if all of the rectangles were successfully
-    ///        packed and 0 otherwise.
     public static @CType("int") int stbrp_pack_rects(@CType("stbrp_context *") java.lang.foreign.MemorySegment context, @CType("stbrp_rect *") java.lang.foreign.MemorySegment rects, @CType("int") int num_rects) {
         try {
             return (int) Handles.MH_stbrp_pack_rects.invokeExact(context, rects, num_rects);
         } catch (Throwable e) { throw new RuntimeException("error in stbrp_pack_rects", e); }
     }
 
-    ///Assign packed locations to rectangles. The rectangles are of type
-    ///'stbrp_rect' defined below, stored in the array 'rects', and there
-    ///are 'num_rects' many of them.
-    ///
-    ///Rectangles which are successfully packed have the 'was_packed' flag
-    ///set to a non-zero value and 'x' and 'y' store the minimum location
-    ///on each axis (i.e. bottom-left in cartesian coordinates, top-left
-    ///if you imagine y increasing downwards). Rectangles which do not fit
-    ///have the 'was_packed' flag set to 0.
-    ///
-    ///You should not try to access the 'rects' array from another thread
-    ///while this function is running, as the function temporarily reorders
-    ///the array while it executes.
-    ///
-    ///To pack into another rectangle, you need to call stbrp_init_target
-    ///again. To continue packing into the same rectangle, you can call
-    ///this function again. Calling this multiple times with multiple rect
-    ///arrays will probably produce worse packing results than calling it
-    ///a single time with the full rectangle array, but the option is
-    ///available.
-    ///
-    ///@return 1 if all of the rectangles were successfully
-    ///        packed and 0 otherwise.
     public static @CType("int") int stbrp_pack_rects(@CType("stbrp_context *") overrungl.stb.STBRPContext context, @CType("stbrp_rect *") overrungl.stb.STBRPRect rects, @CType("int") int num_rects) {
         try {
             return (int) Handles.MH_stbrp_pack_rects.invokeExact(Marshal.marshal(context), Marshal.marshal(rects), num_rects);
         } catch (Throwable e) { throw new RuntimeException("error in stbrp_pack_rects", e); }
     }
 
-    ///Initialize a rectangle packer to:
-    ///pack a rectangle that is 'width' by 'height' in dimensions
-    ///using temporary storage provided by the array 'nodes', which is 'num_nodes' long
-    ///
-    ///You must call this function every time you start packing into a new target.
-    ///
-    ///There is no "shutdown" function. The 'nodes' memory must stay valid for
-    ///the following stbrp_pack_rects() call (or calls), but can be freed after
-    ///the call (or calls) finish.
-    ///
-    ///Note: to guarantee best results, either:
-    ///1. make sure 'num_nodes' >= 'width' or
-    ///2. call stbrp_allow_out_of_mem() defined below with 'allow_out_of_mem = 1'
-    ///
-    ///If you don't do either of the above things, widths will be quantized to multiples
-    ///of small integers to guarantee the algorithm doesn't run out of temporary storage.
-    ///
-    ///If you do #2, then the non-quantized algorithm will be used, but the algorithm
-    ///may run out of temporary storage and be unable to pack some rectangles.
     public static void stbrp_init_target(@CType("stbrp_context *") java.lang.foreign.MemorySegment context, @CType("int") int width, @CType("int") int height, @CType("stbrp_node *") java.lang.foreign.MemorySegment nodes, @CType("int") int num_nodes) {
         try {
             Handles.MH_stbrp_init_target.invokeExact(context, width, height, nodes, num_nodes);
         } catch (Throwable e) { throw new RuntimeException("error in stbrp_init_target", e); }
     }
 
-    ///Initialize a rectangle packer to:
-    ///pack a rectangle that is 'width' by 'height' in dimensions
-    ///using temporary storage provided by the array 'nodes', which is 'num_nodes' long
-    ///
-    ///You must call this function every time you start packing into a new target.
-    ///
-    ///There is no "shutdown" function. The 'nodes' memory must stay valid for
-    ///the following stbrp_pack_rects() call (or calls), but can be freed after
-    ///the call (or calls) finish.
-    ///
-    ///Note: to guarantee best results, either:
-    ///1. make sure 'num_nodes' >= 'width' or
-    ///2. call stbrp_allow_out_of_mem() defined below with 'allow_out_of_mem = 1'
-    ///
-    ///If you don't do either of the above things, widths will be quantized to multiples
-    ///of small integers to guarantee the algorithm doesn't run out of temporary storage.
-    ///
-    ///If you do #2, then the non-quantized algorithm will be used, but the algorithm
-    ///may run out of temporary storage and be unable to pack some rectangles.
     public static void stbrp_init_target(@CType("stbrp_context *") overrungl.stb.STBRPContext context, @CType("int") int width, @CType("int") int height, @CType("stbrp_node *") overrungl.stb.STBRPNode nodes, @CType("int") int num_nodes) {
         try {
             Handles.MH_stbrp_init_target.invokeExact(Marshal.marshal(context), width, height, Marshal.marshal(nodes), num_nodes);
         } catch (Throwable e) { throw new RuntimeException("error in stbrp_init_target", e); }
     }
 
-    ///Optionally call this function after init but before doing any packing to
-    ///change the handling of the out-of-temp-memory scenario, described above.
-    ///If you call init again, this will be reset to the default (false).
     public static void stbrp_setup_allow_out_of_mem(@CType("stbrp_context *") java.lang.foreign.MemorySegment context, @CType("int") boolean allow_out_of_mem) {
         try {
             Handles.MH_stbrp_setup_allow_out_of_mem.invokeExact(context, allow_out_of_mem);
         } catch (Throwable e) { throw new RuntimeException("error in stbrp_setup_allow_out_of_mem", e); }
     }
 
-    ///Optionally call this function after init but before doing any packing to
-    ///change the handling of the out-of-temp-memory scenario, described above.
-    ///If you call init again, this will be reset to the default (false).
     public static void stbrp_setup_allow_out_of_mem(@CType("stbrp_context *") overrungl.stb.STBRPContext context, @CType("int") boolean allow_out_of_mem) {
         try {
             Handles.MH_stbrp_setup_allow_out_of_mem.invokeExact(Marshal.marshal(context), allow_out_of_mem);
         } catch (Throwable e) { throw new RuntimeException("error in stbrp_setup_allow_out_of_mem", e); }
     }
 
-    ///Optionally select which packing heuristic the library should use. Different
-    ///heuristics will produce better/worse results for different data sets.
-    ///If you call init again, this will be reset to the default.
     public static void stbrp_setup_heuristic(@CType("stbrp_context *") java.lang.foreign.MemorySegment context, @CType("int") int heuristic) {
         try {
             Handles.MH_stbrp_setup_heuristic.invokeExact(context, heuristic);
         } catch (Throwable e) { throw new RuntimeException("error in stbrp_setup_heuristic", e); }
     }
 
-    ///Optionally select which packing heuristic the library should use. Different
-    ///heuristics will produce better/worse results for different data sets.
-    ///If you call init again, this will be reset to the default.
     public static void stbrp_setup_heuristic(@CType("stbrp_context *") overrungl.stb.STBRPContext context, @CType("int") int heuristic) {
         try {
             Handles.MH_stbrp_setup_heuristic.invokeExact(Marshal.marshal(context), heuristic);

--- a/modules/overrungl.stb/src/main/java/overrungl/stb/STBTTAlignedQuad.java
+++ b/modules/overrungl.stb/src/main/java/overrungl/stb/STBTTAlignedQuad.java
@@ -27,44 +27,20 @@ import overrungl.util.*;
 /// ## Members
 /// ### x0
 /// [VarHandle][#VH_x0] - [Getter][#x0()] - [Setter][#x0(float)]
-///
-/// top-left
-///
 /// ### y0
 /// [VarHandle][#VH_y0] - [Getter][#y0()] - [Setter][#y0(float)]
-///
-/// top-left
-///
 /// ### s0
 /// [VarHandle][#VH_s0] - [Getter][#s0()] - [Setter][#s0(float)]
-///
-/// top-left
-///
 /// ### t0
 /// [VarHandle][#VH_t0] - [Getter][#t0()] - [Setter][#t0(float)]
-///
-/// top-left
-///
 /// ### x1
 /// [VarHandle][#VH_x1] - [Getter][#x1()] - [Setter][#x1(float)]
-///
-/// bottom-right
-///
 /// ### y1
 /// [VarHandle][#VH_y1] - [Getter][#y1()] - [Setter][#y1(float)]
-///
-/// bottom-right
-///
 /// ### s1
 /// [VarHandle][#VH_s1] - [Getter][#s1()] - [Setter][#s1(float)]
-///
-/// bottom-right
-///
 /// ### t1
 /// [VarHandle][#VH_t1] - [Getter][#t1()] - [Setter][#t1(float)]
-///
-/// bottom-right
-///
 /// ## Layout
 /// [Java definition][#LAYOUT]
 /// ```c

--- a/modules/overrungl.stb/src/main/java/overrungl/stb/STBTTBakedChar.java
+++ b/modules/overrungl.stb/src/main/java/overrungl/stb/STBTTBakedChar.java
@@ -27,24 +27,12 @@ import overrungl.util.*;
 /// ## Members
 /// ### x0
 /// [VarHandle][#VH_x0] - [Getter][#x0()] - [Setter][#x0(short)]
-///
-/// coordinates of bbox in bitmap
-///
 /// ### y0
 /// [VarHandle][#VH_y0] - [Getter][#y0()] - [Setter][#y0(short)]
-///
-/// coordinates of bbox in bitmap
-///
 /// ### x1
 /// [VarHandle][#VH_x1] - [Getter][#x1()] - [Setter][#x1(short)]
-///
-/// coordinates of bbox in bitmap
-///
 /// ### y1
 /// [VarHandle][#VH_y1] - [Getter][#y1()] - [Setter][#y1(short)]
-///
-/// coordinates of bbox in bitmap
-///
 /// ### xoff
 /// [VarHandle][#VH_xoff] - [Getter][#xoff()] - [Setter][#xoff(float)]
 /// ### yoff

--- a/modules/overrungl.stb/src/main/java/overrungl/stb/STBTTFontInfo.java
+++ b/modules/overrungl.stb/src/main/java/overrungl/stb/STBTTFontInfo.java
@@ -24,87 +24,27 @@ import overrungl.annotation.*;
 import overrungl.struct.*;
 import overrungl.util.*;
 
-/// The following structure is defined publicly so you can declare one on
-/// the stack or as a global or etc, but you should treat it as opaque.
-///
 /// ## Members
 /// ### userdata
 /// ### data
-///
-/// pointer to .ttf file
-///
 /// ### fontstart
-///
-/// offset of start of font
-///
 /// ### numGlyphs
-///
-/// number of glyphs, needed for range checking
-///
 /// ### loca
-///
-/// table locations as offset from start of .ttf
-///
 /// ### head
-///
-/// table locations as offset from start of .ttf
-///
 /// ### glyf
-///
-/// table locations as offset from start of .ttf
-///
 /// ### hhea
-///
-/// table locations as offset from start of .ttf
-///
 /// ### hmtx
-///
-/// table locations as offset from start of .ttf
-///
 /// ### kern
-///
-/// table locations as offset from start of .ttf
-///
 /// ### gpos
-///
-/// table locations as offset from start of .ttf
-///
 /// ### svg
-///
-/// table locations as offset from start of .ttf
-///
 /// ### index_map
-///
-/// a cmap mapping for our chosen character encoding
-///
 /// ### indexToLocFormat
-///
-/// format needed to map from glyph index to glyph
-///
 /// ### cff
-///
-/// cff font data
-///
 /// ### charstrings
-///
-/// the charstring index
-///
 /// ### gsubrs
-///
-/// global charstring subroutines index
-///
 /// ### subrs
-///
-/// private charstring subroutines index
-///
 /// ### fontdicts
-///
-/// array of font dicts
-///
 /// ### fdselect
-///
-/// map from glyph to fontdict
-///
 /// ## Layout
 /// [Java definition][#LAYOUT]
 /// ```c

--- a/modules/overrungl.stb/src/main/java/overrungl/stb/STBTTKerningEntry.java
+++ b/modules/overrungl.stb/src/main/java/overrungl/stb/STBTTKerningEntry.java
@@ -27,9 +27,6 @@ import overrungl.util.*;
 /// ## Members
 /// ### glyph1
 /// [VarHandle][#VH_glyph1] - [Getter][#glyph1()] - [Setter][#glyph1(int)]
-///
-/// use stbtt_FindGlyphIndex
-///
 /// ### glyph2
 /// [VarHandle][#VH_glyph2] - [Getter][#glyph2()] - [Setter][#glyph2(int)]
 /// ### advance

--- a/modules/overrungl.stb/src/main/java/overrungl/stb/STBTTPackRange.java
+++ b/modules/overrungl.stb/src/main/java/overrungl/stb/STBTTPackRange.java
@@ -29,31 +29,16 @@ import overrungl.util.*;
 /// [VarHandle][#VH_font_size] - [Getter][#font_size()] - [Setter][#font_size(float)]
 /// ### first_unicode_codepoint_in_range
 /// [VarHandle][#VH_first_unicode_codepoint_in_range] - [Getter][#first_unicode_codepoint_in_range()] - [Setter][#first_unicode_codepoint_in_range(int)]
-///
-/// if non-zero, then the chars are continuous, and this is the first codepoint
-///
 /// ### array_of_unicode_codepoints
 /// [VarHandle][#VH_array_of_unicode_codepoints] - [Getter][#array_of_unicode_codepoints()] - [Setter][#array_of_unicode_codepoints(java.lang.foreign.MemorySegment)]
-///
-/// if non-zero, then this is an array of unicode codepoints
-///
 /// ### num_chars
 /// [VarHandle][#VH_num_chars] - [Getter][#num_chars()] - [Setter][#num_chars(int)]
 /// ### chardata_for_range
 /// [VarHandle][#VH_chardata_for_range] - [Getter][#chardata_for_range()] - [Setter][#chardata_for_range(java.lang.foreign.MemorySegment)]
-///
-/// output
-///
 /// ### h_oversample
 /// [VarHandle][#VH_h_oversample] - [Getter][#h_oversample()] - [Setter][#h_oversample(byte)]
-///
-/// don't set these, they're used internally
-///
 /// ### v_oversample
 /// [VarHandle][#VH_v_oversample] - [Getter][#v_oversample()] - [Setter][#v_oversample(byte)]
-///
-/// don't set these, they're used internally
-///
 /// ## Layout
 /// [Java definition][#LAYOUT]
 /// ```c

--- a/modules/overrungl.stb/src/main/java/overrungl/stb/STBTTPackedChar.java
+++ b/modules/overrungl.stb/src/main/java/overrungl/stb/STBTTPackedChar.java
@@ -27,24 +27,12 @@ import overrungl.util.*;
 /// ## Members
 /// ### x0
 /// [VarHandle][#VH_x0] - [Getter][#x0()] - [Setter][#x0(short)]
-///
-/// coordinates of bbox in bitmap
-///
 /// ### y0
 /// [VarHandle][#VH_y0] - [Getter][#y0()] - [Setter][#y0(short)]
-///
-/// coordinates of bbox in bitmap
-///
 /// ### x1
 /// [VarHandle][#VH_x1] - [Getter][#x1()] - [Setter][#x1(short)]
-///
-/// coordinates of bbox in bitmap
-///
 /// ### y1
 /// [VarHandle][#VH_y1] - [Getter][#y1()] - [Setter][#y1(short)]
-///
-/// coordinates of bbox in bitmap
-///
 /// ### xoff
 /// [VarHandle][#VH_xoff] - [Getter][#xoff()] - [Setter][#xoff(float)]
 /// ### yoff

--- a/modules/overrungl.stb/src/main/java/overrungl/stb/STBTT__bitmap.java
+++ b/modules/overrungl.stb/src/main/java/overrungl/stb/STBTT__bitmap.java
@@ -24,8 +24,6 @@ import overrungl.annotation.*;
 import overrungl.struct.*;
 import overrungl.util.*;
 
-/// `@TODO: don't expose this structure`
-///
 /// ## Members
 /// ### w
 /// ### h

--- a/modules/overrungl.stb/src/main/java/overrungl/stb/STBTT__buf.java
+++ b/modules/overrungl.stb/src/main/java/overrungl/stb/STBTT__buf.java
@@ -24,8 +24,6 @@ import overrungl.annotation.*;
 import overrungl.struct.*;
 import overrungl.util.*;
 
-/// private structure
-///
 /// ## Members
 /// ### data
 /// ### cursor

--- a/modules/overrungl.stb/src/main/java/overrungl/stb/STBTrueType.java
+++ b/modules/overrungl.stb/src/main/java/overrungl/stb/STBTrueType.java
@@ -29,286 +29,19 @@ import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodHandle;
 import java.nio.charset.StandardCharsets;
 
-/**
- * =======================================================================
- * <p>
- * NO SECURITY GUARANTEE -- DO NOT USE THIS ON UNTRUSTED FONT FILES
- * <p>
- * This library does no range checking of the offsets found in the file,
- * meaning an attacker can use it to read arbitrary memory.
- * <p>
- * Immediately after this block comment are a series of sample programs.
- * <p>
- * Some important concepts to understand to use this library:
- * <h2>Codepoint</h2>
- * Characters are defined by unicode codepoints, e.g. 65 is
- * uppercase A, 231 is lowercase c with a cedilla, 0x7e30 is
- * the hiragana for "ma".
- * <h2>Glyph</h2>
- * A visual character shape (every codepoint is rendered as
- * some glyph)
- * <h2>Glyph index</h2>
- * A font-specific integer ID representing a glyph
- * <h2>Baseline</h2>
- * Glyph shapes are defined relative to a baseline, which is the
- * bottom of uppercase characters. Characters extend both above
- * and below the baseline.
- * <h2>Current Point</h2>
- * As you draw text to the screen, you keep track of a "current point"
- * which is the origin of each character. The current point's vertical
- * position is the baseline. Even "baked fonts" use this model.
- * <h2>Vertical Font Metrics</h2>
- * The vertical qualities of the font, used to vertically position
- * and space the characters. See docs for stbtt_GetFontVMetrics.
- * <h2>Font Size in Pixels or Points</h2>
- * The preferred interface for specifying font sizes in stb_truetype
- * is to specify how tall the font's vertical extent should be in pixels.
- * If that sounds good enough, skip the next paragraph.
- * <p>
- * Most font APIs instead use "points", which are a common typographic
- * measurement for describing font size, defined as 72 points per inch.
- * stb_truetype provides a point API for compatibility. However, true
- * "per inch" conventions don't make much sense on computer displays
- * since different monitors have different number of pixels per
- * inch. For example, Windows traditionally uses a convention that
- * there are 96 pixels per inch, thus making 'inch' measurements have
- * nothing to do with inches, and thus effectively defining a point to
- * be 1.333 pixels. Additionally, the TrueType font data provides
- * an explicit scale factor to scale a given font's glyphs to points,
- * but the author has observed that this scale factor is often wrong
- * for non-commercial fonts, thus making fonts scaled in points
- * according to the TrueType spec incoherently sized in practice.
- * <h2>DETAILED USAGE</h2>
- * <h3>Scale</h3>
- * Select how high you want the font to be, in points or pixels.
- * Call ScaleForPixelHeight or ScaleForMappingEmToPixels to compute
- * a scale factor SF that will be used by all other functions.
- * <h3>Baseline</h3>
- * You need to select a y-coordinate that is the baseline of where
- * your text will appear. Call GetFontBoundingBox to get the baseline-relative
- * bounding box for all characters. SF*-y0 will be the distance in pixels
- * that the worst-case character could extend above the baseline, so if
- * you want the top edge of characters to appear at the top of the
- * screen where y=0, then you would set the baseline to SF*-y0.
- * <h3>Current point</h3>
- * Set the current point where the first character will appear. The
- * first character could extend left of the current point; this is font
- * dependent. You can either choose a current point that is the leftmost
- * point and hope, or add some padding, or check the bounding box or
- * left-side-bearing of the first character to be displayed and set
- * the current point based on that.
- * <h3>Displaying a character</h3>
- * Compute the bounding box of the character. It will contain signed values
- * relative to {@code current_point, baseline}. I.e. if it returns x0,y0,x1,y1,
- * then the character should be displayed in the rectangle from
- * {@code current_point+SF*x0, baseline+SF*y0} to {@code current_point+SF*x1,baseline+SF*y1}.
- * <h3>Advancing for the next character</h3>
- * Call GlyphHMetrics, and compute 'current_point += SF * advance'.
- * <h2>ADVANCED USAGE</h2>
- * <h3>Quality</h3>
- * <ul>
- *     <li>Use the functions with Subpixel at the end to allow your characters
- *     to have subpixel positioning. Since the font is anti-aliased, not
- *     hinted, this is very import for quality. (This is not possible with
- *     baked fonts.)</li>
- *     <li>Kerning is now supported, and if you're supporting subpixel rendering
- *     then kerning is worth using to give your text a polished look.</li>
- * </ul>
- * <h3>Performance</h3>
- * <ul>
- *     <li>Convert Unicode codepoints to glyph indexes and operate on the glyphs;
- *     if you don't do this, stb_truetype is forced to do the conversion on
- *     every call.</li>
- *     <li>There are a lot of memory allocations. We should modify it to take
- *     a temp buffer and allocate from the temp buffer (without freeing),
- *     should help performance a lot.</li>
- * </ul>
- * <h2>NOTES</h2>
- * The system uses the raw data found in the .ttf file without changing it
- * and without building auxiliary data structures. This is a bit inefficient
- * on little-endian systems (the data is big-endian), but assuming you're
- * caching the bitmaps or glyph shapes this shouldn't be a big deal.
- * <p>
- * It appears to be very hard to programmatically determine what font a
- * given file is in a general way. I provide an API for this, but I don't
- * recommend it.
- * <h2>Finding the right font...</h2>
- * You should really just solve this offline, keep your own tables
- * of what font is what, and don't try to get it out of the .ttf file.
- * That's because getting it out of the .ttf file is really hard, because
- * the names in the file can appear in many possible encodings, in many
- * possible languages, and e.g. if you need a case-insensitive comparison,
- * the details of that depend on the encoding &amp; language in a complex way
- * (actually underspecified in truetype, but also gigantic).
- * <p>
- * But you can use the provided functions in two possible ways:
- * <p>
- * stbtt_FindMatchingFont() will use *case-sensitive* comparisons on
- * unicode-encoded names to try to find the font you want;
- * you can run this before calling stbtt_InitFont()
- * <p>
- * stbtt_GetFontNameString() lets you get any of the various strings
- * from the file yourself and do your own comparisons on them.
- * You have to have called stbtt_InitFont() first.
- * <h2>SAMPLE PROGRAMS</h2>
- * Incomplete text-in-3d-api example, which draws quads properly aligned to be lossless.
- * {@snippet lang = java:
- * import java.lang.foreign.Arena;
- * import java.nio.channels.FileChannel;
- * import java.nio.file.Path;
- * import java.nio.file.StandardOpenOption;
- * Arena arena = Arena.ofAuto();
- *
- * STBTTBakedChar cdata = STBTTBakedChar.alloc(arena, 96);
- * int ftex = 0;
- *
- * void my_stbtt_initfont() {
- *     try (var fc = FileChannel.open(Path.of("c:/windows/fonts/times.ttf"), StandardOpenOption.READ);
- *          var bufArena = Arena.ofConfined()) {
- *         var ttf_buffer = bufArena.allocate(1 << 20);
- *         var temp_bitmap = bufArena.allocate(512 * 512);
- *         ttf_buffer.copyFrom(fc.map(FileChannel.MapMode.READ_ONLY, 0, 1 << 20, arena));
- *         stbtt_BakeFontBitmap(ttf_buffer, 0, 32.0f, temp_bitmap, 512, 512, 32, 96, cdata); // no guarantee this fits!
- *         // can free ttf_buffer at this point
- *         ftex = gl.GenTextures();
- *         gl.BindTexture(GL_TEXTURE_2D, ftex);
- *         gl.TexImage2D(GL_TEXTURE_2D, 0, GL_ALPHA, 512, 512, 0, GL_ALPHA, GL_UNSIGNED_BYTE, temp_bitmap);
- *         // can free temp_bitmap at this point
- *         gl.TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
- *     }
- * }
- *
- * void my_stbtt_print(float x, float y, String text) {
- *     // assume orthographic projection with units = screen pixels, origin at top left
- *     gl.Enable(GL_BLEND);
- *     gl.BlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
- *     gl.Enable(GL_TEXTURE_2D);
- *     gl.BindTexture(GL_TEXTURE_2D, ftex);
- *     gl.Begin(GL_QUADS);
- *     try (var stack = MemoryStack.pushLocal()) {
- *         var q = STBTTAlignedQuad.alloc(stack);
- *         var px = stack.allocateFrom(ValueLayout.JAVA_FLOAT, x);
- *         var py = stack.allocateFrom(ValueLayout.JAVA_FLOAT, y);
- *         for (int i = 0, c = text.codePointCount(0, text.length()); i < c; i++) {
- *             int p = text.codePointAt(i);
- *             if (p >= 32 && p < 128) {
- *                 stbtt_GetBakedQuad(cdata.segment(), 512, 512, p - 32, px, py, q.segment(), true); //true=opengl & d3d10+,false=d3d9
- *                 gl.TexCoord2f(q.s0(), q.t0()); gl.Vertex2f(q.x0(), q.y0());
- *                 gl.TexCoord2f(q.s1(), q.t0()); gl.Vertex2f(q.x1(), q.y0());
- *                 gl.TexCoord2f(q.s1(), q.t1()); gl.Vertex2f(q.x1(), q.y1());
- *                 gl.TexCoord2f(q.s0(), q.t1()); gl.Vertex2f(q.x0(), q.y1());
- *             }
- *         }
- *     }
- *     gl.End();
- * }
- *}
- * <p>
- * Complete program (this compiles): get a single bitmap, print as ASCII art
- * {@snippet lang = java:
- * import overrungl.stb.STBTTFontInfo;
- * import overrungl.stb.STBTrueType;
- *
- * import java.io.IOException;
- * import java.lang.foreign.Arena;
- * import java.lang.foreign.MemorySegment;
- * import java.lang.foreign.ValueLayout;
- * import java.nio.channels.FileChannel;
- * import java.nio.file.Path;
- * import java.nio.file.StandardOpenOption;
- *
- * void main(String[] args) throws IOException {
- *     var arena = Arena.ofAuto();
- *
- *     var font = STBTTFontInfo.alloc(arena);
- *     int c = (args.length > 0 ? Integer.parseInt(args[0]) : 'a');
- *     int s = (args.length > 1 ? Integer.parseInt(args[1]) : 20);
- *
- *     try (var fc = FileChannel.open(Path.of(args.length > 2 ? args[2] : "c:/windows/fonts/arialbd.ttf"), StandardOpenOption.READ)) {
- *         var ttf_buffer = fc.map(FileChannel.MapMode.READ_ONLY, 0, fc.size(), arena);
- *         stbtt_InitFont(font, ttf_buffer, stbtt_GetFontOffsetForIndex(ttf_buffer, 0));
- *     }
- *
- *     try (var stack = MemoryStack.pushLocal()) {
- *         var pw = stack.allocateFrom(ValueLayout.JAVA_INT, 0);
- *         var ph = stack.allocateFrom(ValueLayout.JAVA_INT, 0);
- *         var bitmap = stbtt_GetCodepointBitmap(font.segment(), 0, stbtt_ScaleForPixelHeight(font, s), c, pw, ph, MemorySegment.NULL, MemorySegment.NULL);
- *         int w = pw.get(ValueLayout.JAVA_INT, 0);
- *         int h = ph.get(ValueLayout.JAVA_INT, 0);
- *         bitmap = bitmap.reinterpret((long) w * h);
- *
- *         final var str = " .:ioVM@";
- *         for (int j = 0; j < h; j++) {
- *             for (int i = 0; i < w; i++) {
- *                 System.out.print(str.charAt(Byte.toUnsignedInt(bitmap.getAtIndex(ValueLayout.JAVA_BYTE, (long) j * w + i)) >> 5));
- *             }
- *             System.out.println();
- *         }
- *     }
- * }
- *}
- * Output:
- * <pre>{@code
- *    .ii.
- *   @@@@@@.
- *  V@Mio@@o
- *  :i.  V@V
- *    :oM@@M
- *  :@@@MM@M
- *  @@o o@M
- * :@@.  M@M
- *  @@@o@@@@
- *  :M@@V:@@.
- * }</pre>
- * <p>
- * Complete program: print "Hello World!" banner, with bugs
- * {@snippet lang = c:
- * char buffer[24<<20];
- * unsigned char screen[20][79];
- *
- * int main(int arg, char **argv)
- * {
- *    stbtt_fontinfo font;
- *    int i,j,ascent,baseline,ch=0;
- *    float scale, xpos=2; // leave a little padding in case the character extends left
- *    char *text = "Heljo World!"; // intentionally misspelled to show 'lj' brokenness
- *
- *    fread(buffer, 1, 1000000, fopen("c:/windows/fonts/arialbd.ttf", "rb"));
- *    stbtt_InitFont(&font, buffer, 0);
- *
- *    scale = stbtt_ScaleForPixelHeight(&font, 15);
- *    stbtt_GetFontVMetrics(&font, &ascent,0,0);
- *    baseline = (int) (ascent*scale);
- *
- *    while (text[ch]) {
- *       int advance,lsb,x0,y0,x1,y1;
- *       float x_shift = xpos - (float) floor(xpos);
- *       stbtt_GetCodepointHMetrics(&font, text[ch], &advance, &lsb);
- *       stbtt_GetCodepointBitmapBoxSubpixel(&font, text[ch], scale,scale,x_shift,0, &x0,&y0,&x1,&y1);
- *       stbtt_MakeCodepointBitmapSubpixel(&font, &screen[baseline + y0][(int) xpos + x0], x1-x0,y1-y0, 79, scale,scale,x_shift,0, text[ch]);
- *       // note that this stomps the old data, so where character boxes overlap (e.g. 'lj') it's wrong
- *       // because this API is really for baking character bitmaps into textures. if you want to render
- *       // a sequence of characters, you really need to render each bitmap to a temp buffer, then
- *       // "alpha blend" that into the working buffer
- *       xpos += (advance * scale);
- *       if (text[ch+1])
- *          xpos += scale*stbtt_GetCodepointKernAdvance(&font, text[ch],text[ch+1]);
- *       ++ch;
- *    }
- *
- *    for (j=0; j < 20; ++j) {
- *       for (i=0; i < 78; ++i)
- *          putchar(" .:ioVM@"[screen[j][i]>>5]);
- *       putchar('\n');
- *    }
- *
- *    return 0;
- * }
- *}
- *
- * @author squid233
- * @since 0.1.0
- */
+/// =======================================================================
+///
+/// NO SECURITY GUARANTEE -- DO NOT USE THIS ON UNTRUSTED FONT FILES
+///
+/// This library does no range checking of the offsets found in the file,
+/// meaning an attacker can use it to read arbitrary memory.
+///
+/// =======================================================================
+///
+/// [stb_truetype.h](https://github.com/nothings/stb/blob/master/stb_truetype.h)
+///
+/// @author squid233
+/// @since 0.1.0
 public final class STBTrueType {
     //region ---[BEGIN GENERATOR BEGIN]---
     //@formatter:off
@@ -318,9 +51,6 @@ public final class STBTrueType {
         STBTT_vline = 2,
         STBTT_vcurve = 3,
         STBTT_vcubic = 4;
-    ///#### Documentation of fields
-    ///##### STBTT_MACSTYLE_NONE
-    ///<= not same as 0, this makes us check the bitfield is 0
     public static final int
         STBTT_MACSTYLE_DONTCARE = 0,
         STBTT_MACSTYLE_BOLD = 1,
@@ -500,50 +230,24 @@ public final class STBTrueType {
     }
     //endregion
 
-    ///if return is positive, the first unused row of the bitmap
-    ///if return is negative, returns the negative of the number of characters that fit
-    ///if return is 0, no characters fit and no rows were used
-    ///This uses a very crappy packing.
     public static @CType("int") int stbtt_BakeFontBitmap(@CType("const unsigned char *") java.lang.foreign.MemorySegment data, @CType("int") int offset, @CType("float") float pixel_height, @CType("unsigned char *") java.lang.foreign.MemorySegment pixels, @CType("int") int pw, @CType("int") int ph, @CType("int") int first_char, @CType("int") int num_chars, @CType("stbtt_bakedchar *") java.lang.foreign.MemorySegment chardata) {
         try {
             return (int) Handles.MH_stbtt_BakeFontBitmap.invokeExact(data, offset, pixel_height, pixels, pw, ph, first_char, num_chars, chardata);
         } catch (Throwable e) { throw new RuntimeException("error in stbtt_BakeFontBitmap", e); }
     }
 
-    ///if return is positive, the first unused row of the bitmap
-    ///if return is negative, returns the negative of the number of characters that fit
-    ///if return is 0, no characters fit and no rows were used
-    ///This uses a very crappy packing.
     public static @CType("int") int stbtt_BakeFontBitmap(@CType("const unsigned char *") java.lang.foreign.MemorySegment data, @CType("int") int offset, @CType("float") float pixel_height, @CType("unsigned char *") java.lang.foreign.MemorySegment pixels, @CType("int") int pw, @CType("int") int ph, @CType("int") int first_char, @CType("int") int num_chars, @CType("stbtt_bakedchar *") overrungl.stb.STBTTBakedChar chardata) {
         try {
             return (int) Handles.MH_stbtt_BakeFontBitmap.invokeExact(data, offset, pixel_height, pixels, pw, ph, first_char, num_chars, Marshal.marshal(chardata));
         } catch (Throwable e) { throw new RuntimeException("error in stbtt_BakeFontBitmap", e); }
     }
 
-    ///Call GetBakedQuad with char_index = 'character - first_char', and it
-    ///creates the quad you need to draw and advances the current position.
-    ///
-    ///The coordinate system used assumes y increases downwards.
-    ///
-    ///Characters will extend both above and below the current position;
-    ///see discussion of "BASELINE" above.
-    ///
-    ///It's inefficient; you might want to c&p it and optimize it.
     public static void stbtt_GetBakedQuad(@CType("const stbtt_bakedchar *") java.lang.foreign.MemorySegment chardata, @CType("int") int pw, @CType("int") int ph, @CType("int") int char_index, @Out @CType("float*") java.lang.foreign.MemorySegment xpos, @Out @CType("float*") java.lang.foreign.MemorySegment ypos, @CType("stbtt_aligned_quad *") java.lang.foreign.MemorySegment q, @CType("int") boolean opengl_fillrule) {
         try {
             Handles.MH_stbtt_GetBakedQuad.invokeExact(chardata, pw, ph, char_index, xpos, ypos, q, opengl_fillrule);
         } catch (Throwable e) { throw new RuntimeException("error in stbtt_GetBakedQuad", e); }
     }
 
-    ///Call GetBakedQuad with char_index = 'character - first_char', and it
-    ///creates the quad you need to draw and advances the current position.
-    ///
-    ///The coordinate system used assumes y increases downwards.
-    ///
-    ///Characters will extend both above and below the current position;
-    ///see discussion of "BASELINE" above.
-    ///
-    ///It's inefficient; you might want to c&p it and optimize it.
     public static void stbtt_GetBakedQuad(@CType("const stbtt_bakedchar *") overrungl.stb.STBTTBakedChar chardata, @CType("int") int pw, @CType("int") int ph, @CType("int") int char_index, @Out @CType("float*") float[] xpos, @Out @CType("float*") float[] ypos, @CType("stbtt_aligned_quad *") overrungl.stb.STBTTAlignedQuad q, @CType("int") boolean opengl_fillrule) {
         try (var __overrungl_stack = MemoryStack.pushLocal()) {
             var __overrungl_ref_xpos = Marshal.marshal(__overrungl_stack, xpos);
@@ -554,14 +258,12 @@ public final class STBTrueType {
         } catch (Throwable e) { throw new RuntimeException("error in stbtt_GetBakedQuad", e); }
     }
 
-    ///Query the font vertical metrics without having to create a font first.
     public static void stbtt_GetScaledFontVMetrics(@CType("const unsigned char *") java.lang.foreign.MemorySegment fontdata, @CType("int") int index, @CType("float") float size, @Out @CType("float*") java.lang.foreign.MemorySegment ascent, @Out @CType("float*") java.lang.foreign.MemorySegment descent, @Out @CType("float*") java.lang.foreign.MemorySegment lineGap) {
         try {
             Handles.MH_stbtt_GetScaledFontVMetrics.invokeExact(fontdata, index, size, ascent, descent, lineGap);
         } catch (Throwable e) { throw new RuntimeException("error in stbtt_GetScaledFontVMetrics", e); }
     }
 
-    ///Query the font vertical metrics without having to create a font first.
     public static void stbtt_GetScaledFontVMetrics(@CType("const unsigned char *") java.lang.foreign.MemorySegment fontdata, @CType("int") int index, @CType("float") float size, @Out @CType("float*") float[] ascent, @Out @CType("float*") float[] descent, @Out @CType("float*") float[] lineGap) {
         try (var __overrungl_stack = MemoryStack.pushLocal()) {
             var __overrungl_ref_ascent = Marshal.marshal(__overrungl_stack, ascent);
@@ -574,122 +276,54 @@ public final class STBTrueType {
         } catch (Throwable e) { throw new RuntimeException("error in stbtt_GetScaledFontVMetrics", e); }
     }
 
-    ///Initializes a packing context stored in the passed-in stbtt_pack_context.
-    ///Future calls using this context will pack characters into the bitmap passed
-    ///in here: a 1-channel bitmap that is width * height. stride_in_bytes is
-    ///the distance from one row to the next (or 0 to mean they are packed tightly
-    ///together). "padding" is the amount of padding to leave between each
-    ///character (normally you want '1' for bitmaps you'll use as textures with
-    ///bilinear filtering).
-    ///
-    ///Returns `false` on failure, `true` on success.
     public static @CType("int") boolean stbtt_PackBegin(@CType("stbtt_pack_context *") java.lang.foreign.MemorySegment spc, @CType("unsigned char *") java.lang.foreign.MemorySegment pixels, @CType("int") int width, @CType("int") int height, @CType("int") int stride_in_bytes, @CType("int") int padding, @CType("void*") java.lang.foreign.MemorySegment alloc_context) {
         try {
             return (boolean) Handles.MH_stbtt_PackBegin.invokeExact(spc, pixels, width, height, stride_in_bytes, padding, alloc_context);
         } catch (Throwable e) { throw new RuntimeException("error in stbtt_PackBegin", e); }
     }
 
-    ///Cleans up the packing context and frees all memory.
     public static void stbtt_PackEnd(@CType("stbtt_pack_context *") java.lang.foreign.MemorySegment spc) {
         try {
             Handles.MH_stbtt_PackEnd.invokeExact(spc);
         } catch (Throwable e) { throw new RuntimeException("error in stbtt_PackEnd", e); }
     }
 
-    ///Creates character bitmaps from the font_index'th font found in fontdata (use
-    ///font_index=0 if you don't know what that is). It creates num_chars_in_range
-    ///bitmaps for characters with unicode values starting at first_unicode_char_in_range
-    ///and increasing. Data for how to render them is stored in chardata_for_range;
-    ///pass these to stbtt_GetPackedQuad to get back renderable quads.
-    ///
-    ///font_size is the full height of the character from ascender to descender,
-    ///as computed by stbtt_ScaleForPixelHeight. To use a point size as computed
-    ///by stbtt_ScaleForMappingEmToPixels, wrap the point size in STBTT_POINT_SIZE()
-    ///and pass that result as 'font_size':
-    ///```
-    ///...,                  20 , ... // font max minus min y is 20 pixels tall
-    ///..., STBTT_POINT_SIZE(20), ... // 'M' is 20 pixels tall
-    ///```
     public static @CType("int") boolean stbtt_PackFontRange(@CType("stbtt_pack_context *") java.lang.foreign.MemorySegment spc, @CType("const unsigned char *") java.lang.foreign.MemorySegment fontdata, @CType("int") int font_index, @CType("float") float font_size, @CType("int") int first_unicode_char_in_range, @CType("int") int num_chars_in_range, @CType("stbtt_packedchar *") java.lang.foreign.MemorySegment chardata_for_range) {
         try {
             return (boolean) Handles.MH_stbtt_PackFontRange.invokeExact(spc, fontdata, font_index, font_size, first_unicode_char_in_range, num_chars_in_range, chardata_for_range);
         } catch (Throwable e) { throw new RuntimeException("error in stbtt_PackFontRange", e); }
     }
 
-    ///Creates character bitmaps from multiple ranges of characters stored in
-    ///ranges. This will usually create a better-packed bitmap than multiple
-    ///calls to stbtt_PackFontRange. Note that you can call this multiple
-    ///times within a single PackBegin/PackEnd.
     public static @CType("int") boolean stbtt_PackFontRanges(@CType("stbtt_pack_context *") java.lang.foreign.MemorySegment spc, @CType("const unsigned char *") java.lang.foreign.MemorySegment fontdata, @CType("int") int font_index, @CType("stbtt_pack_range *") java.lang.foreign.MemorySegment ranges, @CType("int") int num_ranges) {
         try {
             return (boolean) Handles.MH_stbtt_PackFontRanges.invokeExact(spc, fontdata, font_index, ranges, num_ranges);
         } catch (Throwable e) { throw new RuntimeException("error in stbtt_PackFontRanges", e); }
     }
 
-    ///Creates character bitmaps from multiple ranges of characters stored in
-    ///ranges. This will usually create a better-packed bitmap than multiple
-    ///calls to stbtt_PackFontRange. Note that you can call this multiple
-    ///times within a single PackBegin/PackEnd.
     public static @CType("int") boolean stbtt_PackFontRanges(@CType("stbtt_pack_context *") java.lang.foreign.MemorySegment spc, @CType("const unsigned char *") java.lang.foreign.MemorySegment fontdata, @CType("int") int font_index, @CType("stbtt_pack_range *") overrungl.stb.STBTTPackRange ranges, @CType("int") int num_ranges) {
         try {
             return (boolean) Handles.MH_stbtt_PackFontRanges.invokeExact(spc, fontdata, font_index, Marshal.marshal(ranges), num_ranges);
         } catch (Throwable e) { throw new RuntimeException("error in stbtt_PackFontRanges", e); }
     }
 
-    ///Oversampling a font increases the quality by allowing higher-quality subpixel
-    ///positioning, and is especially valuable at smaller text sizes.
-    ///
-    ///This function sets the amount of oversampling for all following calls to
-    ///stbtt_PackFontRange(s) or stbtt_PackFontRangesGatherRects for a given
-    ///pack context. The default (no oversampling) is achieved by h_oversample=1
-    ///and v_oversample=1. The total number of pixels required is
-    ///h_oversample*v_oversample larger than the default; for example, 2x2
-    ///oversampling requires 4x the storage of 1x1. For best results, render
-    ///oversampled textures with bilinear filtering. Look at the readme in
-    ///stb/tests/oversample for information about oversampled fonts
-    ///
-    ///To use with PackFontRangesGather etc., you must set it before calls
-    ///call to PackFontRangesGatherRects.
     public static void stbtt_PackSetOversampling(@CType("stbtt_pack_context *") java.lang.foreign.MemorySegment spc, @CType("unsigned int") int h_oversample, @CType("unsigned int") int v_oversample) {
         try {
             Handles.MH_stbtt_PackSetOversampling.invokeExact(spc, h_oversample, v_oversample);
         } catch (Throwable e) { throw new RuntimeException("error in stbtt_PackSetOversampling", e); }
     }
 
-    ///If skip != 0, this tells stb_truetype to skip any codepoints for which
-    ///there is no corresponding glyph. If skip=0, which is the default, then
-    ///codepoints without a glyph recived the font's "missing character" glyph,
-    ///typically an empty box by convention.
     public static void stbtt_PackSetSkipMissingCodepoints(@CType("stbtt_pack_context *") java.lang.foreign.MemorySegment spc, @CType("int") boolean skip) {
         try {
             Handles.MH_stbtt_PackSetSkipMissingCodepoints.invokeExact(spc, skip);
         } catch (Throwable e) { throw new RuntimeException("error in stbtt_PackSetSkipMissingCodepoints", e); }
     }
 
-    ///Calling these functions in sequence is roughly equivalent to calling
-    ///stbtt_PackFontRanges(). If you more control over the packing of multiple
-    ///fonts, or if you want to pack custom data into a font texture, take a look
-    ///at the source to of stbtt_PackFontRanges() and create a custom version
-    ///using these functions, e.g. call GatherRects multiple times,
-    ///building up a single array of rects, then call PackRects once,
-    ///then call RenderIntoRects repeatedly. This may result in a
-    ///better packing than calling PackFontRanges multiple times
-    ///(or it may not).
     public static void stbtt_GetPackedQuad(@CType("const stbtt_packedchar *") java.lang.foreign.MemorySegment chardata, @CType("int") int pw, @CType("int") int ph, @CType("int") int char_index, @Out @CType("float*") java.lang.foreign.MemorySegment xpos, @Out @CType("float*") java.lang.foreign.MemorySegment ypos, @CType("stbtt_aligned_quad *") java.lang.foreign.MemorySegment q, @CType("int") boolean align_to_integer) {
         try {
             Handles.MH_stbtt_GetPackedQuad.invokeExact(chardata, pw, ph, char_index, xpos, ypos, q, align_to_integer);
         } catch (Throwable e) { throw new RuntimeException("error in stbtt_GetPackedQuad", e); }
     }
 
-    ///Calling these functions in sequence is roughly equivalent to calling
-    ///stbtt_PackFontRanges(). If you more control over the packing of multiple
-    ///fonts, or if you want to pack custom data into a font texture, take a look
-    ///at the source to of stbtt_PackFontRanges() and create a custom version
-    ///using these functions, e.g. call GatherRects multiple times,
-    ///building up a single array of rects, then call PackRects once,
-    ///then call RenderIntoRects repeatedly. This may result in a
-    ///better packing than calling PackFontRanges multiple times
-    ///(or it may not).
     public static void stbtt_GetPackedQuad(@CType("const stbtt_packedchar *") overrungl.stb.STBTTPackedChar chardata, @CType("int") int pw, @CType("int") int ph, @CType("int") int char_index, @Out @CType("float*") float[] xpos, @Out @CType("float*") float[] ypos, @CType("stbtt_aligned_quad *") overrungl.stb.STBTTAlignedQuad q, @CType("int") boolean align_to_integer) {
         try (var __overrungl_stack = MemoryStack.pushLocal()) {
             var __overrungl_ref_xpos = Marshal.marshal(__overrungl_stack, xpos);
@@ -718,94 +352,48 @@ public final class STBTrueType {
         } catch (Throwable e) { throw new RuntimeException("error in stbtt_PackFontRangesRenderIntoRects", e); }
     }
 
-    ///This function will determine the number of fonts in a font file.  TrueType
-    ///collection (.ttc) files may contain multiple fonts, while TrueType font
-    ///(.ttf) files only contain one font. The number of fonts can be used for
-    ///indexing with the previous function where the index is between zero and one
-    ///less than the total fonts. If an error occurs, -1 is returned.
     public static @CType("int") int stbtt_GetNumberOfFonts(@CType("const unsigned char *") java.lang.foreign.MemorySegment data) {
         try {
             return (int) Handles.MH_stbtt_GetNumberOfFonts.invokeExact(data);
         } catch (Throwable e) { throw new RuntimeException("error in stbtt_GetNumberOfFonts", e); }
     }
 
-    ///Each .ttf/.ttc file may have more than one font. Each font has a sequential
-    ///index number starting from 0. Call this function to get the font offset for
-    ///a given index; it returns -1 if the index is out of range. A regular .ttf
-    ///file will only define one font and it always be at offset 0, so it will
-    ///return '0' for index 0, and -1 for all other indices.
     public static @CType("int") int stbtt_GetFontOffsetForIndex(@CType("const unsigned char *") java.lang.foreign.MemorySegment data, @CType("int") int index) {
         try {
             return (int) Handles.MH_stbtt_GetFontOffsetForIndex.invokeExact(data, index);
         } catch (Throwable e) { throw new RuntimeException("error in stbtt_GetFontOffsetForIndex", e); }
     }
 
-    ///Given an offset into the file that defines a font, this function builds
-    ///the necessary cached info for the rest of the system. You must allocate
-    ///the stbtt_fontinfo yourself, and stbtt_InitFont will fill it out. You don't
-    ///need to do anything special to free it, because the contents are pure
-    ///value data with no additional data structures.
-    ///@return 0 on failure.
     public static @CType("int") boolean stbtt_InitFont(@CType("stbtt_fontinfo *") java.lang.foreign.MemorySegment info, @CType("const unsigned char *") java.lang.foreign.MemorySegment data, @CType("int") int offset) {
         try {
             return (boolean) Handles.MH_stbtt_InitFont.invokeExact(info, data, offset);
         } catch (Throwable e) { throw new RuntimeException("error in stbtt_InitFont", e); }
     }
 
-    ///If you're going to perform multiple operations on the same character
-    ///and you want a speed-up, call this function with the character you're
-    ///going to process, then use glyph-based functions instead of the
-    ///codepoint-based functions.
-    ///@return 0 if the character codepoint is not defined in the font.
     public static @CType("int") int stbtt_FindGlyphIndex(@CType("const stbtt_fontinfo *") java.lang.foreign.MemorySegment info, @CType("int") int unicode_codepoint) {
         try {
             return (int) Handles.MH_stbtt_FindGlyphIndex.invokeExact(info, unicode_codepoint);
         } catch (Throwable e) { throw new RuntimeException("error in stbtt_FindGlyphIndex", e); }
     }
 
-    ///computes a scale factor to produce a font whose "height" is 'pixels' tall.
-    ///Height is measured as the distance from the highest ascender to the lowest
-    ///descender; in other words, it's equivalent to calling stbtt_GetFontVMetrics
-    ///and computing:
-    ///```
-    ///scale = pixels / (ascent - descent)
-    ///```
-    ///so if you prefer to measure height by the ascent only, use a similar calculation.
     public static @CType("float") float stbtt_ScaleForPixelHeight(@CType("const stbtt_fontinfo *") java.lang.foreign.MemorySegment info, @CType("float") float pixels) {
         try {
             return (float) Handles.MH_stbtt_ScaleForPixelHeight.invokeExact(info, pixels);
         } catch (Throwable e) { throw new RuntimeException("error in stbtt_ScaleForPixelHeight", e); }
     }
 
-    ///computes a scale factor to produce a font whose EM size is mapped to
-    ///'pixels' tall. This is probably what traditional APIs compute, but
-    ///I'm not positive.
     public static @CType("float") float stbtt_ScaleForMappingEmToPixels(@CType("const stbtt_fontinfo *") java.lang.foreign.MemorySegment info, @CType("float") float pixels) {
         try {
             return (float) Handles.MH_stbtt_ScaleForMappingEmToPixels.invokeExact(info, pixels);
         } catch (Throwable e) { throw new RuntimeException("error in stbtt_ScaleForMappingEmToPixels", e); }
     }
 
-    ///these are expressed in unscaled coordinates, so you must multiply by
-    ///the scale factor for a given size
-    ///
-    ///@param ascent the coordinate above the baseline the font extends
-    ///@param descent the coordinate below the baseline the font extends (i.e. it is typically negative)
-    ///@param lineGap the spacing between one row's descent and the next row's ascent...
-    ///so you should advance the vertical position by "*ascent - *descent + *lineGap"
     public static void stbtt_GetFontVMetrics(@CType("const stbtt_fontinfo *") java.lang.foreign.MemorySegment info, @Out @CType("int*") java.lang.foreign.MemorySegment ascent, @Out @CType("int*") java.lang.foreign.MemorySegment descent, @Out @CType("int*") java.lang.foreign.MemorySegment lineGap) {
         try {
             Handles.MH_stbtt_GetFontVMetrics.invokeExact(info, ascent, descent, lineGap);
         } catch (Throwable e) { throw new RuntimeException("error in stbtt_GetFontVMetrics", e); }
     }
 
-    ///these are expressed in unscaled coordinates, so you must multiply by
-    ///the scale factor for a given size
-    ///
-    ///@param ascent the coordinate above the baseline the font extends
-    ///@param descent the coordinate below the baseline the font extends (i.e. it is typically negative)
-    ///@param lineGap the spacing between one row's descent and the next row's ascent...
-    ///so you should advance the vertical position by "*ascent - *descent + *lineGap"
     public static void stbtt_GetFontVMetrics(@CType("const stbtt_fontinfo *") overrungl.stb.STBTTFontInfo info, @Out @CType("int*") int[] ascent, @Out @CType("int*") int[] descent, @Out @CType("int*") int[] lineGap) {
         try (var __overrungl_stack = MemoryStack.pushLocal()) {
             var __overrungl_ref_ascent = Marshal.marshal(__overrungl_stack, ascent);
@@ -818,20 +406,12 @@ public final class STBTrueType {
         } catch (Throwable e) { throw new RuntimeException("error in stbtt_GetFontVMetrics", e); }
     }
 
-    ///analogous to GetFontVMetrics, but returns the "typographic" values from the OS/2
-    ///table (specific to MS/Windows TTF files).
-    ///
-    ///@return 1 on success (table present), 0 on failure.
     public static @CType("int") boolean stbtt_GetFontVMetricsOS2(@CType("const stbtt_fontinfo *") java.lang.foreign.MemorySegment info, @Out @CType("int*") java.lang.foreign.MemorySegment typoAscent, @Out @CType("int*") java.lang.foreign.MemorySegment typoDescent, @Out @CType("int*") java.lang.foreign.MemorySegment typoLineGap) {
         try {
             return (boolean) Handles.MH_stbtt_GetFontVMetricsOS2.invokeExact(info, typoAscent, typoDescent, typoLineGap);
         } catch (Throwable e) { throw new RuntimeException("error in stbtt_GetFontVMetricsOS2", e); }
     }
 
-    ///analogous to GetFontVMetrics, but returns the "typographic" values from the OS/2
-    ///table (specific to MS/Windows TTF files).
-    ///
-    ///@return 1 on success (table present), 0 on failure.
     public static @CType("int") boolean stbtt_GetFontVMetricsOS2(@CType("const stbtt_fontinfo *") overrungl.stb.STBTTFontInfo info, @Out @CType("int*") int[] typoAscent, @Out @CType("int*") int[] typoDescent, @Out @CType("int*") int[] typoLineGap) {
         try (var __overrungl_stack = MemoryStack.pushLocal()) {
             var __overrungl_ref_typoAscent = Marshal.marshal(__overrungl_stack, typoAscent);
@@ -845,14 +425,12 @@ public final class STBTrueType {
         } catch (Throwable e) { throw new RuntimeException("error in stbtt_GetFontVMetricsOS2", e); }
     }
 
-    ///the bounding box around all possible characters
     public static void stbtt_GetFontBoundingBox(@CType("const stbtt_fontinfo *") java.lang.foreign.MemorySegment info, @Out @CType("int*") java.lang.foreign.MemorySegment x0, @Out @CType("int*") java.lang.foreign.MemorySegment y0, @Out @CType("int*") java.lang.foreign.MemorySegment x1, @Out @CType("int*") java.lang.foreign.MemorySegment y1) {
         try {
             Handles.MH_stbtt_GetFontBoundingBox.invokeExact(info, x0, y0, x1, y1);
         } catch (Throwable e) { throw new RuntimeException("error in stbtt_GetFontBoundingBox", e); }
     }
 
-    ///the bounding box around all possible characters
     public static void stbtt_GetFontBoundingBox(@CType("const stbtt_fontinfo *") overrungl.stb.STBTTFontInfo info, @Out @CType("int*") int[] x0, @Out @CType("int*") int[] y0, @Out @CType("int*") int[] x1, @Out @CType("int*") int[] y1) {
         try (var __overrungl_stack = MemoryStack.pushLocal()) {
             var __overrungl_ref_x0 = Marshal.marshal(__overrungl_stack, x0);
@@ -867,18 +445,12 @@ public final class STBTrueType {
         } catch (Throwable e) { throw new RuntimeException("error in stbtt_GetFontBoundingBox", e); }
     }
 
-    ///these are expressed in unscaled coordinates
-    ///@param advanceWidth the offset from the current horizontal position to the next horizontal position
-    ///@param leftSideBearing the offset from the current horizontal position to the left edge of the character
     public static void stbtt_GetCodepointHMetrics(@CType("const stbtt_fontinfo *") java.lang.foreign.MemorySegment info, @CType("int") int codepoint, @Out @CType("int*") java.lang.foreign.MemorySegment advanceWidth, @Out @CType("int*") java.lang.foreign.MemorySegment leftSideBearing) {
         try {
             Handles.MH_stbtt_GetCodepointHMetrics.invokeExact(info, codepoint, advanceWidth, leftSideBearing);
         } catch (Throwable e) { throw new RuntimeException("error in stbtt_GetCodepointHMetrics", e); }
     }
 
-    ///these are expressed in unscaled coordinates
-    ///@param advanceWidth the offset from the current horizontal position to the next horizontal position
-    ///@param leftSideBearing the offset from the current horizontal position to the left edge of the character
     public static void stbtt_GetCodepointHMetrics(@CType("const stbtt_fontinfo *") overrungl.stb.STBTTFontInfo info, @CType("int") int codepoint, @Out @CType("int*") int[] advanceWidth, @Out @CType("int*") int[] leftSideBearing) {
         try (var __overrungl_stack = MemoryStack.pushLocal()) {
             var __overrungl_ref_advanceWidth = Marshal.marshal(__overrungl_stack, advanceWidth);
@@ -889,21 +461,18 @@ public final class STBTrueType {
         } catch (Throwable e) { throw new RuntimeException("error in stbtt_GetCodepointHMetrics", e); }
     }
 
-    ///an additional amount to add to the 'advance' value between ch1 and ch2
     public static @CType("int") int stbtt_GetCodepointKernAdvance(@CType("const stbtt_fontinfo *") java.lang.foreign.MemorySegment info, @CType("int") int ch1, @CType("int") int ch2) {
         try {
             return (int) Handles.MH_stbtt_GetCodepointKernAdvance.invokeExact(info, ch1, ch2);
         } catch (Throwable e) { throw new RuntimeException("error in stbtt_GetCodepointKernAdvance", e); }
     }
 
-    ///Gets the bounding box of the visible part of the glyph, in unscaled coordinates
     public static @CType("int") int stbtt_GetCodepointBox(@CType("const stbtt_fontinfo *") java.lang.foreign.MemorySegment info, @CType("int") int codepoint, @Out @CType("int*") java.lang.foreign.MemorySegment x0, @Out @CType("int*") java.lang.foreign.MemorySegment y0, @Out @CType("int*") java.lang.foreign.MemorySegment x1, @Out @CType("int*") java.lang.foreign.MemorySegment y1) {
         try {
             return (int) Handles.MH_stbtt_GetCodepointBox.invokeExact(info, codepoint, x0, y0, x1, y1);
         } catch (Throwable e) { throw new RuntimeException("error in stbtt_GetCodepointBox", e); }
     }
 
-    ///Gets the bounding box of the visible part of the glyph, in unscaled coordinates
     public static @CType("int") int stbtt_GetCodepointBox(@CType("const stbtt_fontinfo *") overrungl.stb.STBTTFontInfo info, @CType("int") int codepoint, @Out @CType("int*") int[] x0, @Out @CType("int*") int[] y0, @Out @CType("int*") int[] x1, @Out @CType("int*") int[] y1) {
         try (var __overrungl_stack = MemoryStack.pushLocal()) {
             var __overrungl_ref_x0 = Marshal.marshal(__overrungl_stack, x0);
@@ -919,14 +488,12 @@ public final class STBTrueType {
         } catch (Throwable e) { throw new RuntimeException("error in stbtt_GetCodepointBox", e); }
     }
 
-    ///as above, but takes one or more glyph indices for greater efficiency
     public static void stbtt_GetGlyphHMetrics(@CType("const stbtt_fontinfo *") java.lang.foreign.MemorySegment info, @CType("int") int glyph_index, @Out @CType("int*") java.lang.foreign.MemorySegment advanceWidth, @Out @CType("int*") java.lang.foreign.MemorySegment leftSideBearing) {
         try {
             Handles.MH_stbtt_GetGlyphHMetrics.invokeExact(info, glyph_index, advanceWidth, leftSideBearing);
         } catch (Throwable e) { throw new RuntimeException("error in stbtt_GetGlyphHMetrics", e); }
     }
 
-    ///as above, but takes one or more glyph indices for greater efficiency
     public static void stbtt_GetGlyphHMetrics(@CType("const stbtt_fontinfo *") overrungl.stb.STBTTFontInfo info, @CType("int") int glyph_index, @Out @CType("int*") int[] advanceWidth, @Out @CType("int*") int[] leftSideBearing) {
         try (var __overrungl_stack = MemoryStack.pushLocal()) {
             var __overrungl_ref_advanceWidth = Marshal.marshal(__overrungl_stack, advanceWidth);
@@ -970,60 +537,36 @@ public final class STBTrueType {
         } catch (Throwable e) { throw new RuntimeException("error in stbtt_GetKerningTableLength", e); }
     }
 
-    ///Retrieves a complete list of all of the kerning pairs provided by the font
-    ///stbtt_GetKerningTable never writes more than table_length entries and returns how many entries it did write.
-    ///The table will be sorted by (a.glyph1 == b.glyph1)?(a.glyph2 < b.glyph2):(a.glyph1 < b.glyph1)
     public static @CType("int") int stbtt_GetKerningTable(@CType("const stbtt_fontinfo *") java.lang.foreign.MemorySegment info, @CType("stbtt_kerningentry*") java.lang.foreign.MemorySegment table, @CType("int") int table_length) {
         try {
             return (int) Handles.MH_stbtt_GetKerningTable.invokeExact(info, table, table_length);
         } catch (Throwable e) { throw new RuntimeException("error in stbtt_GetKerningTable", e); }
     }
 
-    ///@return `true` if nothing is drawn for this glyph
     public static @CType("int") boolean stbtt_IsGlyphEmpty(@CType("const stbtt_fontinfo *") java.lang.foreign.MemorySegment info, @CType("int") int glyph_index) {
         try {
             return (boolean) Handles.MH_stbtt_IsGlyphEmpty.invokeExact(info, glyph_index);
         } catch (Throwable e) { throw new RuntimeException("error in stbtt_IsGlyphEmpty", e); }
     }
 
-    ///{@return # of vertices and fills *vertices with the pointer to them}
-    ///these are expressed in "unscaled" coordinates
-    ///
-    ///The shape is a series of contours. Each one starts with
-    ///a STBTT_moveto, then consists of a series of mixed
-    ///STBTT_lineto and STBTT_curveto segments. A lineto
-    ///draws a line from previous endpoint to its x,y; a curveto
-    ///draws a quadratic bezier from previous endpoint to
-    ///its x,y, using cx,cy as the bezier control point.
     public static @CType("int") int stbtt_GetCodepointShape(@CType("const stbtt_fontinfo *") java.lang.foreign.MemorySegment info, @CType("int") int unicode_codepoint, @CType("stbtt_vertex **") java.lang.foreign.MemorySegment vertices) {
         try {
             return (int) Handles.MH_stbtt_GetCodepointShape.invokeExact(info, unicode_codepoint, vertices);
         } catch (Throwable e) { throw new RuntimeException("error in stbtt_GetCodepointShape", e); }
     }
 
-    ///{@return # of vertices and fills *vertices with the pointer to them}
-    ///these are expressed in "unscaled" coordinates
-    ///
-    ///The shape is a series of contours. Each one starts with
-    ///a STBTT_moveto, then consists of a series of mixed
-    ///STBTT_lineto and STBTT_curveto segments. A lineto
-    ///draws a line from previous endpoint to its x,y; a curveto
-    ///draws a quadratic bezier from previous endpoint to
-    ///its x,y, using cx,cy as the bezier control point.
     public static @CType("int") int stbtt_GetGlyphShape(@CType("const stbtt_fontinfo *") java.lang.foreign.MemorySegment info, @CType("int") int glyph_index, @CType("stbtt_vertex **") java.lang.foreign.MemorySegment vertices) {
         try {
             return (int) Handles.MH_stbtt_GetGlyphShape.invokeExact(info, glyph_index, vertices);
         } catch (Throwable e) { throw new RuntimeException("error in stbtt_GetGlyphShape", e); }
     }
 
-    ///frees the data allocated above
     public static void stbtt_FreeShape(@CType("const stbtt_fontinfo *") java.lang.foreign.MemorySegment info, @CType("stbtt_vertex *") java.lang.foreign.MemorySegment vertices) {
         try {
             Handles.MH_stbtt_FreeShape.invokeExact(info, vertices);
         } catch (Throwable e) { throw new RuntimeException("error in stbtt_FreeShape", e); }
     }
 
-    ///frees the data allocated above
     public static void stbtt_FreeShape(@CType("const stbtt_fontinfo *") overrungl.stb.STBTTFontInfo info, @CType("stbtt_vertex *") overrungl.stb.STBTTVertex vertices) {
         try {
             Handles.MH_stbtt_FreeShape.invokeExact(Marshal.marshal(info), Marshal.marshal(vertices));
@@ -1036,49 +579,30 @@ public final class STBTrueType {
         } catch (Throwable e) { throw new RuntimeException("error in stbtt_FindSVGDoc", e); }
     }
 
-    ///fills svg with the character's SVG data.
-    ///@return data size or 0 if SVG not found.
     public static @CType("int") int stbtt_GetCodepointSVG(@CType("const stbtt_fontinfo *") java.lang.foreign.MemorySegment info, @CType("int") int unicode_codepoint, @CType("const char **") java.lang.foreign.MemorySegment svg) {
         try {
             return (int) Handles.MH_stbtt_GetCodepointSVG.invokeExact(info, unicode_codepoint, svg);
         } catch (Throwable e) { throw new RuntimeException("error in stbtt_GetCodepointSVG", e); }
     }
 
-    ///fills svg with the character's SVG data.
-    ///@return data size or 0 if SVG not found.
     public static @CType("int") int stbtt_GetGlyphSVG(@CType("const stbtt_fontinfo *") java.lang.foreign.MemorySegment info, @CType("int") int gl, @CType("const char **") java.lang.foreign.MemorySegment svg) {
         try {
             return (int) Handles.MH_stbtt_GetGlyphSVG.invokeExact(info, gl, svg);
         } catch (Throwable e) { throw new RuntimeException("error in stbtt_GetGlyphSVG", e); }
     }
 
-    ///frees the bitmap allocated below
     public static void stbtt_FreeBitmap(@CType("unsigned char *") java.lang.foreign.MemorySegment bitmap, @CType("void*") java.lang.foreign.MemorySegment userdata) {
         try {
             Handles.MH_stbtt_FreeBitmap.invokeExact(bitmap, userdata);
         } catch (Throwable e) { throw new RuntimeException("error in stbtt_FreeBitmap", e); }
     }
 
-    ///allocates a large-enough single-channel 8bpp bitmap and renders the
-    ///specified character/glyph at the specified scale into it, with
-    ///antialiasing. 0 is no coverage (transparent), 255 is fully covered (opaque).
-    ///*width & *height are filled out with the width & height of the bitmap,
-    ///which is stored left-to-right, top-to-bottom.
-    ///
-    ///xoff/yoff are the offset it pixel space from the glyph origin to the top-left of the bitmap
     public static @CType("unsigned char *") java.lang.foreign.MemorySegment stbtt_GetCodepointBitmap(@CType("const stbtt_fontinfo *") java.lang.foreign.MemorySegment info, @CType("float") float scale_x, @CType("float") float scale_y, @CType("int") int codepoint, @Out @CType("int*") java.lang.foreign.MemorySegment width, @Out @CType("int*") java.lang.foreign.MemorySegment height, @Out @CType("int*") java.lang.foreign.MemorySegment xoff, @Out @CType("int*") java.lang.foreign.MemorySegment yoff) {
         try {
             return (java.lang.foreign.MemorySegment) Handles.MH_stbtt_GetCodepointBitmap.invokeExact(info, scale_x, scale_y, codepoint, width, height, xoff, yoff);
         } catch (Throwable e) { throw new RuntimeException("error in stbtt_GetCodepointBitmap", e); }
     }
 
-    ///allocates a large-enough single-channel 8bpp bitmap and renders the
-    ///specified character/glyph at the specified scale into it, with
-    ///antialiasing. 0 is no coverage (transparent), 255 is fully covered (opaque).
-    ///*width & *height are filled out with the width & height of the bitmap,
-    ///which is stored left-to-right, top-to-bottom.
-    ///
-    ///xoff/yoff are the offset it pixel space from the glyph origin to the top-left of the bitmap
     public static @CType("unsigned char *") java.lang.foreign.MemorySegment stbtt_GetCodepointBitmap(@CType("const stbtt_fontinfo *") overrungl.stb.STBTTFontInfo info, @CType("float") float scale_x, @CType("float") float scale_y, @CType("int") int codepoint, @Out @CType("int*") int[] width, @Out @CType("int*") int[] height, @Out @CType("int*") int[] xoff, @Out @CType("int*") int[] yoff) {
         try (var __overrungl_stack = MemoryStack.pushLocal()) {
             var __overrungl_ref_width = Marshal.marshal(__overrungl_stack, width);
@@ -1094,16 +618,12 @@ public final class STBTrueType {
         } catch (Throwable e) { throw new RuntimeException("error in stbtt_GetCodepointBitmap", e); }
     }
 
-    ///the same as stbtt_GetCodepointBitmap, but you can specify a subpixel
-    ///shift for the character
     public static @CType("unsigned char *") java.lang.foreign.MemorySegment stbtt_GetCodepointBitmapSubpixel(@CType("const stbtt_fontinfo *") java.lang.foreign.MemorySegment info, @CType("float") float scale_x, @CType("float") float scale_y, @CType("float") float shift_x, @CType("float") float shift_y, @CType("int") int codepoint, @Out @CType("int*") java.lang.foreign.MemorySegment width, @Out @CType("int*") java.lang.foreign.MemorySegment height, @Out @CType("int*") java.lang.foreign.MemorySegment xoff, @Out @CType("int*") java.lang.foreign.MemorySegment yoff) {
         try {
             return (java.lang.foreign.MemorySegment) Handles.MH_stbtt_GetCodepointBitmapSubpixel.invokeExact(info, scale_x, scale_y, shift_x, shift_y, codepoint, width, height, xoff, yoff);
         } catch (Throwable e) { throw new RuntimeException("error in stbtt_GetCodepointBitmapSubpixel", e); }
     }
 
-    ///the same as stbtt_GetCodepointBitmap, but you can specify a subpixel
-    ///shift for the character
     public static @CType("unsigned char *") java.lang.foreign.MemorySegment stbtt_GetCodepointBitmapSubpixel(@CType("const stbtt_fontinfo *") overrungl.stb.STBTTFontInfo info, @CType("float") float scale_x, @CType("float") float scale_y, @CType("float") float shift_x, @CType("float") float shift_y, @CType("int") int codepoint, @Out @CType("int*") int[] width, @Out @CType("int*") int[] height, @Out @CType("int*") int[] xoff, @Out @CType("int*") int[] yoff) {
         try (var __overrungl_stack = MemoryStack.pushLocal()) {
             var __overrungl_ref_width = Marshal.marshal(__overrungl_stack, width);
@@ -1119,34 +639,24 @@ public final class STBTrueType {
         } catch (Throwable e) { throw new RuntimeException("error in stbtt_GetCodepointBitmapSubpixel", e); }
     }
 
-    ///the same as stbtt_GetCodepointBitmap, but you pass in storage for the bitmap
-    ///in the form of 'output', with row spacing of 'out_stride' bytes. the bitmap
-    ///is clipped to out_w/out_h bytes. Call stbtt_GetCodepointBitmapBox to get the
-    ///width and height and positioning info for it first.
     public static void stbtt_MakeCodepointBitmap(@CType("const stbtt_fontinfo *") java.lang.foreign.MemorySegment info, @CType("unsigned char *") java.lang.foreign.MemorySegment output, @CType("int") int out_w, @CType("int") int out_h, @CType("int") int out_stride, @CType("float") float scale_x, @CType("float") float scale_y, @CType("int") int codepoint) {
         try {
             Handles.MH_stbtt_MakeCodepointBitmap.invokeExact(info, output, out_w, out_h, out_stride, scale_x, scale_y, codepoint);
         } catch (Throwable e) { throw new RuntimeException("error in stbtt_MakeCodepointBitmap", e); }
     }
 
-    ///same as stbtt_MakeCodepointBitmap, but you can specify a subpixel
-    ///shift for the character
     public static void stbtt_MakeCodepointBitmapSubpixel(@CType("const stbtt_fontinfo *") java.lang.foreign.MemorySegment info, @CType("unsigned char *") java.lang.foreign.MemorySegment output, @CType("int") int out_w, @CType("int") int out_h, @CType("int") int out_stride, @CType("float") float scale_x, @CType("float") float scale_y, @CType("float") float shift_x, @CType("float") float shift_y, @CType("int") int codepoint) {
         try {
             Handles.MH_stbtt_MakeCodepointBitmapSubpixel.invokeExact(info, output, out_w, out_h, out_stride, scale_x, scale_y, shift_x, shift_y, codepoint);
         } catch (Throwable e) { throw new RuntimeException("error in stbtt_MakeCodepointBitmapSubpixel", e); }
     }
 
-    ///same as stbtt_MakeCodepointBitmapSubpixel, but prefiltering
-    ///is performed (see stbtt_PackSetOversampling)
     public static void stbtt_MakeCodepointBitmapSubpixelPrefilter(@CType("const stbtt_fontinfo *") java.lang.foreign.MemorySegment info, @CType("unsigned char *") java.lang.foreign.MemorySegment output, @CType("int") int out_w, @CType("int") int out_h, @CType("int") int out_stride, @CType("float") float scale_x, @CType("float") float scale_y, @CType("float") float shift_x, @CType("float") float shift_y, @CType("int") int oversample_x, @CType("int") int oversample_y, @Out @CType("float*") java.lang.foreign.MemorySegment sub_x, @Out @CType("float*") java.lang.foreign.MemorySegment sub_y, @CType("int") int codepoint) {
         try {
             Handles.MH_stbtt_MakeCodepointBitmapSubpixelPrefilter.invokeExact(info, output, out_w, out_h, out_stride, scale_x, scale_y, shift_x, shift_y, oversample_x, oversample_y, sub_x, sub_y, codepoint);
         } catch (Throwable e) { throw new RuntimeException("error in stbtt_MakeCodepointBitmapSubpixelPrefilter", e); }
     }
 
-    ///same as stbtt_MakeCodepointBitmapSubpixel, but prefiltering
-    ///is performed (see stbtt_PackSetOversampling)
     public static void stbtt_MakeCodepointBitmapSubpixelPrefilter(@CType("const stbtt_fontinfo *") overrungl.stb.STBTTFontInfo info, @CType("unsigned char *") java.lang.foreign.MemorySegment output, @CType("int") int out_w, @CType("int") int out_h, @CType("int") int out_stride, @CType("float") float scale_x, @CType("float") float scale_y, @CType("float") float shift_x, @CType("float") float shift_y, @CType("int") int oversample_x, @CType("int") int oversample_y, @Out @CType("float*") float[] sub_x, @Out @CType("float*") float[] sub_y, @CType("int") int codepoint) {
         try (var __overrungl_stack = MemoryStack.pushLocal()) {
             var __overrungl_ref_sub_x = Marshal.marshal(__overrungl_stack, sub_x);
@@ -1157,22 +667,12 @@ public final class STBTrueType {
         } catch (Throwable e) { throw new RuntimeException("error in stbtt_MakeCodepointBitmapSubpixelPrefilter", e); }
     }
 
-    ///get the bbox of the bitmap centered around the glyph origin; so the
-    ///bitmap width is ix1-ix0, height is iy1-iy0, and location to place
-    ///the bitmap top left is (leftSideBearing*scale,iy0).
-    ///(Note that the bitmap uses y-increases-down, but the shape uses
-    ///y-increases-up, so CodepointBitmapBox and CodepointBox are inverted.)
     public static void stbtt_GetCodepointBitmapBox(@CType("const stbtt_fontinfo *") java.lang.foreign.MemorySegment font, @CType("int") int codepoint, @CType("float") float scale_x, @CType("float") float scale_y, @Out @CType("int*") java.lang.foreign.MemorySegment ix0, @Out @CType("int*") java.lang.foreign.MemorySegment iy0, @Out @CType("int*") java.lang.foreign.MemorySegment ix1, @Out @CType("int*") java.lang.foreign.MemorySegment iy1) {
         try {
             Handles.MH_stbtt_GetCodepointBitmapBox.invokeExact(font, codepoint, scale_x, scale_y, ix0, iy0, ix1, iy1);
         } catch (Throwable e) { throw new RuntimeException("error in stbtt_GetCodepointBitmapBox", e); }
     }
 
-    ///get the bbox of the bitmap centered around the glyph origin; so the
-    ///bitmap width is ix1-ix0, height is iy1-iy0, and location to place
-    ///the bitmap top left is (leftSideBearing*scale,iy0).
-    ///(Note that the bitmap uses y-increases-down, but the shape uses
-    ///y-increases-up, so CodepointBitmapBox and CodepointBox are inverted.)
     public static void stbtt_GetCodepointBitmapBox(@CType("const stbtt_fontinfo *") overrungl.stb.STBTTFontInfo font, @CType("int") int codepoint, @CType("float") float scale_x, @CType("float") float scale_y, @Out @CType("int*") int[] ix0, @Out @CType("int*") int[] iy0, @Out @CType("int*") int[] ix1, @Out @CType("int*") int[] iy1) {
         try (var __overrungl_stack = MemoryStack.pushLocal()) {
             var __overrungl_ref_ix0 = Marshal.marshal(__overrungl_stack, ix0);
@@ -1187,16 +687,12 @@ public final class STBTrueType {
         } catch (Throwable e) { throw new RuntimeException("error in stbtt_GetCodepointBitmapBox", e); }
     }
 
-    ///same as stbtt_GetCodepointBitmapBox, but you can specify a subpixel
-    ///shift for the character
     public static void stbtt_GetCodepointBitmapBoxSubpixel(@CType("const stbtt_fontinfo *") java.lang.foreign.MemorySegment font, @CType("int") int codepoint, @CType("float") float scale_x, @CType("float") float scale_y, @CType("float") float shift_x, @CType("float") float shift_y, @Out @CType("int*") java.lang.foreign.MemorySegment ix0, @Out @CType("int*") java.lang.foreign.MemorySegment iy0, @Out @CType("int*") java.lang.foreign.MemorySegment ix1, @Out @CType("int*") java.lang.foreign.MemorySegment iy1) {
         try {
             Handles.MH_stbtt_GetCodepointBitmapBoxSubpixel.invokeExact(font, codepoint, scale_x, scale_y, shift_x, shift_y, ix0, iy0, ix1, iy1);
         } catch (Throwable e) { throw new RuntimeException("error in stbtt_GetCodepointBitmapBoxSubpixel", e); }
     }
 
-    ///same as stbtt_GetCodepointBitmapBox, but you can specify a subpixel
-    ///shift for the character
     public static void stbtt_GetCodepointBitmapBoxSubpixel(@CType("const stbtt_fontinfo *") overrungl.stb.STBTTFontInfo font, @CType("int") int codepoint, @CType("float") float scale_x, @CType("float") float scale_y, @CType("float") float shift_x, @CType("float") float shift_y, @Out @CType("int*") int[] ix0, @Out @CType("int*") int[] iy0, @Out @CType("int*") int[] ix1, @Out @CType("int*") int[] iy1) {
         try (var __overrungl_stack = MemoryStack.pushLocal()) {
             var __overrungl_ref_ix0 = Marshal.marshal(__overrungl_stack, ix0);
@@ -1211,16 +707,12 @@ public final class STBTrueType {
         } catch (Throwable e) { throw new RuntimeException("error in stbtt_GetCodepointBitmapBoxSubpixel", e); }
     }
 
-    ///the following functions are equivalent to the above functions, but operate
-    ///on glyph indices instead of Unicode codepoints (for efficiency)
     public static @CType("unsigned char *") java.lang.foreign.MemorySegment stbtt_GetGlyphBitmap(@CType("const stbtt_fontinfo *") java.lang.foreign.MemorySegment info, @CType("float") float scale_x, @CType("float") float scale_y, @CType("int") int glyph, @Out @CType("int*") java.lang.foreign.MemorySegment width, @Out @CType("int*") java.lang.foreign.MemorySegment height, @Out @CType("int*") java.lang.foreign.MemorySegment xoff, @Out @CType("int*") java.lang.foreign.MemorySegment yoff) {
         try {
             return (java.lang.foreign.MemorySegment) Handles.MH_stbtt_GetGlyphBitmap.invokeExact(info, scale_x, scale_y, glyph, width, height, xoff, yoff);
         } catch (Throwable e) { throw new RuntimeException("error in stbtt_GetGlyphBitmap", e); }
     }
 
-    ///the following functions are equivalent to the above functions, but operate
-    ///on glyph indices instead of Unicode codepoints (for efficiency)
     public static @CType("unsigned char *") java.lang.foreign.MemorySegment stbtt_GetGlyphBitmap(@CType("const stbtt_fontinfo *") overrungl.stb.STBTTFontInfo info, @CType("float") float scale_x, @CType("float") float scale_y, @CType("int") int glyph, @Out @CType("int*") int[] width, @Out @CType("int*") int[] height, @Out @CType("int*") int[] xoff, @Out @CType("int*") int[] yoff) {
         try (var __overrungl_stack = MemoryStack.pushLocal()) {
             var __overrungl_ref_width = Marshal.marshal(__overrungl_stack, width);
@@ -1325,155 +817,30 @@ public final class STBTrueType {
         } catch (Throwable e) { throw new RuntimeException("error in stbtt_GetGlyphBitmapBoxSubpixel", e); }
     }
 
-    ///rasterize a shape with quadratic beziers into a bitmap
-    ///@param result 1-channel bitmap to draw into
-    ///@param flatness_in_pixels allowable error of curve in pixels
-    ///@param vertices array of vertices defining shape
-    ///@param num_verts number of vertices in above array
-    ///@param scale_x scale applied to input vertices
-    ///@param scale_y scale applied to input vertices
-    ///@param shift_x translation applied to input vertices
-    ///@param shift_y translation applied to input vertices
-    ///@param x_off another translation applied to input
-    ///@param y_off another translation applied to input
-    ///@param invert if non-zero, vertically flip shape
-    ///@param userdata context for to STBTT_MALLOC
     public static void stbtt_Rasterize(@CType("stbtt__bitmap *") java.lang.foreign.MemorySegment result, @CType("float") float flatness_in_pixels, @CType("stbtt_vertex *") java.lang.foreign.MemorySegment vertices, @CType("int") int num_verts, @CType("float") float scale_x, @CType("float") float scale_y, @CType("float") float shift_x, @CType("float") float shift_y, @CType("int") int x_off, @CType("int") int y_off, @CType("int") boolean invert, @CType("void*") java.lang.foreign.MemorySegment userdata) {
         try {
             Handles.MH_stbtt_Rasterize.invokeExact(result, flatness_in_pixels, vertices, num_verts, scale_x, scale_y, shift_x, shift_y, x_off, y_off, invert, userdata);
         } catch (Throwable e) { throw new RuntimeException("error in stbtt_Rasterize", e); }
     }
 
-    ///rasterize a shape with quadratic beziers into a bitmap
-    ///@param result 1-channel bitmap to draw into
-    ///@param flatness_in_pixels allowable error of curve in pixels
-    ///@param vertices array of vertices defining shape
-    ///@param num_verts number of vertices in above array
-    ///@param scale_x scale applied to input vertices
-    ///@param scale_y scale applied to input vertices
-    ///@param shift_x translation applied to input vertices
-    ///@param shift_y translation applied to input vertices
-    ///@param x_off another translation applied to input
-    ///@param y_off another translation applied to input
-    ///@param invert if non-zero, vertically flip shape
-    ///@param userdata context for to STBTT_MALLOC
     public static void stbtt_Rasterize(@CType("stbtt__bitmap *") overrungl.stb.STBTT__bitmap result, @CType("float") float flatness_in_pixels, @CType("stbtt_vertex *") overrungl.stb.STBTTVertex vertices, @CType("int") int num_verts, @CType("float") float scale_x, @CType("float") float scale_y, @CType("float") float shift_x, @CType("float") float shift_y, @CType("int") int x_off, @CType("int") int y_off, @CType("int") boolean invert, @CType("void*") java.lang.foreign.MemorySegment userdata) {
         try {
             Handles.MH_stbtt_Rasterize.invokeExact(Marshal.marshal(result), flatness_in_pixels, Marshal.marshal(vertices), num_verts, scale_x, scale_y, shift_x, shift_y, x_off, y_off, invert, userdata);
         } catch (Throwable e) { throw new RuntimeException("error in stbtt_Rasterize", e); }
     }
 
-    ///frees the SDF bitmap allocated below
     public static void stbtt_FreeSDF(@CType("unsigned char *") java.lang.foreign.MemorySegment bitmap, @CType("void*") java.lang.foreign.MemorySegment userdata) {
         try {
             Handles.MH_stbtt_FreeSDF.invokeExact(bitmap, userdata);
         } catch (Throwable e) { throw new RuntimeException("error in stbtt_FreeSDF", e); }
     }
 
-    ///These functions compute a discretized SDF field for a single character, suitable for storing
-    ///in a single-channel texture, sampling with bilinear filtering, and testing against
-    ///larger than some threshold to produce scalable fonts.
-    ///
-    ///pixel_dist_scale & onedge_value are a scale & bias that allows you to make
-    ///optimal use of the limited 0..255 for your application, trading off precision
-    ///and special effects. SDF values outside the range 0..255 are clamped to 0..255.
-    ///
-    ///The function computes the SDF analytically at each SDF pixel, not by e.g.
-    ///building a higher-res bitmap and approximating it. In theory the quality
-    ///should be as high as possible for an SDF of this size & representation, but
-    ///unclear if this is true in practice (perhaps building a higher-res bitmap
-    ///and computing from that can allow drop-out prevention).
-    ///
-    ///The algorithm has not been optimized at all, so expect it to be slow
-    ///if computing lots of characters or very large sizes.
-    ///
-    ///#### Example
-    ///- scale = stbtt_ScaleForPixelHeight(22)
-    ///- padding = 5
-    ///- onedge_value = 180
-    ///- pixel_dist_scale = 180/5.0 = 36.0
-    ///
-    ///This will create an SDF bitmap in which the character is about 22 pixels
-    ///high but the whole bitmap is about 22+5+5=32 pixels high. To produce a filled
-    ///shape, sample the SDF at each pixel and fill the pixel if the SDF value
-    ///is greater than or equal to 180/255. (You'll actually want to antialias,
-    ///which is beyond the scope of this example.) Additionally, you can compute
-    ///offset outlines (e.g. to stroke the character border inside & outside,
-    ///or only outside). For example, to fill outside the character up to 3 SDF
-    ///pixels, you would compare against (180-36.0*3)/255 = 72/255. The above
-    ///choice of variables maps a range from 5 pixels outside the shape to
-    ///2 pixels inside the shape to 0..255; this is intended primarily for apply
-    ///outside effects only (the interior range is needed to allow proper
-    ///antialiasing of the font at *smaller* sizes)
-    ///
-    ///@param info             the font
-    ///@param scale            controls the size of the resulting SDF bitmap, same as it would be creating a regular bitmap
-    ///@param glyph            the character to generate the SDF for
-    ///@param padding          extra "pixels" around the character which are filled with the distance to the character (not 0),
-    ///                        which allows effects like bit outlines
-    ///@param onedge_value     value 0-255 to test the SDF against to reconstruct the character (i.e. the isocontour of the character)
-    ///@param pixel_dist_scale what value the SDF should increase by when moving one SDF "pixel" away from the edge (on the 0..255 scale)
-    ///                        if positive, > onedge_value is inside; if negative, < onedge_value is inside
-    ///@param width            output width of the SDF bitmap (including padding)
-    ///@param height           output height of the SDF bitmap (including padding)
-    ///@param xoff             output origin of the character
-    ///@param yoff             output origin of the character
-    ///@return a 2D array of bytes 0..255, width*height in size
     public static @CType("unsigned char *") java.lang.foreign.MemorySegment stbtt_GetGlyphSDF(@CType("const stbtt_fontinfo *") java.lang.foreign.MemorySegment info, @CType("float") float scale, @CType("int") int glyph, @CType("int") int padding, @CType("unsigned char") byte onedge_value, @CType("float") float pixel_dist_scale, @Out @CType("int*") java.lang.foreign.MemorySegment width, @Out @CType("int*") java.lang.foreign.MemorySegment height, @Out @CType("int*") java.lang.foreign.MemorySegment xoff, @Out @CType("int*") java.lang.foreign.MemorySegment yoff) {
         try {
             return (java.lang.foreign.MemorySegment) Handles.MH_stbtt_GetGlyphSDF.invokeExact(info, scale, glyph, padding, onedge_value, pixel_dist_scale, width, height, xoff, yoff);
         } catch (Throwable e) { throw new RuntimeException("error in stbtt_GetGlyphSDF", e); }
     }
 
-    ///These functions compute a discretized SDF field for a single character, suitable for storing
-    ///in a single-channel texture, sampling with bilinear filtering, and testing against
-    ///larger than some threshold to produce scalable fonts.
-    ///
-    ///pixel_dist_scale & onedge_value are a scale & bias that allows you to make
-    ///optimal use of the limited 0..255 for your application, trading off precision
-    ///and special effects. SDF values outside the range 0..255 are clamped to 0..255.
-    ///
-    ///The function computes the SDF analytically at each SDF pixel, not by e.g.
-    ///building a higher-res bitmap and approximating it. In theory the quality
-    ///should be as high as possible for an SDF of this size & representation, but
-    ///unclear if this is true in practice (perhaps building a higher-res bitmap
-    ///and computing from that can allow drop-out prevention).
-    ///
-    ///The algorithm has not been optimized at all, so expect it to be slow
-    ///if computing lots of characters or very large sizes.
-    ///
-    ///#### Example
-    ///- scale = stbtt_ScaleForPixelHeight(22)
-    ///- padding = 5
-    ///- onedge_value = 180
-    ///- pixel_dist_scale = 180/5.0 = 36.0
-    ///
-    ///This will create an SDF bitmap in which the character is about 22 pixels
-    ///high but the whole bitmap is about 22+5+5=32 pixels high. To produce a filled
-    ///shape, sample the SDF at each pixel and fill the pixel if the SDF value
-    ///is greater than or equal to 180/255. (You'll actually want to antialias,
-    ///which is beyond the scope of this example.) Additionally, you can compute
-    ///offset outlines (e.g. to stroke the character border inside & outside,
-    ///or only outside). For example, to fill outside the character up to 3 SDF
-    ///pixels, you would compare against (180-36.0*3)/255 = 72/255. The above
-    ///choice of variables maps a range from 5 pixels outside the shape to
-    ///2 pixels inside the shape to 0..255; this is intended primarily for apply
-    ///outside effects only (the interior range is needed to allow proper
-    ///antialiasing of the font at *smaller* sizes)
-    ///
-    ///@param info             the font
-    ///@param scale            controls the size of the resulting SDF bitmap, same as it would be creating a regular bitmap
-    ///@param glyph            the character to generate the SDF for
-    ///@param padding          extra "pixels" around the character which are filled with the distance to the character (not 0),
-    ///                        which allows effects like bit outlines
-    ///@param onedge_value     value 0-255 to test the SDF against to reconstruct the character (i.e. the isocontour of the character)
-    ///@param pixel_dist_scale what value the SDF should increase by when moving one SDF "pixel" away from the edge (on the 0..255 scale)
-    ///                        if positive, > onedge_value is inside; if negative, < onedge_value is inside
-    ///@param width            output width of the SDF bitmap (including padding)
-    ///@param height           output height of the SDF bitmap (including padding)
-    ///@param xoff             output origin of the character
-    ///@param yoff             output origin of the character
-    ///@return a 2D array of bytes 0..255, width*height in size
     public static @CType("unsigned char *") java.lang.foreign.MemorySegment stbtt_GetGlyphSDF(@CType("const stbtt_fontinfo *") overrungl.stb.STBTTFontInfo info, @CType("float") float scale, @CType("int") int glyph, @CType("int") int padding, @CType("unsigned char") byte onedge_value, @CType("float") float pixel_dist_scale, @Out @CType("int*") int[] width, @Out @CType("int*") int[] height, @Out @CType("int*") int[] xoff, @Out @CType("int*") int[] yoff) {
         try (var __overrungl_stack = MemoryStack.pushLocal()) {
             var __overrungl_ref_width = Marshal.marshal(__overrungl_stack, width);
@@ -1489,14 +856,12 @@ public final class STBTrueType {
         } catch (Throwable e) { throw new RuntimeException("error in stbtt_GetGlyphSDF", e); }
     }
 
-    ///See stbtt_GetGlyphSDF
     public static @CType("unsigned char *") java.lang.foreign.MemorySegment stbtt_GetCodepointSDF(@CType("const stbtt_fontinfo *") java.lang.foreign.MemorySegment info, @CType("float") float scale, @CType("int") int codepoint, @CType("int") int padding, @CType("unsigned char") byte onedge_value, @CType("float") float pixel_dist_scale, @Out @CType("int*") java.lang.foreign.MemorySegment width, @Out @CType("int*") java.lang.foreign.MemorySegment height, @Out @CType("int*") java.lang.foreign.MemorySegment xoff, @Out @CType("int*") java.lang.foreign.MemorySegment yoff) {
         try {
             return (java.lang.foreign.MemorySegment) Handles.MH_stbtt_GetCodepointSDF.invokeExact(info, scale, codepoint, padding, onedge_value, pixel_dist_scale, width, height, xoff, yoff);
         } catch (Throwable e) { throw new RuntimeException("error in stbtt_GetCodepointSDF", e); }
     }
 
-    ///See stbtt_GetGlyphSDF
     public static @CType("unsigned char *") java.lang.foreign.MemorySegment stbtt_GetCodepointSDF(@CType("const stbtt_fontinfo *") overrungl.stb.STBTTFontInfo info, @CType("float") float scale, @CType("int") int codepoint, @CType("int") int padding, @CType("unsigned char") byte onedge_value, @CType("float") float pixel_dist_scale, @Out @CType("int*") int[] width, @Out @CType("int*") int[] height, @Out @CType("int*") int[] xoff, @Out @CType("int*") int[] yoff) {
         try (var __overrungl_stack = MemoryStack.pushLocal()) {
             var __overrungl_ref_width = Marshal.marshal(__overrungl_stack, width);
@@ -1512,40 +877,24 @@ public final class STBTrueType {
         } catch (Throwable e) { throw new RuntimeException("error in stbtt_GetCodepointSDF", e); }
     }
 
-    ///returns the offset (not index) of the font that matches, or -1 if none
-    ///if you use STBTT_MACSTYLE_DONTCARE, use a font name like "Arial Bold".
-    ///if you use any other flag, use a font name like "Arial"; this checks
-    ///the 'macStyle' header field; i don't know if fonts set this consistently
     public static @CType("int") int stbtt_FindMatchingFont(@CType("const unsigned char *") java.lang.foreign.MemorySegment fontdata, @CType("const char*") java.lang.foreign.MemorySegment name, @CType("int") int flags) {
         try {
             return (int) Handles.MH_stbtt_FindMatchingFont.invokeExact(fontdata, name, flags);
         } catch (Throwable e) { throw new RuntimeException("error in stbtt_FindMatchingFont", e); }
     }
 
-    ///returns the offset (not index) of the font that matches, or -1 if none
-    ///if you use STBTT_MACSTYLE_DONTCARE, use a font name like "Arial Bold".
-    ///if you use any other flag, use a font name like "Arial"; this checks
-    ///the 'macStyle' header field; i don't know if fonts set this consistently
     public static @CType("int") int stbtt_FindMatchingFont(@CType("const unsigned char *") java.lang.foreign.MemorySegment fontdata, @CType("const char*") java.lang.String name, @CType("int") int flags) {
         try (var __overrungl_stack = MemoryStack.pushLocal()) {
             return (int) Handles.MH_stbtt_FindMatchingFont.invokeExact(fontdata, Marshal.marshal(__overrungl_stack, name), flags);
         } catch (Throwable e) { throw new RuntimeException("error in stbtt_FindMatchingFont", e); }
     }
 
-    ///returns 1/0 whether the first string interpreted as utf8 is identical to
-    ///the second string interpreted as big-endian utf16... useful for strings from next func
     public static @CType("int") boolean stbtt_CompareUTF8toUTF16_bigendian(@CType("const char*") java.lang.foreign.MemorySegment s1, @CType("int") int len1, @CType("const char*") java.lang.foreign.MemorySegment s2, @CType("int") int len2) {
         try {
             return (boolean) Handles.MH_stbtt_CompareUTF8toUTF16_bigendian.invokeExact(s1, len1, s2, len2);
         } catch (Throwable e) { throw new RuntimeException("error in stbtt_CompareUTF8toUTF16_bigendian", e); }
     }
 
-    ///returns the string (which may be big-endian double byte, e.g. for unicode)
-    ///and puts the length in bytes in *length.
-    ///
-    ///some of the values for the IDs are below; for more see the truetype spec:
-    ///- <https://developer.apple.com/textfonts/TTRefMan/RM06/Chap6name.html>
-    ///- <https://www.microsoft.com/typography/otspec/name.htm>
     public static @CType("const char*") java.lang.foreign.MemorySegment stbtt_GetFontNameString(@CType("const stbtt_fontinfo *") java.lang.foreign.MemorySegment font, @Out @CType("int*") java.lang.foreign.MemorySegment length, @CType("int") int platformID, @CType("int") int encodingID, @CType("int") int languageID, @CType("int") int nameID) {
         try {
             return (java.lang.foreign.MemorySegment) Handles.MH_stbtt_GetFontNameString.invokeExact(font, length, platformID, encodingID, languageID, nameID);
@@ -1571,8 +920,6 @@ public final class STBTrueType {
         return -x;
     }
 
-    /// returns 1/0 whether the first string interpreted as utf8 is identical to
-    /// the second string interpreted as big-endian utf16... useful for strings from next func
     public static boolean stbtt_CompareUTF8toUTF16_bigendian(String s1, String s2) {
         try (MemoryStack stack = MemoryStack.pushLocal()) {
             MemorySegment ps1 = Marshal.marshal(stack, s1);
@@ -1581,7 +928,6 @@ public final class STBTrueType {
         }
     }
 
-    /// Overloads [#stbtt_GetFontNameString(MemorySegment, MemorySegment, int, int, int, int)]
     public static String stbtt_GetFontNameString(STBTTFontInfo font, int platformID, int encodingID, int languageID, int nameID) {
         try (MemoryStack stack = MemoryStack.pushLocal()) {
             MemorySegment pLength = stack.allocate(ValueLayout.JAVA_INT);

--- a/modules/overrungl.stb/src/main/java/overrungl/stb/STBVorbis.java
+++ b/modules/overrungl.stb/src/main/java/overrungl/stb/STBVorbis.java
@@ -27,64 +27,7 @@ import java.lang.foreign.FunctionDescriptor;
 import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodHandle;
 
-/// ## THREAD SAFETY
-/// Individual stb_vorbis* handles are not thread-safe; you cannot decode from
-/// them from multiple threads at the same time. However, you can have multiple
-/// stb_vorbis* handles and decode from them independently in multiple thrads.
-///
-/// ## MEMORY ALLOCATION
-/// normally stb_vorbis uses malloc() to allocate memory at startup,
-/// and alloca() to allocate temporary memory during a frame on the
-/// stack.
-/// (Memory consumption will depend on the amount of setup
-/// data in the file and how you set the compile flags for speed
-/// vs. size. In my test files the maximal-size usage is ~150KB.)
-///
-/// You can modify the wrapper functions in the source (setup_malloc,
-/// setup_temp_malloc, temp_malloc) to change this behavior, or you
-/// can use a simpler allocation model: you pass in a buffer from
-/// which stb_vorbis will allocate _all_ its memory (including the
-/// temp memory).
-/// "open" may fail with a VORBIS_outofmem if you
-/// do not pass in enough data; there is no way to determine how
-/// much you do need except to succeed (at which point you can
-/// query get_info to find the exact amount required. yes I know
-/// this is lame).
-///
-/// If you pass in a non-NULL buffer of the type below, allocation
-/// will occur from it as described above.
-/// Otherwise just pass NULL
-/// to use malloc()/alloca()
-///
-/// ## PUSHDATA API
-/// this API allows you to get blocks of data from any source and hand
-/// them to stb_vorbis. you have to buffer them; stb_vorbis will tell
-/// you how much it used, and you have to give it the rest next time;
-/// and stb_vorbis may not have enough data to work with and you will
-/// need to give it the same data again PLUS more. Note that the Vorbis
-/// specification does not bound the size of an individual frame.
-///
-/// ## PULLING INPUT API
-/// This API assumes stb_vorbis is allowed to pull data from a source--
-/// either a block of memory containing the _entire_ vorbis stream, or a
-/// FILE * that you or it create, or possibly some other reading mechanism
-/// if you go modify the source to replace the FILE * case with some kind
-/// of callback to your code. (But if you don't support seeking, you may
-/// just want to go ahead and use pushdata.)
-///
-/// ## Channel coercion rules
-/// Let M be the number of channels requested, and N the number of channels present,
-/// and Cn be the nth channel; let stereo L be the sum of all L and center channels,
-/// and stereo R be the sum of all R and center channels (channel assignment from the
-/// vorbis spec).
-/// | M | N |                output                |
-/// |---|---|--------------------------------------|
-/// | 1 | k | sum(Ck) for all k                    |
-/// | 2 | * | stereo L, stereo R                   |
-/// | k | l | k > l, the first l channels, then 0s |
-/// | k | l | k <= l, the first k channels         |
-/// Note that this is not _good_ surround etc. mixing at all! It's just so
-/// you get something useful.
+/// [stb_vorbis.c](https://github.com/nothings/stb/blob/master/stb_vorbis.c)
 ///
 /// @author squid233
 /// @since 0.1.0
@@ -92,51 +35,6 @@ public final class STBVorbis {
     //region ---[BEGIN GENERATOR BEGIN]---
     //@formatter:off
     //region Fields
-    ///STBVorbisError
-    ///
-    ///from 20: decoding errors (corrupt/invalid stream) -- you probably
-    ///don't care about the exact details of these
-    ///#### Documentation of fields
-    ///##### VORBIS_need_more_data
-    ///not a real error
-    ///##### VORBIS_invalid_api_mixing
-    ///can't mix API modes
-    ///##### VORBIS_outofmem
-    ///not enough memory
-    ///##### VORBIS_feature_not_supported
-    ///uses floor 0
-    ///##### VORBIS_too_many_channels
-    ///STB_VORBIS_MAX_CHANNELS is too small
-    ///##### VORBIS_file_open_failure
-    ///fopen() failed
-    ///##### VORBIS_seek_without_length
-    ///can't seek in unknown-length file
-    ///##### VORBIS_unexpected_eof
-    ///file is truncated?
-    ///##### VORBIS_seek_invalid
-    ///seek past EOF
-    ///##### VORBIS_invalid_setup
-    ///vorbis errors
-    ///##### VORBIS_invalid_stream
-    ///vorbis errors
-    ///##### VORBIS_missing_capture_pattern
-    ///ogg errors
-    ///##### VORBIS_invalid_stream_structure_version
-    ///ogg errors
-    ///##### VORBIS_continued_packet_flag_invalid
-    ///ogg errors
-    ///##### VORBIS_incorrect_stream_serial_number
-    ///ogg errors
-    ///##### VORBIS_invalid_first_page
-    ///ogg errors
-    ///##### VORBIS_bad_packet_type
-    ///ogg errors
-    ///##### VORBIS_cant_find_last_page
-    ///ogg errors
-    ///##### VORBIS_seek_failed
-    ///ogg errors
-    ///##### VORBIS_ogg_skeleton_not_supported
-    ///ogg errors
     public static final int
         VORBIS__no_error = 0,
         VORBIS_need_more_data = 1,
@@ -217,96 +115,60 @@ public final class STBVorbis {
     }
     //endregion
 
-    ///get general information about the file
     public static @CType("stb_vorbis_info") java.lang.foreign.MemorySegment stb_vorbis_get_info_(java.lang.foreign.SegmentAllocator allocator, @CType("stb_vorbis *") java.lang.foreign.MemorySegment f) {
         try {
             return (java.lang.foreign.MemorySegment) Handles.MH_stb_vorbis_get_info.invokeExact(allocator, f);
         } catch (Throwable e) { throw new RuntimeException("error in stb_vorbis_get_info", e); }
     }
 
-    ///get general information about the file
     public static @CType("stb_vorbis_info") overrungl.stb.STBVorbisInfo stb_vorbis_get_info(java.lang.foreign.SegmentAllocator allocator, @CType("stb_vorbis *") java.lang.foreign.MemorySegment f) {
         try {
             return overrungl.stb.STBVorbisInfo.of((java.lang.foreign.MemorySegment) Handles.MH_stb_vorbis_get_info.invokeExact(allocator, f));
         } catch (Throwable e) { throw new RuntimeException("error in stb_vorbis_get_info", e); }
     }
 
-    ///get ogg comments
     public static @CType("stb_vorbis_comment") java.lang.foreign.MemorySegment stb_vorbis_get_comment_(java.lang.foreign.SegmentAllocator allocator, @CType("stb_vorbis *") java.lang.foreign.MemorySegment f) {
         try {
             return (java.lang.foreign.MemorySegment) Handles.MH_stb_vorbis_get_comment.invokeExact(allocator, f);
         } catch (Throwable e) { throw new RuntimeException("error in stb_vorbis_get_comment", e); }
     }
 
-    ///get ogg comments
     public static @CType("stb_vorbis_comment") overrungl.stb.STBVorbisComment stb_vorbis_get_comment(java.lang.foreign.SegmentAllocator allocator, @CType("stb_vorbis *") java.lang.foreign.MemorySegment f) {
         try {
             return overrungl.stb.STBVorbisComment.of((java.lang.foreign.MemorySegment) Handles.MH_stb_vorbis_get_comment.invokeExact(allocator, f));
         } catch (Throwable e) { throw new RuntimeException("error in stb_vorbis_get_comment", e); }
     }
 
-    ///get the last error detected (clears it, too)
     public static @CType("int") int stb_vorbis_get_error(@CType("stb_vorbis *") java.lang.foreign.MemorySegment f) {
         try {
             return (int) Handles.MH_stb_vorbis_get_error.invokeExact(f);
         } catch (Throwable e) { throw new RuntimeException("error in stb_vorbis_get_error", e); }
     }
 
-    ///close an ogg vorbis file and free all memory in use
     public static void stb_vorbis_close(@CType("stb_vorbis *") java.lang.foreign.MemorySegment f) {
         try {
             Handles.MH_stb_vorbis_close.invokeExact(f);
         } catch (Throwable e) { throw new RuntimeException("error in stb_vorbis_close", e); }
     }
 
-    ///this function returns the offset (in samples) from the beginning of the
-    ///file that will be returned by the next decode, if it is known, or -1
-    ///otherwise. after a flush_pushdata() call, this may take a while before
-    ///it becomes valid again.
-    ///
-    ///NOT WORKING YET after a seek with PULLDATA API
     public static @CType("int") int stb_vorbis_get_sample_offset(@CType("stb_vorbis *") java.lang.foreign.MemorySegment f) {
         try {
             return (int) Handles.MH_stb_vorbis_get_sample_offset.invokeExact(f);
         } catch (Throwable e) { throw new RuntimeException("error in stb_vorbis_get_sample_offset", e); }
     }
 
-    ///@return the current seek point within the file, or offset from the beginning
-    ///of the memory buffer. In pushdata mode it returns 0.
     public static @CType("unsigned int") int stb_vorbis_get_file_offset(@CType("stb_vorbis *") java.lang.foreign.MemorySegment f) {
         try {
             return (int) Handles.MH_stb_vorbis_get_file_offset.invokeExact(f);
         } catch (Throwable e) { throw new RuntimeException("error in stb_vorbis_get_file_offset", e); }
     }
 
-    ///create a vorbis decoder by passing in the initial data block containing
-    ///the ogg&vorbis headers (you don't need to do parse them, just provide
-    ///the first N bytes of the file--you're told if it's not enough, see below)
-    ///
-    ///on success, returns an stb_vorbis *, does not set error, returns the amount of
-    ///data parsed/consumed on this call in *datablock_memory_consumed_in_bytes;
-    ///
-    ///on failure, returns NULL on error and sets *error, does not change *datablock_memory_consumed
-    ///
-    ///if returns NULL and *error is VORBIS_need_more_data, then the input block was
-    ///incomplete and you need to pass in a larger block from the start of the file
     public static @CType("stb_vorbis *") java.lang.foreign.MemorySegment stb_vorbis_open_pushdata(@CType("const unsigned char *") java.lang.foreign.MemorySegment datablock, @CType("int") int datablock_length_in_bytes, @Out @CType("int*") java.lang.foreign.MemorySegment datablock_memory_consumed_in_bytes, @Out @CType("int*") java.lang.foreign.MemorySegment error, @CType("const stb_vorbis_alloc *") java.lang.foreign.MemorySegment alloc_buffer) {
         try {
             return (java.lang.foreign.MemorySegment) Handles.MH_stb_vorbis_open_pushdata.invokeExact(datablock, datablock_length_in_bytes, datablock_memory_consumed_in_bytes, error, alloc_buffer);
         } catch (Throwable e) { throw new RuntimeException("error in stb_vorbis_open_pushdata", e); }
     }
 
-    ///create a vorbis decoder by passing in the initial data block containing
-    ///the ogg&vorbis headers (you don't need to do parse them, just provide
-    ///the first N bytes of the file--you're told if it's not enough, see below)
-    ///
-    ///on success, returns an stb_vorbis *, does not set error, returns the amount of
-    ///data parsed/consumed on this call in *datablock_memory_consumed_in_bytes;
-    ///
-    ///on failure, returns NULL on error and sets *error, does not change *datablock_memory_consumed
-    ///
-    ///if returns NULL and *error is VORBIS_need_more_data, then the input block was
-    ///incomplete and you need to pass in a larger block from the start of the file
     public static @CType("stb_vorbis *") java.lang.foreign.MemorySegment stb_vorbis_open_pushdata(@CType("const unsigned char *") java.lang.foreign.MemorySegment datablock, @CType("int") int datablock_length_in_bytes, @Out @CType("int*") int[] datablock_memory_consumed_in_bytes, @Out @CType("int*") int[] error, @CType("const stb_vorbis_alloc *") overrungl.stb.STBVorbisAlloc alloc_buffer) {
         try (var __overrungl_stack = MemoryStack.pushLocal()) {
             var __overrungl_ref_datablock_memory_consumed_in_bytes = Marshal.marshal(__overrungl_stack, datablock_memory_consumed_in_bytes);
@@ -318,90 +180,36 @@ public final class STBVorbis {
         } catch (Throwable e) { throw new RuntimeException("error in stb_vorbis_open_pushdata", e); }
     }
 
-    ///decode a frame of audio sample data if possible from the passed-in data block
-    ///
-    ///possible cases:
-    ///- 0 bytes used, 0 samples output (need more data)
-    ///- N bytes used, 0 samples output (resynching the stream, keep going)
-    ///- N bytes used, M samples output (one frame of data)
-    ///
-    ///note that after opening a file, you will ALWAYS get one N-bytes,0-sample
-    ///frame, because Vorbis always "discards" the first frame.
-    ///
-    ///Note that on resynch, stb_vorbis will rarely consume all of the buffer,
-    ///instead only datablock_length_in_bytes-3 or less. This is because it wants
-    ///to avoid missing parts of a page header if they cross a datablock boundary,
-    ///without writing state-machiney code to record a partial detection.
-    ///
-    ///The number of channels returned are stored in *channels (which can be
-    ///NULL--it is always the same as the number of channels reported by
-    ///get_info). *output will contain an array of float* buffers, one per
-    ///channel. In other words, (*output)[0][0] contains the first sample from
-    ///the first channel, and (*output)[1][0] contains the first sample from
-    ///the second channel.
-    ///
-    ///*output points into stb_vorbis's internal output buffer storage; these
-    ///buffers are owned by stb_vorbis and application code should not free
-    ///them or modify their contents. They are transient and will be overwritten
-    ///once you ask for more data to get decoded, so be sure to grab any data
-    ///you need before then.
-    ///
-    ///@param channels place to write number of float * buffers
-    ///@param output   place to write float ** array of float * buffers
-    ///@param samples  place to write number of output samples
-    ///@return number of bytes we used from datablock
     public static @CType("int") int stb_vorbis_decode_frame_pushdata(@CType("stb_vorbis *") java.lang.foreign.MemorySegment f, @CType("const unsigned char *") java.lang.foreign.MemorySegment datablock, @CType("int") int datablock_length_in_bytes, @Out @CType("int*") java.lang.foreign.MemorySegment channels, @Out @CType("float ***") java.lang.foreign.MemorySegment output, @Out @CType("int*") java.lang.foreign.MemorySegment samples) {
         try {
             return (int) Handles.MH_stb_vorbis_decode_frame_pushdata.invokeExact(f, datablock, datablock_length_in_bytes, channels, output, samples);
         } catch (Throwable e) { throw new RuntimeException("error in stb_vorbis_decode_frame_pushdata", e); }
     }
 
-    ///inform stb_vorbis that your next datablock will not be contiguous with
-    ///previous ones (e.g. you've seeked in the data); future attempts to decode
-    ///frames will cause stb_vorbis to resynchronize (as noted above), and
-    ///once it sees a valid Ogg page (typically 4-8KB, as large as 64KB), it
-    ///will begin decoding the _next_ frame.
-    ///
-    ///if you want to seek using pushdata, you need to seek in your file, then
-    ///call stb_vorbis_flush_pushdata(), then start calling decoding, then once
-    ///decoding is returning you data, call stb_vorbis_get_sample_offset, and
-    ///if you don't like the result, seek your file again and repeat.
     public static void stb_vorbis_flush_pushdata(@CType("stb_vorbis *") java.lang.foreign.MemorySegment f) {
         try {
             Handles.MH_stb_vorbis_flush_pushdata.invokeExact(f);
         } catch (Throwable e) { throw new RuntimeException("error in stb_vorbis_flush_pushdata", e); }
     }
 
-    ///decode an entire file and output the data interleaved into a malloc()ed
-    ///buffer stored in *output. The return value is the number of samples
-    ///decoded, or -1 if the file could not be opened or was not an ogg vorbis file.
-    ///When you're done with it, just free() the pointer returned in *output.
     public static @CType("int") int stb_vorbis_decode_filename(@CType("const char*") java.lang.foreign.MemorySegment filename, @Out @CType("int*") java.lang.foreign.MemorySegment channels, @Out @CType("int*") java.lang.foreign.MemorySegment sample_rate, @Out @CType("short **") java.lang.foreign.MemorySegment output) {
         try {
             return (int) Handles.MH_stb_vorbis_decode_filename.invokeExact(filename, channels, sample_rate, output);
         } catch (Throwable e) { throw new RuntimeException("error in stb_vorbis_decode_filename", e); }
     }
 
-    ///decode an entire file and output the data interleaved into a malloc()ed
-    ///buffer stored in *output. The return value is the number of samples
-    ///decoded, or -1 if the file could not be opened or was not an ogg vorbis file.
-    ///When you're done with it, just free() the pointer returned in *output.
     public static @CType("int") int stb_vorbis_decode_memory(@CType("const unsigned char *") java.lang.foreign.MemorySegment mem, @CType("int") int len, @Out @CType("int*") java.lang.foreign.MemorySegment channels, @Out @CType("int*") java.lang.foreign.MemorySegment sample_rate, @Out @CType("short **") java.lang.foreign.MemorySegment output) {
         try {
             return (int) Handles.MH_stb_vorbis_decode_memory.invokeExact(mem, len, channels, sample_rate, output);
         } catch (Throwable e) { throw new RuntimeException("error in stb_vorbis_decode_memory", e); }
     }
 
-    ///create an ogg vorbis decoder from an ogg vorbis stream in memory (note
-    ///this must be the entire stream!). on failure, returns NULL and sets *error
     public static @CType("stb_vorbis *") java.lang.foreign.MemorySegment stb_vorbis_open_memory(@CType("const unsigned char *") java.lang.foreign.MemorySegment data, @CType("int") int len, @Out @CType("int*") java.lang.foreign.MemorySegment error, @CType("const stb_vorbis_alloc *") java.lang.foreign.MemorySegment alloc_buffer) {
         try {
             return (java.lang.foreign.MemorySegment) Handles.MH_stb_vorbis_open_memory.invokeExact(data, len, error, alloc_buffer);
         } catch (Throwable e) { throw new RuntimeException("error in stb_vorbis_open_memory", e); }
     }
 
-    ///create an ogg vorbis decoder from an ogg vorbis stream in memory (note
-    ///this must be the entire stream!). on failure, returns NULL and sets *error
     public static @CType("stb_vorbis *") java.lang.foreign.MemorySegment stb_vorbis_open_memory(@CType("const unsigned char *") java.lang.foreign.MemorySegment data, @CType("int") int len, @Out @CType("int*") int[] error, @CType("const stb_vorbis_alloc *") overrungl.stb.STBVorbisAlloc alloc_buffer) {
         try (var __overrungl_stack = MemoryStack.pushLocal()) {
             var __overrungl_ref_error = Marshal.marshal(__overrungl_stack, error);
@@ -411,16 +219,12 @@ public final class STBVorbis {
         } catch (Throwable e) { throw new RuntimeException("error in stb_vorbis_open_memory", e); }
     }
 
-    ///create an ogg vorbis decoder from a filename via fopen(). on failure,
-    ///returns NULL and sets *error (possibly to VORBIS_file_open_failure).
     public static @CType("stb_vorbis *") java.lang.foreign.MemorySegment stb_vorbis_open_filename(@CType("const char*") java.lang.foreign.MemorySegment filename, @Out @CType("int*") java.lang.foreign.MemorySegment error, @CType("const stb_vorbis_alloc *") java.lang.foreign.MemorySegment alloc_buffer) {
         try {
             return (java.lang.foreign.MemorySegment) Handles.MH_stb_vorbis_open_filename.invokeExact(filename, error, alloc_buffer);
         } catch (Throwable e) { throw new RuntimeException("error in stb_vorbis_open_filename", e); }
     }
 
-    ///create an ogg vorbis decoder from a filename via fopen(). on failure,
-    ///returns NULL and sets *error (possibly to VORBIS_file_open_failure).
     public static @CType("stb_vorbis *") java.lang.foreign.MemorySegment stb_vorbis_open_filename(@CType("const char*") java.lang.String filename, @Out @CType("int*") int[] error, @CType("const stb_vorbis_alloc *") overrungl.stb.STBVorbisAlloc alloc_buffer) {
         try (var __overrungl_stack = MemoryStack.pushLocal()) {
             var __overrungl_ref_error = Marshal.marshal(__overrungl_stack, error);
@@ -430,137 +234,72 @@ public final class STBVorbis {
         } catch (Throwable e) { throw new RuntimeException("error in stb_vorbis_open_filename", e); }
     }
 
-    ///these functions seek in the Vorbis file to (approximately) 'sample_number'.
-    ///after calling seek_frame(), the next call to get_frame_*() will include
-    ///the specified sample. after calling stb_vorbis_seek(), the next call to
-    ///stb_vorbis_get_samples_* will start with the specified sample. If you
-    ///do not need to seek to EXACTLY the target sample when using get_samples_*,
-    ///you can also use seek_frame().
     public static @CType("int") int stb_vorbis_seek_frame(@CType("stb_vorbis *") java.lang.foreign.MemorySegment f, @CType("unsigned int") int sample_number) {
         try {
             return (int) Handles.MH_stb_vorbis_seek_frame.invokeExact(f, sample_number);
         } catch (Throwable e) { throw new RuntimeException("error in stb_vorbis_seek_frame", e); }
     }
 
-    ///these functions seek in the Vorbis file to (approximately) 'sample_number'.
-    ///after calling seek_frame(), the next call to get_frame_*() will include
-    ///the specified sample. after calling stb_vorbis_seek(), the next call to
-    ///stb_vorbis_get_samples_* will start with the specified sample. If you
-    ///do not need to seek to EXACTLY the target sample when using get_samples_*,
-    ///you can also use seek_frame().
     public static @CType("int") int stb_vorbis_seek(@CType("stb_vorbis *") java.lang.foreign.MemorySegment f, @CType("unsigned int") int sample_number) {
         try {
             return (int) Handles.MH_stb_vorbis_seek.invokeExact(f, sample_number);
         } catch (Throwable e) { throw new RuntimeException("error in stb_vorbis_seek", e); }
     }
 
-    ///this function is equivalent to stb_vorbis_seek(f,0)
     public static @CType("int") int stb_vorbis_seek_start(@CType("stb_vorbis *") java.lang.foreign.MemorySegment f) {
         try {
             return (int) Handles.MH_stb_vorbis_seek_start.invokeExact(f);
         } catch (Throwable e) { throw new RuntimeException("error in stb_vorbis_seek_start", e); }
     }
 
-    ///these functions return the total length of the vorbis stream
     public static @CType("unsigned int") int stb_vorbis_stream_length_in_samples(@CType("stb_vorbis *") java.lang.foreign.MemorySegment f) {
         try {
             return (int) Handles.MH_stb_vorbis_stream_length_in_samples.invokeExact(f);
         } catch (Throwable e) { throw new RuntimeException("error in stb_vorbis_stream_length_in_samples", e); }
     }
 
-    ///these functions return the total length of the vorbis stream
     public static @CType("float") float stb_vorbis_stream_length_in_seconds(@CType("stb_vorbis *") java.lang.foreign.MemorySegment f) {
         try {
             return (float) Handles.MH_stb_vorbis_stream_length_in_seconds.invokeExact(f);
         } catch (Throwable e) { throw new RuntimeException("error in stb_vorbis_stream_length_in_seconds", e); }
     }
 
-    ///decode the next frame and return the number of samples. the number of
-    ///channels returned are stored in *channels (which can be NULL--it is always
-    ///the same as the number of channels reported by get_info). *output will
-    ///contain an array of float* buffers, one per channel. These outputs will
-    ///be overwritten on the next call to stb_vorbis_get_frame_*.
-    ///
-    ///You generally should not intermix calls to stb_vorbis_get_frame_*()
-    ///and stb_vorbis_get_samples_*(), since the latter calls the former.
     public static @CType("int") int stb_vorbis_get_frame_float(@CType("stb_vorbis *") java.lang.foreign.MemorySegment f, @Out @CType("int*") java.lang.foreign.MemorySegment channels, @Out @CType("float ***") java.lang.foreign.MemorySegment output) {
         try {
             return (int) Handles.MH_stb_vorbis_get_frame_float.invokeExact(f, channels, output);
         } catch (Throwable e) { throw new RuntimeException("error in stb_vorbis_get_frame_float", e); }
     }
 
-    ///decode the next frame and return the number of *samples* per channel.
-    ///Note that for interleaved data, you pass in the number of shorts (the
-    ///size of your array), but the return value is the number of samples per
-    ///channel, not the total number of samples.
-    ///
-    ///The data is coerced to the number of channels you request according to the
-    ///channel coercion rules (see below). You must pass in the size of your
-    ///buffer(s) so that stb_vorbis will not overwrite the end of the buffer.
-    ///The maximum buffer size needed can be gotten from get_info(); however,
-    ///the Vorbis I specification implies an absolute maximum of 4096 samples
-    ///per channel.
     public static @CType("int") int stb_vorbis_get_frame_short_interleaved(@CType("stb_vorbis *") java.lang.foreign.MemorySegment f, @CType("int") int num_c, @Out @CType("short*") java.lang.foreign.MemorySegment buffer, @CType("int") int num_shorts) {
         try {
             return (int) Handles.MH_stb_vorbis_get_frame_short_interleaved.invokeExact(f, num_c, buffer, num_shorts);
         } catch (Throwable e) { throw new RuntimeException("error in stb_vorbis_get_frame_short_interleaved", e); }
     }
 
-    ///decode the next frame and return the number of *samples* per channel.
-    ///Note that for interleaved data, you pass in the number of shorts (the
-    ///size of your array), but the return value is the number of samples per
-    ///channel, not the total number of samples.
-    ///
-    ///The data is coerced to the number of channels you request according to the
-    ///channel coercion rules (see below). You must pass in the size of your
-    ///buffer(s) so that stb_vorbis will not overwrite the end of the buffer.
-    ///The maximum buffer size needed can be gotten from get_info(); however,
-    ///the Vorbis I specification implies an absolute maximum of 4096 samples
-    ///per channel.
     public static @CType("int") int stb_vorbis_get_frame_short(@CType("stb_vorbis *") java.lang.foreign.MemorySegment f, @CType("int") int num_c, @Out @CType("short **") java.lang.foreign.MemorySegment buffer, @CType("int") int num_samples) {
         try {
             return (int) Handles.MH_stb_vorbis_get_frame_short.invokeExact(f, num_c, buffer, num_samples);
         } catch (Throwable e) { throw new RuntimeException("error in stb_vorbis_get_frame_short", e); }
     }
 
-    ///gets num_samples samples, not necessarily on a frame boundary--this requires
-    ///buffering so you have to supply the buffers. DOES NOT APPLY THE COERCION RULES.
-    ///@return the number of samples stored per channel; it may be less than requested
-    ///at the end of the file. If there are no more samples in the file, returns 0.
     public static @CType("int") int stb_vorbis_get_samples_float_interleaved(@CType("stb_vorbis *") java.lang.foreign.MemorySegment f, @CType("int") int channels, @Out @CType("float*") java.lang.foreign.MemorySegment buffer, @CType("int") int num_floats) {
         try {
             return (int) Handles.MH_stb_vorbis_get_samples_float_interleaved.invokeExact(f, channels, buffer, num_floats);
         } catch (Throwable e) { throw new RuntimeException("error in stb_vorbis_get_samples_float_interleaved", e); }
     }
 
-    ///gets num_samples samples, not necessarily on a frame boundary--this requires
-    ///buffering so you have to supply the buffers. DOES NOT APPLY THE COERCION RULES.
-    ///@return the number of samples stored per channel; it may be less than requested
-    ///at the end of the file. If there are no more samples in the file, returns 0.
     public static @CType("int") int stb_vorbis_get_samples_float(@CType("stb_vorbis *") java.lang.foreign.MemorySegment f, @CType("int") int channels, @Out @CType("float **") java.lang.foreign.MemorySegment buffer, @CType("int") int num_samples) {
         try {
             return (int) Handles.MH_stb_vorbis_get_samples_float.invokeExact(f, channels, buffer, num_samples);
         } catch (Throwable e) { throw new RuntimeException("error in stb_vorbis_get_samples_float", e); }
     }
 
-    ///gets num_samples samples, not necessarily on a frame boundary--this requires
-    ///buffering so you have to supply the buffers. Applies the coercion rules above
-    ///to produce 'channels' channels.
-    ///@return the number of samples stored per channel;
-    ///it may be less than requested at the end of the file. If there are no more
-    ///samples in the file, returns 0.
     public static @CType("int") int stb_vorbis_get_samples_short_interleaved(@CType("stb_vorbis *") java.lang.foreign.MemorySegment f, @CType("int") int channels, @Out @CType("short*") java.lang.foreign.MemorySegment buffer, @CType("int") int num_shorts) {
         try {
             return (int) Handles.MH_stb_vorbis_get_samples_short_interleaved.invokeExact(f, channels, buffer, num_shorts);
         } catch (Throwable e) { throw new RuntimeException("error in stb_vorbis_get_samples_short_interleaved", e); }
     }
 
-    ///gets num_samples samples, not necessarily on a frame boundary--this requires
-    ///buffering so you have to supply the buffers. Applies the coercion rules above
-    ///to produce 'channels' channels.
-    ///@return the number of samples stored per channel;
-    ///it may be less than requested at the end of the file. If there are no more
-    ///samples in the file, returns 0.
     public static @CType("int") int stb_vorbis_get_samples_short(@CType("stb_vorbis *") java.lang.foreign.MemorySegment f, @CType("int") int channels, @Out @CType("short **") java.lang.foreign.MemorySegment buffer, @CType("int") int num_samples) {
         try {
             return (int) Handles.MH_stb_vorbis_get_samples_short.invokeExact(f, channels, buffer, num_samples);

--- a/modules/overrungl.stb/src/main/java/overrungl/stb/package-info.java
+++ b/modules/overrungl.stb/src/main/java/overrungl/stb/package-info.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023-2025 Overrun Organization
+ * Copyright (c) 2025 Overrun Organization
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -14,13 +14,10 @@
  * copies or substantial portions of the Software.
  */
 
-/// The GLFW binding.
+/// The stb binding.
+///
+/// - [Source](https://github.com/nothings/stb)
 ///
 /// @author squid233
 /// @since 0.1.0
-module overrungl.glfw {
-    exports overrungl.glfw;
-
-    requires transitive overrungl.core;
-    requires static org.jetbrains.annotations;
-}
+package overrungl.stb;


### PR DESCRIPTION
# Summary

Remove javadocs of native bindings. Refer to their own documentation.

# Motivation


# Description


# Additional Context


---

- [x] I agree to follow this project's [Code of Conduct](https://github.com/Over-Run/overrungl/blob/main/CODE_OF_CONDUCT.md)
