### PR TITLE
fix: [opengl] remove `non-sealed` modifier from GL

### DIFF
--- a/modules/overrungl.opengl/src/main/java/overrungl/opengl/GL.java
+++ b/modules/overrungl.opengl/src/main/java/overrungl/opengl/GL.java
@@ -22,7 +22,7 @@ package overrungl.opengl;
  * @author squid233
  * @since 0.1.0
  */
-public non-sealed class GL extends GL46 {
+public class GL extends GL46 {
     /// Creates an instance of OpenGL functions.
     ///
     /// @param function a function that returns the address of specific OpenGL function


### PR DESCRIPTION
# Summary

remove `non-sealed` modifier from GL

# Motivation


# Description


# Additional Context


---

- [x] I agree to follow this project's [Code of Conduct](https://github.com/Over-Run/overrungl/blob/main/CODE_OF_CONDUCT.md)
